### PR TITLE
Fixes points value overflowing and being off-center

### DIFF
--- a/src/styles/40k-10e.less
+++ b/src/styles/40k-10e.less
@@ -298,7 +298,7 @@
       .header_container {
         grid-area: c1;
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         justify-content: space-between;
         padding-top: 32px;
         padding-left: 32px;
@@ -336,6 +336,7 @@
           padding-right: 16px;
           z-index: 2;
           padding-top: 4px;
+          height: auto;
           .points {
             white-space: nowrap;
             text-transform: uppercase;

--- a/src/styles/40k-10e.less
+++ b/src/styles/40k-10e.less
@@ -298,7 +298,7 @@
       .header_container {
         grid-area: c1;
         display: flex;
-        align-items: flex-start;
+        align-items: center;
         justify-content: space-between;
         padding-top: 32px;
         padding-left: 32px;
@@ -331,8 +331,8 @@
 
         .points_container {
           display: flex;
-          align-items: "flex-start";
-          justify-content: flex-end;
+          align-items: center;
+          justify-content: center;
           padding-right: 16px;
           z-index: 2;
           padding-top: 4px;


### PR DESCRIPTION
Tweaks the flexbox CSS values in .header_container and .points_container to make sure the points value and points container are correctly centered vertically.

Before:
![image](https://github.com/ronplanken/game-datacards/assets/4805393/e2161d67-a0f4-474a-b7f5-7fdb9580ac3b)


After:
![image](https://github.com/ronplanken/game-datacards/assets/4805393/4b9fadc8-792d-4b60-a2ce-98648d3e3fb5)
