### PR TITLE
Adding print_side to Print Dialogue

### DIFF
--- a/src/Pages/Print.jsx
+++ b/src/Pages/Print.jsx
@@ -34,6 +34,7 @@ export const Print = () => {
   const [customSize, setCustomSize] = useState(settings.printSettings?.customSize || { height: "15cm", width: "15cm" });
   const [verticalAlignment, setVerticalAlignment] = useState(settings.printSettings?.verticalAlignment || "flex-start");
   const [backgrounds, setBackgrounds] = useState(settings.printSettings?.backgrounds || "standard");
+  const [print_side, setPrintSide] = useState(settings.printSettings?.print_side || "front");
 
   const { cardStorage } = useCardStorage();
 
@@ -283,6 +284,23 @@ export const Print = () => {
                   size={"small"}
                 />
               </Form.Item>
+              <Form.Item label={"Print Side"}>
+                <Select
+                  defaultValue={print_side}
+                  onChange={(val) => {
+                    setPrintSide(val);
+                    updateSettings({
+                      ...settings,
+                      printSettings: { ...settings.printSettings, print_side: val },
+                    });
+                  }}
+                  options={[
+                    { label: "Front", value: "front" },
+                    { label: "Back", value: "back" },
+                  ]}
+                  size={"small"}
+                />
+              </Form.Item>
             </Form>
             <Form
               style={{
@@ -340,7 +358,7 @@ export const Print = () => {
                               type="print"
                               key={`${rowIndex}-${index}`}
                               cardScaling={cardScaling}
-                              side={card.print_side || "front"}
+                              side={settings.printSettings.print_side || "front"}
                               backgrounds={backgrounds}
                             />
                           )}

--- a/src/Pages/Print.jsx
+++ b/src/Pages/Print.jsx
@@ -376,7 +376,7 @@ export const Print = () => {
                               type="print"
                               key={`${rowIndex}-${index}`}
                               cardScaling={cardScaling}
-                              side={force_print_side ? print_side : card.print_side}
+                              side={!card.print_side || force_print_side ? print_side : card.print_side}
                               backgrounds={backgrounds}
                             />
                           )}

--- a/src/Pages/Print.jsx
+++ b/src/Pages/Print.jsx
@@ -35,6 +35,7 @@ export const Print = () => {
   const [verticalAlignment, setVerticalAlignment] = useState(settings.printSettings?.verticalAlignment || "flex-start");
   const [backgrounds, setBackgrounds] = useState(settings.printSettings?.backgrounds || "standard");
   const [print_side, setPrintSide] = useState(settings.printSettings?.print_side || "front");
+  const [force_print_side, setForcePrintSide] = useState(settings.printSettings?.force_print_side || false);
 
   const { cardStorage } = useCardStorage();
 
@@ -284,6 +285,23 @@ export const Print = () => {
                   size={"small"}
                 />
               </Form.Item>
+              <Form.Item label={"Force Print Side"}>
+                <Select
+                  defaultValue={force_print_side}
+                  onChange={(val) => {
+                    setForcePrintSide(val);
+                    updateSettings({
+                      ...settings,
+                      printSettings: { ...settings.printSettings, force_print_side: val },
+                    });
+                  }}
+                  options={[
+                    { label: "Yes", value: true },
+                    { label: "No", value: false },
+                  ]}
+                  size={"small"}
+                />
+              </Form.Item>
               <Form.Item label={"Print Side"}>
                 <Select
                   defaultValue={print_side}
@@ -358,7 +376,7 @@ export const Print = () => {
                               type="print"
                               key={`${rowIndex}-${index}`}
                               cardScaling={cardScaling}
-                              side={settings.printSettings.print_side || "front"}
+                              side={force_print_side ? print_side : card.print_side || "front"}
                               backgrounds={backgrounds}
                             />
                           )}

--- a/src/Pages/Print.jsx
+++ b/src/Pages/Print.jsx
@@ -376,7 +376,7 @@ export const Print = () => {
                               type="print"
                               key={`${rowIndex}-${index}`}
                               cardScaling={cardScaling}
-                              side={force_print_side ? print_side : card.print_side || "front"}
+                              side={force_print_side ? print_side : card.print_side}
                               backgrounds={backgrounds}
                             />
                           )}

--- a/src/Pages/Print.jsx
+++ b/src/Pages/Print.jsx
@@ -1,4 +1,4 @@
-import { Button, Col, Form, Grid, Image, Input, Layout, Row, Select, Slider, Space, Typography } from "antd";
+import { Button, Col, Form, Grid, Image, Input, Layout, Row, Select, Slider, Space, Tooltip, Typography } from "antd";
 import split from "just-split";
 import { useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router-dom";
@@ -285,7 +285,7 @@ export const Print = () => {
                   size={"small"}
                 />
               </Form.Item>
-              <Form.Item label={"Force Print Side"}>
+              <Form.Item label={"Force Print Side"} tooltip="Force the print side even if datacards have one saved">
                 <Select
                   defaultValue={force_print_side}
                   onChange={(val) => {
@@ -302,7 +302,7 @@ export const Print = () => {
                   size={"small"}
                 />
               </Form.Item>
-              <Form.Item label={"Print Side"}>
+              <Form.Item label={"Print Side"} tooltip="Set the print side if the datacard does not have one saved">
                 <Select
                   defaultValue={print_side}
                   onChange={(val) => {


### PR DESCRIPTION
Attempting to address issue https://github.com/ronplanken/game-datacards/issues/85.

After discussion with @ronplanken on discord it sounds like there is a desire to keep backward compatibilty with previous behavior to help those who already duplicated their cards.

I'll need to add a force override option toggle to the print settings menu.
