### PR TITLE
Version 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-datacards",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "The only tool you will ever need for your custom datacards",
   "private": false,
   "homepage": "https://game-datacards.eu",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-datacards",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "The only tool you will ever need for your custom datacards",
   "private": false,
   "homepage": "https://game-datacards.eu",

--- a/src/App.js
+++ b/src/App.js
@@ -644,7 +644,9 @@ function App() {
                               updateActiveCard({ ...activeCard, print_side: "back" }, true);
                             }
                           }}>
-                          {activeCard.print_side === "back" ? "Show front" : "Show back"}
+                          {settings.showCardsAsDoubleSided === false && activeCard?.variant !== "full" && (
+                            <>{activeCard.print_side === "back" ? "Show front" : "Show back"}</>
+                          )}
                         </Button>
                       </>
                     )}

--- a/src/App.js
+++ b/src/App.js
@@ -635,19 +635,19 @@ function App() {
                             }}
                           />
                         </Space.Compact>
-                        <Button
-                          type={"primary"}
-                          onClick={() => {
-                            if (activeCard.print_side === "back") {
-                              updateActiveCard({ ...activeCard, print_side: "front" }, true);
-                            } else {
-                              updateActiveCard({ ...activeCard, print_side: "back" }, true);
-                            }
-                          }}>
-                          {settings.showCardsAsDoubleSided === false && activeCard?.variant !== "full" && (
-                            <>{activeCard.print_side === "back" ? "Show front" : "Show back"}</>
-                          )}
-                        </Button>
+                        {settings.showCardsAsDoubleSided !== true && activeCard?.variant !== "full" && (
+                          <Button
+                            type={"primary"}
+                            onClick={() => {
+                              if (activeCard.print_side === "back") {
+                                updateActiveCard({ ...activeCard, print_side: "front" }, true);
+                              } else {
+                                updateActiveCard({ ...activeCard, print_side: "back" }, true);
+                              }
+                            }}>
+                            {activeCard.print_side === "back" ? "Show front" : "Show back"}
+                          </Button>
+                        )}
                       </>
                     )}
                     {activeCard && !activeCard.isCustom && (

--- a/src/Components/FactionSettingsModal.jsx
+++ b/src/Components/FactionSettingsModal.jsx
@@ -311,6 +311,25 @@ export const FactionSettingsModal = () => {
                             <Col span={23}>
                               <Card
                                 type={"inner"}
+                                key={`display-01`}
+                                size={"small"}
+                                title={"Always show cards in single-side view"}
+                                bodyStyle={{ padding: 0 }}
+                                style={{ marginTop: "8px" }}
+                                extra={
+                                  <Switch
+                                    checked={settings.showCardsAsDoubleSided || false}
+                                    onChange={(value) => {
+                                      updateSettings({ ...settings, showCardsAsDoubleSided: value });
+                                    }}
+                                  />
+                                }></Card>
+                            </Col>
+                          </Row>
+                          <Row style={{ paddingTop: "0px" }}>
+                            <Col span={23}>
+                              <Card
+                                type={"inner"}
                                 key={`display-04`}
                                 size={"small"}
                                 title={"Group cards by role"}

--- a/src/Components/MarkdownSpanWrapDisplay.jsx
+++ b/src/Components/MarkdownSpanWrapDisplay.jsx
@@ -3,7 +3,7 @@ import rehypeSanitize from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 import stringWidth from "string-width";
 
-export const MarkdownSpanDisplay = ({ content, components }) => {
+export const MarkdownSpanWrapDisplay = ({ content, components }) => {
   return (
     <ReactMarkdown
       remarkPlugins={[[remarkGfm, { stringLength: stringWidth }]]}
@@ -11,7 +11,7 @@ export const MarkdownSpanDisplay = ({ content, components }) => {
       components={{
         p(props) {
           const { node, ...rest } = props;
-          return <span {...rest} />;
+          return <span style={{ whiteSpace: "pre-wrap" }} {...rest} />;
         },
       }}>
       {content}

--- a/src/Components/ServiceMessage.jsx
+++ b/src/Components/ServiceMessage.jsx
@@ -53,7 +53,7 @@ export const ServiceMessage = () => {
                   fontSize: "24px",
                   color: "white",
                 }}>
-                Messages
+                Service messages
               </h1>
             </div>
             <div className="welcome-cover">
@@ -61,7 +61,7 @@ export const ServiceMessage = () => {
                 {messages.map((message) => {
                   return (
                     <Row style={{ padding: "16px" }} className="whatsnew-content" key={message.id}>
-                      <Col>
+                      <Col style={{ padding: "16px" }}>
                         <Typography.Title level={5}>{message.title}</Typography.Title>
                         <Typography.Paragraph style={{ fontSize: "16px" }}>{message.body}</Typography.Paragraph>
                       </Col>

--- a/src/Components/SettingsModal.jsx
+++ b/src/Components/SettingsModal.jsx
@@ -328,6 +328,39 @@ export const SettingsModal = () => {
                       </ul>
                     </Typography.Paragraph>
                   </Panel> */}
+                  <Panel header={"Version 2.4.0"} key={"2.4.0"}>
+                    <b> 16-03-2024 </b>
+                    <Typography.Title level={5}>Updates</Typography.Title>
+                    <Typography.Paragraph style={{ fontSize: "16px" }}>
+                      <ul>
+                        <li>
+                          <strong>Space Marines update</strong>
+                          <br />
+                          The 10e Space Marines have been updated to their latest source. Make sure to update your
+                          datasources.
+                        </li>
+                      </ul>
+                      <ul>
+                        <li>
+                          <strong>Necron update</strong>
+                          <br />
+                          The 10e Necrons have been updated to their latest source. Make sure to update your
+                          datasources.
+                        </li>
+                      </ul>
+                    </Typography.Paragraph>
+                    <Typography.Title level={5}>Features</Typography.Title>
+                    <Typography.Paragraph style={{ fontSize: "16px" }}>
+                      <ul>
+                        <li>
+                          <strong>Service Messages</strong>
+                          <br />
+                          We are now able to add a simple message to the website to inform you of any issues or updates
+                          without having to make a new release.
+                        </li>
+                      </ul>
+                    </Typography.Paragraph>
+                  </Panel>
                   <Panel header={"Version 2.3.3"} key={"2.3.3"}>
                     <b> 15-12-2023 </b>
                     <Typography.Title level={5}>New Features</Typography.Title>

--- a/src/Components/SettingsModal.jsx
+++ b/src/Components/SettingsModal.jsx
@@ -328,6 +328,63 @@ export const SettingsModal = () => {
                       </ul>
                     </Typography.Paragraph>
                   </Panel> */}
+                  <Panel header={"Version 2.5.0"} key={"2.5.0"}>
+                    <b> 19-03-2024 </b>
+                    <Typography.Title level={5}>Updates</Typography.Title>
+                    <Typography.Paragraph style={{ fontSize: "16px" }}>
+                      <ul>
+                        <li>
+                          <strong>Dark Angels update</strong>
+                          <br />
+                          The new Dark Angels 10e codex has been added to the website.
+                        </li>
+                        <li>
+                          <strong>Chaos Space Marines</strong>
+                          <br />
+                          The CSM stratagems have been updated to comply with the latest index.
+                        </li>
+                      </ul>
+                    </Typography.Paragraph>
+                    <Typography.Title level={5}>Features</Typography.Title>
+                    <Typography.Paragraph style={{ fontSize: "16px" }}>
+                      <ul>
+                        <li>
+                          <strong>Markdown</strong>
+                          <br />
+                          Markdown has been re-enabled for most description fields. Please note that some options are
+                          not fully compatible yet. (Such as newlines)
+                        </li>
+                        <li>
+                          <strong>Invulnerable save display</strong>
+                          <br />
+                          The invulnerable save is now displayed at the top of the unit card. Old datasheets still
+                          default to the old location. Updated ones are by default displayed at the top.
+                        </li>
+                        <li>
+                          <strong>Combined weapon profiles</strong>
+                          <br />
+                          Weapons that have exclusive profiles (such as sweep & strike for melee) now have the maker to
+                          show they are exclusive.
+                        </li>
+                        <li>
+                          <strong>Weapon abilities</strong>
+                          <br />
+                          Weapon abilities (such as one-shot) can now be edited and added.
+                        </li>
+                        <li>
+                          <strong>Image Generator</strong>
+                          <br />A Image Generator has been added to the website. This allows you to create images of
+                          complete factions. This is an experimental feature and can be found{" "}
+                          <a href="/image-generator">here</a>.
+                        </li>
+                        <li>
+                          <strong>Various fixes</strong>
+                          <br />
+                          Various fixes and improvements have been made to the website.
+                        </li>
+                      </ul>
+                    </Typography.Paragraph>
+                  </Panel>
                   <Panel header={"Version 2.4.0"} key={"2.4.0"}>
                     <b> 16-03-2024 </b>
                     <Typography.Title level={5}>Updates</Typography.Title>

--- a/src/Components/Viewer/MobileFaction.jsx
+++ b/src/Components/Viewer/MobileFaction.jsx
@@ -92,9 +92,9 @@ export const MobileFaction = () => {
                             stratagem?.detachment?.toLowerCase() === selectedDetachment?.toLowerCase() ||
                             !stratagem.detachment
                         )
-                        .map((val) => (
+                        .map((val, index) => (
                           <Collapse.Panel
-                            key={`${val.detachment}-${val.name}`}
+                            key={`${val.detachment}-${val.name}-${index}`}
                             header={
                               <div style={{ display: "flex", justifyContent: "space-between" }}>
                                 <span>{val.name}</span>

--- a/src/Components/Viewer/MobileMenu.jsx
+++ b/src/Components/Viewer/MobileMenu.jsx
@@ -128,6 +128,20 @@ export const MobileMenu = ({ setIsVisible }) => {
                   }}
                 />
               }></Card>
+            <Card
+              type={"inner"}
+              key={`display-full-size`}
+              size={"small"}
+              title={"Always show cards in single-side view"}
+              bodyStyle={{ padding: 0 }}
+              extra={
+                <Switch
+                  checked={settings.showCardsAsDoubleSided || false}
+                  onChange={(value) => {
+                    updateSettings({ ...settings, showCardsAsDoubleSided: value });
+                  }}
+                />
+              }></Card>
             <Typography.Text style={{ color: "white" }}>Actions</Typography.Text>
             <Button
               size="large"

--- a/src/Components/Viewer/MobileNav.jsx
+++ b/src/Components/Viewer/MobileNav.jsx
@@ -5,10 +5,12 @@ import { useCardStorage } from "../../Hooks/useCardStorage";
 import { AddCard } from "../../Icons/AddCard";
 import { ListOverview } from "./ListCreator/ListOverview";
 import { useMobileList } from "./useMobileList";
+import { useSettingsStorage } from "../../Hooks/useSettingsStorage";
 
 export const MobileNav = ({ setSide, side, setMenuVisible, setSharingVisible, setAddListvisible }) => {
   const { activeCard } = useCardStorage();
   const { lists, selectedList } = useMobileList();
+  const { settings, updateSettings } = useSettingsStorage();
 
   const [showList, setShowList] = useState(false);
 
@@ -62,7 +64,7 @@ export const MobileNav = ({ setSide, side, setMenuVisible, setSharingVisible, se
                 className="button-bar mobile-icon-button"
                 onClick={() => setAddListvisible((val) => !val)}></Button>
             )}
-            {activeCard && (
+            {activeCard && settings.showCardsAsDoubleSided === false && (
               <Button
                 icon={side === "front" ? <RedoOutlined /> : <UndoOutlined />}
                 type="ghost"

--- a/src/Components/Warhammer40k-10e/CardDisplay.jsx
+++ b/src/Components/Warhammer40k-10e/CardDisplay.jsx
@@ -3,6 +3,8 @@ import { COLOURS } from "../../Helpers/printcolours.js";
 import { useCardStorage } from "../../Hooks/useCardStorage";
 import { StratagemCard } from "./StratagemCard";
 import { UnitCard } from "./UnitCard";
+import { useSettingsStorage } from "../../Hooks/useSettingsStorage.jsx";
+import { useDataSourceStorage } from "../../Hooks/useDataSourceStorage.jsx";
 
 export const Warhammer40K10eCardDisplay = ({
   type,
@@ -13,11 +15,20 @@ export const Warhammer40K10eCardDisplay = ({
   backgrounds = "standard",
 }) => {
   const { activeCard } = useCardStorage();
+  const { settings } = useSettingsStorage();
+  const { dataSource } = useDataSourceStorage();
+
+  const cardFaction = dataSource.data.find((faction) => faction.id === card?.faction_id);
 
   // if no background selected, use standard
   // this does assume standard will always exist but the alternative is duplicating the data?
   if (!(backgrounds in COLOURS)) {
     backgrounds = "standard";
+  }
+
+  if (backgrounds === "standard" || backgrounds === "colourprint" || backgrounds === "light") {
+    COLOURS[backgrounds].headerColour = cardFaction?.colours?.header;
+    COLOURS[backgrounds].bannerColour = cardFaction?.colours?.banner;
   }
   return (
     <>
@@ -42,8 +53,14 @@ export const Warhammer40K10eCardDisplay = ({
                 gap: printPadding,
                 transformOrigin: "top",
                 transform: `scale(${cardScaling / 100})`,
-                height: `${714 * (cardScaling / 100)}px`,
-                width: `${1077 * (cardScaling / 100)}px`,
+                height:
+                  settings.showCardsAsDoubleSided === true || card.variant === "full"
+                    ? "auto"
+                    : `${714 * (cardScaling / 100)}px`,
+                width:
+                  settings.showCardsAsDoubleSided === true || card.variant === "full"
+                    ? "auto"
+                    : `${1077 * (cardScaling / 100)}px`,
                 "--background-colour": COLOURS[backgrounds].titleBackgroundColour,
                 "--title-text-colour": COLOURS[backgrounds].titleTextColour,
                 "--faction-text-colour": COLOURS[backgrounds].factionTextColour,

--- a/src/Components/Warhammer40k-10e/CardEditor.jsx
+++ b/src/Components/Warhammer40k-10e/CardEditor.jsx
@@ -12,7 +12,7 @@ export const Warhammer40K10eCardEditor = () => {
 
   return (
     <>
-      {activeCard && settings.showCardsAsDoubleSided === false && activeCard.variant !== "full" && (
+      {activeCard && settings.showCardsAsDoubleSided !== true && activeCard.variant !== "full" && (
         <Col span={24} className={`card-editor`}>
           {activeCard.cardType === "DataCard" && (activeCard.print_side === "front" || !activeCard.print_side) && (
             <UnitCardEditor />

--- a/src/Components/Warhammer40k-10e/CardEditor.jsx
+++ b/src/Components/Warhammer40k-10e/CardEditor.jsx
@@ -3,18 +3,34 @@ import { useCardStorage } from "../../Hooks/useCardStorage";
 import { StratagemEditor } from "./StratagemEditor";
 import { UnitCardBackEditor } from "./UnitCardBackEditor";
 import { UnitCardEditor } from "./UnitCardEditor";
+import { useSettingsStorage } from "../../Hooks/useSettingsStorage";
+import { UnitCardFullEditor } from "./UnitCardFullEditor";
 
 export const Warhammer40K10eCardEditor = () => {
   const { activeCard } = useCardStorage();
+  const { settings, updateSettings } = useSettingsStorage();
+
   return (
-    activeCard && (
-      <Col span={24} className={`card-editor`}>
-        {activeCard.cardType === "DataCard" && (activeCard.print_side === "front" || !activeCard.print_side) && (
-          <UnitCardEditor />
-        )}
-        {activeCard.cardType === "stratagem" && <StratagemEditor />}
-        {activeCard.cardType === "DataCard" && activeCard.print_side === "back" && <UnitCardBackEditor />}
-      </Col>
-    )
+    <>
+      {activeCard && settings.showCardsAsDoubleSided === false && activeCard.variant !== "full" && (
+        <Col span={24} className={`card-editor`}>
+          {activeCard.cardType === "DataCard" && (activeCard.print_side === "front" || !activeCard.print_side) && (
+            <UnitCardEditor />
+          )}
+          {activeCard.cardType === "stratagem" && <StratagemEditor />}
+          {activeCard.cardType === "DataCard" && activeCard.print_side === "back" && <UnitCardBackEditor />}
+        </Col>
+      )}
+      {activeCard && (settings.showCardsAsDoubleSided === true || activeCard.variant === "full") && (
+        <Col span={24} className={`card-editor`}>
+          {activeCard.cardType === "DataCard" && (
+            <>
+              <UnitCardFullEditor />
+            </>
+          )}
+          {activeCard.cardType === "stratagem" && <StratagemEditor />}
+        </Col>
+      )}
+    </>
   );
 };

--- a/src/Components/Warhammer40k-10e/UnitCard.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard.jsx
@@ -6,7 +6,7 @@ import { UnitCardFull } from "./UnitCardFull";
 export const UnitCard = ({ unit, cardStyle, paddingTop = "32px", className, side = "front" }) => {
   const { settings, updateSettings } = useSettingsStorage();
 
-  if (unit.variant === "full" || settings.showCardsAsDoubleSided) {
+  if (unit.variant === "full" || settings.showCardsAsDoubleSided === true) {
     return <UnitCardFull unit={unit} cardStyle={cardStyle} paddingTop={paddingTop} className={className} />;
   }
   if (side === "front") {

--- a/src/Components/Warhammer40k-10e/UnitCard.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard.jsx
@@ -1,7 +1,14 @@
+import { useSettingsStorage } from "../../Hooks/useSettingsStorage";
 import { UnitCardBack } from "./UnitCardBack";
 import { UnitCardFront } from "./UnitCardFront";
+import { UnitCardFull } from "./UnitCardFull";
 
 export const UnitCard = ({ unit, cardStyle, paddingTop = "32px", className, side = "front" }) => {
+  const { settings, updateSettings } = useSettingsStorage();
+
+  if (unit.variant === "full" || settings.showCardsAsDoubleSided) {
+    return <UnitCardFull unit={unit} cardStyle={cardStyle} paddingTop={paddingTop} className={className} />;
+  }
   if (side === "front") {
     return <UnitCardFront unit={unit} cardStyle={cardStyle} paddingTop={paddingTop} className={className} />;
   }

--- a/src/Components/Warhammer40k-10e/UnitCard/KeywordTooltip.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/KeywordTooltip.jsx
@@ -6,7 +6,7 @@ export const tooltipProps = {
 };
 
 export const KeywordTooltip = ({ keyword }) => {
-  if (keyword.includes("anti-")) {
+  if (keyword.toLowerCase().includes("anti-")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -15,14 +15,14 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("one shot")) {
+  if (keyword.toLowerCase().includes("one shot")) {
     return (
       <Tooltip {...tooltipProps} title={"The bearer can only shoot with this weapon once per battle."}>
         <Button type="text" size="small" className="keyword-button">{`${keyword}`}</Button>
       </Tooltip>
     );
   }
-  if (keyword.includes("linked fire")) {
+  if (keyword.toLowerCase().includes("linked fire")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -33,7 +33,7 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("plasma warhead")) {
+  if (keyword.toLowerCase().includes("plasma warhead")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -44,7 +44,7 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("feel no pain")) {
+  if (keyword.toLowerCase().includes("feel no pain")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -55,14 +55,14 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("assault")) {
+  if (keyword.toLowerCase().includes("assault")) {
     return (
       <Tooltip {...tooltipProps} title={"Can be shot even if the bearer’s unit Advanced."}>
         <Button type="text" size="small" className="keyword-button">{`${keyword}`}</Button>
       </Tooltip>
     );
   }
-  if (keyword.includes("pistol")) {
+  if (keyword.toLowerCase().includes("pistol")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -79,7 +79,7 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("melta")) {
+  if (keyword.toLowerCase().includes("melta")) {
     return (
       <Tooltip
         title={
@@ -90,14 +90,14 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("rapid fire")) {
+  if (keyword.toLowerCase().includes("rapid fire")) {
     return (
       <Tooltip title={"Increase the Attacks by ‘x’ when targeting units within half range."} {...tooltipProps}>
         <Button type="text" size="small" className="keyword-button">{`${keyword}`}</Button>
       </Tooltip>
     );
   }
-  if (keyword.includes("torrent")) {
+  if (keyword.toLowerCase().includes("torrent")) {
     return (
       <Tooltip
         title={"Each time an attack is made with this weapon, that attack automatically hits the target."}
@@ -106,7 +106,7 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("ignores cover")) {
+  if (keyword.toLowerCase().includes("ignores cover")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -117,7 +117,7 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("lethal hits")) {
+  if (keyword.toLowerCase().includes("lethal hits")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -126,7 +126,7 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("lance")) {
+  if (keyword.toLowerCase().includes("lance")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -137,7 +137,7 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("indirect fire")) {
+  if (keyword.toLowerCase().includes("indirect fire")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -155,7 +155,7 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("precision")) {
+  if (keyword.toLowerCase().includes("precision")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -166,7 +166,7 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("blast")) {
+  if (keyword.toLowerCase().includes("blast")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -183,14 +183,14 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("heavy")) {
+  if (keyword.toLowerCase().includes("heavy")) {
     return (
       <Tooltip {...tooltipProps} title={"Add 1 to Hit rolls if the bearer’s unit Remained Stationary this turn."}>
         <Button type="text" size="small" className="keyword-button">{`${keyword}`}</Button>
       </Tooltip>
     );
   }
-  if (keyword.includes("twin-linked")) {
+  if (keyword.toLowerCase().includes("twin-linked")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -199,7 +199,7 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("hazardous")) {
+  if (keyword.toLowerCase().includes("hazardous")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -210,7 +210,7 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("devastating wounds")) {
+  if (keyword.toLowerCase().includes("devastating wounds")) {
     return (
       <Tooltip
         title={
@@ -221,14 +221,14 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("sustained hits")) {
+  if (keyword.toLowerCase().includes("sustained hits")) {
     return (
       <Tooltip {...tooltipProps} title={"Each Critical Hit scores ‘x’ additional hits on the target."}>
         <Button type="text" size="small" className="keyword-button">{`${keyword}`}</Button>
       </Tooltip>
     );
   }
-  if (keyword.includes("extra attacks")) {
+  if (keyword.toLowerCase().includes("extra attacks")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -237,7 +237,7 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("extra attacks")) {
+  if (keyword.toLowerCase().includes("extra attacks")) {
     return (
       <Tooltip
         {...tooltipProps}
@@ -246,7 +246,7 @@ export const KeywordTooltip = ({ keyword }) => {
       </Tooltip>
     );
   }
-  if (keyword.includes("psychic")) {
+  if (keyword.toLowerCase().includes("psychic")) {
     return (
       <Tooltip
         {...tooltipProps}

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitAbilityDescription.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitAbilityDescription.jsx
@@ -74,7 +74,11 @@ export function replaceKeywords(inputString) {
         const newChildren = component.props.children.split("■").map((segment, i) => (
           <React.Fragment key={i}>
             {<MarkdownSpanDisplay content={segment} />}
-            {i !== component.props.children.split("■").length - 1 && <br />}
+            {i !== component.props.children.split("■").length - 1 && (
+              <>
+                <br /> ■
+              </>
+            )}
           </React.Fragment>
         ));
 
@@ -93,7 +97,11 @@ export function replaceKeywords(inputString) {
           return child.split("■").map((segment, j) => (
             <React.Fragment key={j}>
               {<MarkdownSpanDisplay content={segment} />}
-              {j !== child.split("■").length - 1 && <br />}
+              {j !== child.split("■").length - 1 && (
+                <>
+                  <br /> ■
+                </>
+              )}
             </React.Fragment>
           ));
         }

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitAbilityDescription.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitAbilityDescription.jsx
@@ -91,7 +91,6 @@ export function replaceKeywords(inputString) {
     } else if (React.isValidElement(component) && component.props.children.length > 0) {
       // Loop over all children and check if they are strings
       const newChildren = component.props.children.map((child, i) => {
-        console.log(child);
         // Replace "■" with newline components
         if (typeof child === "string" && child.includes("■")) {
           return child.split("■").map((segment, j) => (

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitAbilityDescription.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitAbilityDescription.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { KeywordTooltip } from "./KeywordTooltip";
 import { RuleTooltip } from "./RuleTooltip";
-import { MarkdownSpanDisplay } from "../../MarkdownSpanDisplay";
+import { MarkdownSpanWrapDisplay } from "../../MarkdownSpanWrapDisplay";
 export function replaceKeywords(inputString) {
   if (!inputString) {
     return;
@@ -58,7 +58,7 @@ export function replaceKeywords(inputString) {
       if (component.includes("■")) {
         return component.split("■").map((segment, i) => (
           <React.Fragment key={i}>
-            {<MarkdownSpanDisplay content={segment} />}
+            {<MarkdownSpanWrapDisplay content={segment} />}
             {i !== component.split("■").length - 1 && (
               <>
                 <br /> ■
@@ -67,13 +67,13 @@ export function replaceKeywords(inputString) {
           </React.Fragment>
         ));
       }
-      return <MarkdownSpanDisplay content={component} key={index} />;
+      return <MarkdownSpanWrapDisplay content={component} key={index} />;
     } else if (React.isValidElement(component) && typeof component.props.children === "string") {
       // Replace "■" with newline components
       if (component.props.children.includes("■")) {
         const newChildren = component.props.children.split("■").map((segment, i) => (
           <React.Fragment key={i}>
-            {<MarkdownSpanDisplay content={segment} />}
+            {<MarkdownSpanWrapDisplay content={segment} />}
             {i !== component.props.children.split("■").length - 1 && (
               <>
                 <br /> ■
@@ -86,7 +86,7 @@ export function replaceKeywords(inputString) {
         return React.cloneElement(component, { ...component.props, key: index, children: newChildren });
       }
 
-      const newChildren = <MarkdownSpanDisplay content={component.props.children} />;
+      const newChildren = <MarkdownSpanWrapDisplay content={component.props.children} />;
       return React.cloneElement(component, { ...component.props, key: index, children: newChildren });
     } else if (React.isValidElement(component) && component.props.children.length > 0) {
       // Loop over all children and check if they are strings
@@ -96,7 +96,7 @@ export function replaceKeywords(inputString) {
         if (typeof child === "string" && child.includes("■")) {
           return child.split("■").map((segment, j) => (
             <React.Fragment key={j}>
-              {<MarkdownSpanDisplay content={segment} />}
+              {<MarkdownSpanWrapDisplay content={segment} />}
               {j !== child.split("■").length - 1 && (
                 <>
                   <br /> ■
@@ -107,7 +107,7 @@ export function replaceKeywords(inputString) {
         }
         // if it doesnt containt a newline character, return as a MarkDownSpanDisplay
         if (typeof child === "string") {
-          return <MarkdownSpanDisplay content={child} key={i} />;
+          return <MarkdownSpanWrapDisplay content={child} key={i} />;
         }
 
         // Return the component as is if it doesn't meet the criteria

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitLoadout.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitLoadout.jsx
@@ -46,7 +46,7 @@ export const UnitLoadout = ({ unit }) => {
                   <div key={`leader-${leader}`}>
                     ■
                     <Link
-                      to={`/viewer/${selectedFaction.name.toLowerCase().replaceAll(" ", "-")}/${leader
+                      to={`/viewer/${selectedFaction?.name.toLowerCase().replaceAll(" ", "-")}/${leader
                         .replaceAll(" ", "-")
                         .toLowerCase()}`}>
                       <span className="value">{leader}</span>

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitWargear.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitWargear.jsx
@@ -13,13 +13,33 @@ export const UnitWargear = ({ unit }) => {
               explanations.push(...lines.slice(1));
               return (
                 <div className="item" key={`wargear-${index}`}>
-                  <span className="description">{lines[0].replaceAll("◦", "\n◦")}</span>
+                  <span className="description">
+                    {wargear.split("◦")[0]}
+                    <ul style={{ listStyle: "none", padding: "0" }}>
+                      {wargear
+                        .split("◦")
+                        .filter((item, index) => index !== 0)
+                        .map((line) => (
+                          <li key={line}>{line?.trim()}</li>
+                        ))}
+                    </ul>
+                  </span>
                 </div>
               );
             }
             return (
               <div className="item" key={`wargear-${index}`}>
-                <span className="description">{wargear.replaceAll("◦", "\n◦")}</span>
+                <span className="description">
+                  {wargear.split("◦")[0]}
+                  <ul style={{ columns: wargear?.split("◦")?.length > 4 ? "2" : "1" }}>
+                    {wargear
+                      .split("◦")
+                      .filter((item, index) => index !== 0)
+                      .map((line) => (
+                        <li key={line}>{line?.trim()}</li>
+                      ))}
+                  </ul>
+                </span>
               </div>
             );
           })}

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitWeaponKeyword.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitWeaponKeyword.jsx
@@ -7,6 +7,7 @@ export const tooltipProps = {
 
 export const UnitWeaponKeywords = ({ keywords }) => {
   const tooltips = keywords.map((keyword, index) => {
+    console.log("keyword:", keyword);
     return <KeywordTooltip keyword={keyword} key={`${keyword}-${index}`} />;
   });
 

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitWeaponKeyword.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitWeaponKeyword.jsx
@@ -7,7 +7,6 @@ export const tooltipProps = {
 
 export const UnitWeaponKeywords = ({ keywords }) => {
   const tooltips = keywords.map((keyword, index) => {
-    console.log("keyword:", keyword);
     return <KeywordTooltip keyword={keyword} key={`${keyword}-${index}`} />;
   });
 

--- a/src/Components/Warhammer40k-10e/UnitCardEditor/UnitBasicInfo.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCardEditor/UnitBasicInfo.jsx
@@ -33,7 +33,7 @@ export function UnitBasicInfo() {
           onChange={(value) => updateActiveCard({ ...activeCard, faction_id: value })}
         />
       </Form.Item>
-      {settings.showCardsAsDoubleSided === false && (
+      {settings.showCardsAsDoubleSided !== true && (
         <>
           <Form.Item label={"Variant"}>
             <Select

--- a/src/Components/Warhammer40k-10e/UnitCardEditor/UnitBasicInfo.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCardEditor/UnitBasicInfo.jsx
@@ -2,11 +2,14 @@ import { Form, Input, Select, Switch } from "antd";
 import React from "react";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
 import { FactionSelect } from "../FactionSelect";
+import { settings } from "firebase/analytics";
+import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
 
 const { Option } = Select;
 
 export function UnitBasicInfo() {
   const { activeCard, updateActiveCard } = useCardStorage();
+  const { settings, updateSettings } = useSettingsStorage();
 
   return (
     <Form>
@@ -30,14 +33,37 @@ export function UnitBasicInfo() {
           onChange={(value) => updateActiveCard({ ...activeCard, faction_id: value })}
         />
       </Form.Item>
-      <Form.Item label={"Print side"}>
-        <Select
-          value={activeCard.print_side || "front"}
-          onChange={(value) => updateActiveCard({ ...activeCard, print_side: value })}>
-          <Option value="front">Front</Option>
-          <Option value="back">Back</Option>
-        </Select>
-      </Form.Item>
+      {settings.showCardsAsDoubleSided === false && (
+        <>
+          <Form.Item label={"Variant"}>
+            <Select
+              value={activeCard.variant || "double"}
+              onChange={(value) => updateActiveCard({ ...activeCard, variant: value })}>
+              <Option value="full">Full card</Option>
+              <Option value="double">Double sided</Option>
+            </Select>
+          </Form.Item>
+          {activeCard.variant !== "full" && (
+            <Form.Item label={"Print side"}>
+              <Select
+                value={activeCard.print_side || "front"}
+                onChange={(value) => updateActiveCard({ ...activeCard, print_side: value })}>
+                <Option value="front">Front</Option>
+                <Option value="back">Back</Option>
+              </Select>
+            </Form.Item>
+          )}
+        </>
+      )}
+      {settings.showCardsAsDoubleSided === true && (
+        <Form.Item label={"Variant"}>
+          <Select value={"full"} disabled={true}>
+            <Option value="full">Full card</Option>
+            <Option value="double">Double sided</Option>
+          </Select>
+        </Form.Item>
+      )}
+
       <Form.Item label={"Legends"}>
         <Switch
           checked={activeCard.legends || false}

--- a/src/Components/Warhammer40k-10e/UnitCardFull.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCardFull.jsx
@@ -1,0 +1,51 @@
+import { UnitExtra } from "./UnitCard/UnitExtra";
+import { UnitFactions } from "./UnitCard/UnitFactions";
+import { UnitInvulTop } from "./UnitCard/UnitInvulTop";
+import { UnitKeywords } from "./UnitCard/UnitKeywords";
+import { UnitLoadout } from "./UnitCard/UnitLoadout";
+import { UnitName } from "./UnitCard/UnitName";
+import { UnitStats } from "./UnitCard/UnitStats";
+import { UnitWargear } from "./UnitCard/UnitWargear";
+import { UnitWeapons } from "./UnitCard/UnitWeapons";
+
+export const UnitCardFull = ({ unit, cardStyle, paddingTop = "32px", className }) => {
+  return (
+    <div
+      className={className}
+      style={{
+        ...cardStyle,
+        justifyContent: "center",
+        justifyItems: "center",
+        display: "flex",
+      }}>
+      <div className={`unit full`}>
+        <div className={"header"}>
+          <UnitName name={unit.name} subname={unit.subname} points={unit.points} legends={unit.legends} />
+          <UnitStats stats={unit.stats} />
+          <div className="stats_container" key={`stat-line-invul`}>
+            {unit.abilities?.invul?.showInvulnerableSave && unit.abilities?.invul?.showAtTop && (
+              <UnitInvulTop invul={unit.abilities?.invul} />
+            )}
+          </div>
+        </div>
+        <div className="data_container">
+          <div className="data">
+            <UnitWeapons unit={unit} />
+            <div className="multi-data">
+              <UnitWargear unit={unit} />
+              <UnitLoadout unit={unit} />
+            </div>
+            <UnitExtra unit={unit} />
+          </div>
+        </div>
+        <div className="footer">
+          <UnitKeywords keywords={unit.keywords} />
+          <UnitFactions factions={unit.factions} />
+        </div>
+        <div className="faction">
+          <div className={unit.faction_id}></div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/Components/Warhammer40k-10e/UnitCardFullEditor.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCardFullEditor.jsx
@@ -1,0 +1,88 @@
+import { Collapse } from "antd";
+import { useCardStorage } from "../../Hooks/useCardStorage";
+import { UnitBasicAbility } from "./UnitCardEditor/UnitBasicAbility";
+import { UnitBasicInfo } from "./UnitCardEditor/UnitBasicInfo";
+import { UnitDamageTable } from "./UnitCardEditor/UnitDamageTable";
+import { UnitExtendedAbilities } from "./UnitCardEditor/UnitExtendedAbilities";
+import { UnitInvulnerableSave } from "./UnitCardEditor/UnitInvulnerableSave";
+import { UnitKeywords } from "./UnitCardEditor/UnitKeywords";
+import { UnitPoints } from "./UnitCardEditor/UnitPoints";
+import { UnitPrimarchAbilities } from "./UnitCardEditor/UnitPrimarchAbilities";
+import { UnitStats } from "./UnitCardEditor/UnitStats";
+import { UnitWeapons } from "./UnitCardEditor/UnitWeapons";
+import { UnitWargearOptions } from "./UnitCardEditor/UnitWargearOptions";
+import { UnitComposition } from "./UnitCardEditor/UnitComposition";
+import { UnitLoadout } from "./UnitCardEditor/UnitLoadout";
+import { UnitTransport } from "./UnitCardEditor/UnitTransport";
+import { UnitLeader } from "./UnitCardEditor/UnitLeads";
+import { UnitLedBy } from "./UnitCardEditor/UnitLedBy";
+
+const { Panel } = Collapse;
+
+export const UnitCardFullEditor = () => {
+  const { activeCard } = useCardStorage();
+
+  return (
+    <Collapse defaultActiveKey={["1"]}>
+      <Panel header="Basic information" style={{ width: "100%" }} key="1">
+        <UnitBasicInfo />
+      </Panel>
+      <Panel header="Datasheets" style={{ width: "100%" }} key="2">
+        <UnitStats />
+      </Panel>
+      <Panel header="Invulnerable save" style={{ width: "100%" }} key="9">
+        <UnitInvulnerableSave />
+      </Panel>
+      <Panel header="Points" style={{ width: "100%" }} key="points">
+        <UnitPoints />
+      </Panel>
+      <Panel header="Ranged weapons" style={{ width: "100%" }} key="3">
+        <UnitWeapons type={"rangedWeapons"} />
+      </Panel>
+      <Panel header="Melee weapons" style={{ width: "100%" }} key="4">
+        <UnitWeapons type={"meleeWeapons"} />
+      </Panel>
+      <Panel header="Basic abilities" style={{ width: "100%" }} key="5">
+        <UnitBasicAbility type={"core"} />
+        <UnitBasicAbility type={"faction"} />
+      </Panel>
+      <Panel header="Extended abilities" style={{ width: "100%" }} key="6">
+        <UnitExtendedAbilities type={"other"} />
+      </Panel>
+      <Panel header="Wargear abilities" style={{ width: "100%" }} key="7">
+        <UnitExtendedAbilities type={"wargear"} />
+      </Panel>
+      <Panel header="Special abilities" style={{ width: "100%" }} key="special">
+        <UnitExtendedAbilities type={"special"} />
+      </Panel>
+      <Panel header="Damaged ability" style={{ width: "100%" }} key="8">
+        <UnitDamageTable />
+      </Panel>
+      <Panel header="Primarch ability" style={{ width: "100%" }} key="primarch">
+        <UnitPrimarchAbilities />
+      </Panel>
+      <Panel header="Wargear Options" style={{ width: "100%" }} key="wargear_options">
+        <UnitWargearOptions />
+      </Panel>
+      <Panel header="Composition" style={{ width: "100%" }} key="composition">
+        <UnitComposition />
+      </Panel>
+      <Panel header="Loadout" style={{ width: "100%" }} key="loadout">
+        <UnitLoadout />
+      </Panel>
+      <Panel header="Transport" style={{ width: "100%" }} key="transport">
+        <UnitTransport />
+      </Panel>
+      <Panel header="Leader" style={{ width: "100%" }} key="leader">
+        <UnitLeader />
+      </Panel>
+      <Panel header="Led by" style={{ width: "100%" }} key="ledby">
+        <UnitLedBy />
+      </Panel>
+      <Panel header="Keywords" style={{ width: "100%" }} key="10">
+        <UnitKeywords type={"keywords"} />
+        <UnitKeywords type={"factions"} />
+      </Panel>
+    </Collapse>
+  );
+};

--- a/src/Components/WhatsNew.jsx
+++ b/src/Components/WhatsNew.jsx
@@ -45,7 +45,7 @@ export const WhatsNew = () => {
                   fontSize: "32px",
                   color: "white",
                 }}>
-                Whats new in 2.4.0
+                Whats new in 2.5.0
               </h1>
             </div>
             <div className="welcome-cover">
@@ -56,18 +56,14 @@ export const WhatsNew = () => {
                     <Typography.Paragraph style={{ fontSize: "16px" }}>
                       <ul>
                         <li>
-                          <strong>Space Marines update</strong>
+                          <strong>Dark Angels update</strong>
                           <br />
-                          The 10e Space Marines have been updated to their latest source. Make sure to update your
-                          datasources.
+                          The new Dark Angels 10e codex has been added to the website.
                         </li>
-                      </ul>
-                      <ul>
                         <li>
-                          <strong>Necron update</strong>
+                          <strong>Chaos Space Marines</strong>
                           <br />
-                          The 10e Necrons have been updated to their latest source. Make sure to update your
-                          datasources.
+                          The CSM stratagems have been updated to comply with the latest index.
                         </li>
                       </ul>
                     </Typography.Paragraph>
@@ -75,10 +71,38 @@ export const WhatsNew = () => {
                     <Typography.Paragraph style={{ fontSize: "16px" }}>
                       <ul>
                         <li>
-                          <strong>Service Messages</strong>
+                          <strong>Markdown</strong>
                           <br />
-                          We are now able to add a simple message to the website to inform you of any issues or updates
-                          without having to make a new release.
+                          Markdown has been re-enabled for most description fields. Please note that some options are
+                          not fully compatible yet. (Such as newlines)
+                        </li>
+                        <li>
+                          <strong>Invulnerable save display</strong>
+                          <br />
+                          The invulnerable save is now displayed at the top of the unit card. Old datasheets still
+                          default to the old location. Updated ones are by default displayed at the top.
+                        </li>
+                        <li>
+                          <strong>Combined weapon profiles</strong>
+                          <br />
+                          Weapons that have exclusive profiles (such as sweep & strike for melee) now have the maker to
+                          show they are exclusive.
+                        </li>
+                        <li>
+                          <strong>Weapon abilities</strong>
+                          <br />
+                          Weapon abilities (such as one-shot) can now be edited and added.
+                        </li>
+                        <li>
+                          <strong>Image Generator</strong>
+                          <br />A Image Generator has been added to the website. This allows you to create images of
+                          complete factions. This is an experimental feature and can be found{" "}
+                          <a href="/image-generator">here</a>.
+                        </li>
+                        <li>
+                          <strong>Various fixes</strong>
+                          <br />
+                          Various fixes and improvements have been made to the website.
                         </li>
                       </ul>
                     </Typography.Paragraph>

--- a/src/Components/WhatsNew.jsx
+++ b/src/Components/WhatsNew.jsx
@@ -45,66 +45,70 @@ export const WhatsNew = () => {
                   fontSize: "32px",
                   color: "white",
                 }}>
-                Whats new in 2.5.0
+                Whats new in 2.6.0
               </h1>
             </div>
             <div className="welcome-cover">
               <>
                 <Row style={{ padding: "16px" }} className="whatsnew-content">
                   <Col>
-                    <Typography.Title level={5}>Updates</Typography.Title>
-                    <Typography.Paragraph style={{ fontSize: "16px" }}>
-                      <ul>
-                        <li>
-                          <strong>Dark Angels update</strong>
-                          <br />
-                          The new Dark Angels 10e codex has been added to the website.
-                        </li>
-                        <li>
-                          <strong>Chaos Space Marines</strong>
-                          <br />
-                          The CSM stratagems have been updated to comply with the latest index.
-                        </li>
-                      </ul>
-                    </Typography.Paragraph>
                     <Typography.Title level={5}>Features</Typography.Title>
                     <Typography.Paragraph style={{ fontSize: "16px" }}>
                       <ul>
                         <li>
-                          <strong>Markdown</strong>
+                          <strong>Full sized cards display</strong>
                           <br />
-                          Markdown has been re-enabled for most description fields. Please note that some options are
-                          not fully compatible yet. (Such as newlines)
+                          Finally! The technology has arrived to display Warhammer 10e cards in a single full sized card
+                          side. This is a feature that has been requested for a long time and is finally here. You can
+                          toggle the feature per card (as a Variant) or globally in the settings.
+                          <br />
+                          The settings option can be found next to the faction selection dropdown on desktop and in the
+                          settings menu on mobile. Please note this overrides any options regarding the back & front
+                          options of a card.
                         </li>
                         <li>
-                          <strong>Invulnerable save display</strong>
+                          <strong>Complete and thorough cleanup of datasources</strong>
                           <br />
-                          The invulnerable save is now displayed at the top of the unit card. Old datasheets still
-                          default to the old location. Updated ones are by default displayed at the top.
-                        </li>
-                        <li>
-                          <strong>Combined weapon profiles</strong>
+                          We have set all our servitors to work and managed to automate the error checking and cleanup
+                          of our datasources. This means we are now able to provide a more consistent and reliable
+                          experience with your datacards!
                           <br />
-                          Weapons that have exclusive profiles (such as sweep & strike for melee) now have the maker to
-                          show they are exclusive.
-                        </li>
-                        <li>
-                          <strong>Weapon abilities</strong>
-                          <br />
-                          Weapon abilities (such as one-shot) can now be edited and added.
-                        </li>
-                        <li>
-                          <strong>Image Generator</strong>
-                          <br />A Image Generator has been added to the website. This allows you to create images of
-                          complete factions. This is an experimental feature and can be found{" "}
-                          <a href="/image-generator">here</a>.
-                        </li>
-                        <li>
-                          <strong>Various fixes</strong>
-                          <br />
-                          Various fixes and improvements have been made to the website.
+                          During this setup we also changed all cards to default to the invulnerable save at the top of
+                          the card. Your old cards are unfortunately not updated to this new standard and need a manual
+                          update or create a new duplicate card.
                         </li>
                       </ul>
+                    </Typography.Paragraph>
+                    <Typography.Title level={5}>Known issues</Typography.Title>
+                    <Typography.Paragraph style={{ fontSize: "16px" }}>
+                      <ul>
+                        <li>
+                          <strong>Printing full sized cards</strong>
+                          <br />
+                          Unfortunately the full sized cards currently do not play nice with other cards while printing.
+                          This means when you try to print multiple cards on a page they might take up more space then
+                          you wish. You can still print them, but min/maxing the page might be tricky. We are working on
+                          a fix and will keep you updated.
+                        </li>
+                      </ul>
+                    </Typography.Paragraph>
+                    <Typography.Title level={5}>Social</Typography.Title>
+                    <Typography.Paragraph style={{ fontSize: "16px" }}>
+                      <ul>
+                        <li>
+                          <strong>We need your help!</strong>
+                          <br />
+                          Please report any issues you find to the Discord or join us to chat about new and upcoming
+                          features!
+                        </li>
+                      </ul>
+                      <Row style={{ padding: "16px" }} justify={"center"}>
+                        <Col span={24} style={{ textAlign: "center" }}>
+                          <a href="https://discord.gg/anfn4qTYC4" target={"_blank"} rel="noreferrer">
+                            <img src="https://discordapp.com/api/guilds/997166169540788244/widget.png?style=banner2"></img>
+                          </a>
+                        </Col>
+                      </Row>
                     </Typography.Paragraph>
                   </Col>
                 </Row>

--- a/src/Helpers/external.helpers.js
+++ b/src/Helpers/external.helpers.js
@@ -474,7 +474,7 @@ export const get40k10eData = async () => {
 };
 
 export const getMessages = async () => {
-  const url = `${process.env.REACT_APP_MESSAGES_URL}`;
+  const url = `${process.env.REACT_APP_MESSAGES_URL}?${new Date().getTime()}`;
   const data = await readCsv(url);
   return data;
 };

--- a/src/Helpers/printcolours.js
+++ b/src/Helpers/printcolours.js
@@ -30,7 +30,7 @@
 // blueStratagemColour;
 // redStratagemColour;
 
-export const COLOURS = {
+export let COLOURS = {
   standard: {
     titleBackgroundColour: "black",
     titleTextColour: "white",

--- a/src/Hooks/useDataSourceStorage.jsx
+++ b/src/Hooks/useDataSourceStorage.jsx
@@ -49,7 +49,6 @@ export const DataSourceStorageProviderComponent = (props) => {
         setDataSource(dataFactions);
       }
       if (settings.selectedDataSource === "40k-10e") {
-        console.log("update settings");
         const storedData = await dataStore.getItem("40k-10e");
         if (storedData) {
           setDataSource(storedData);

--- a/src/Pages/ImageGenerator.jsx
+++ b/src/Pages/ImageGenerator.jsx
@@ -116,6 +116,7 @@ export const ImageGenerator = () => {
   const [selectedFactions, setSelectedFactions] = useState([]);
   const [addStratagems, setAddStratagems] = useState(false);
   const [addDatasheets, setAddDatasheets] = useState(true);
+  const [invulTop, setInvulTop] = useState(false);
 
   const { Id } = useParams();
   const navigate = useNavigate();
@@ -250,6 +251,9 @@ export const ImageGenerator = () => {
                   <Button type={addDatasheets ? "primary" : "default"} onClick={() => setAddDatasheets((val) => !val)}>
                     {addDatasheets ? <CheckSquareOutlined /> : <BorderOutlined />}Datasheets
                   </Button>
+                  <Button type={invulTop ? "primary" : "default"} onClick={() => setInvulTop((val) => !val)}>
+                    {invulTop ? <CheckSquareOutlined /> : <BorderOutlined />}Invul at top
+                  </Button>
                 </Space>
               </Typography.Title>
             </Space>
@@ -298,6 +302,9 @@ export const ImageGenerator = () => {
                 <>
                   {addDatasheets &&
                     faction.datasheets.map((card, index) => {
+                      if (card.abilities?.invul?.showInvulnerableSave && invulTop) {
+                        card.abilities.invul.showAtTop = true;
+                      }
                       return (
                         <div
                           style={{

--- a/src/Pages/Print.jsx
+++ b/src/Pages/Print.jsx
@@ -304,6 +304,7 @@ export const Print = () => {
                   <Form.Item label={"Force Print Side"} tooltip="Force the print side even if datacards have one saved">
                     <Select
                       defaultValue={force_print_side}
+                      disabled={settings.showCardsAsDoubleSided === true}
                       onChange={(val) => {
                         setForcePrintSide(val);
                         updateSettings({
@@ -321,6 +322,7 @@ export const Print = () => {
                   <Form.Item label={"Print Side"} tooltip="Set the print side if the datacard does not have one saved">
                     <Select
                       defaultValue={print_side}
+                      disabled={settings.showCardsAsDoubleSided === true}
                       onChange={(val) => {
                         setPrintSide(val);
                         updateSettings({

--- a/src/Pages/Shared.jsx
+++ b/src/Pages/Shared.jsx
@@ -164,25 +164,27 @@ export const Shared = () => {
                     <Col>
                       {card?.source === "40k-10e" && (
                         <>
-                          <Button
-                            type={"primary"}
-                            onClick={() => {
-                              if (card.print_side === "back") {
-                                setSharedStorage((prev) => {
-                                  const oldCards = clone(prev.category.cards);
-                                  oldCards[index].print_side = "front";
-                                  return { ...prev, category: { ...prev.category, cards: oldCards } };
-                                });
-                              } else {
-                                setSharedStorage((prev) => {
-                                  const oldCards = clone(prev.category.cards);
-                                  oldCards[index].print_side = "back";
-                                  return { ...prev, category: { ...prev.category, cards: oldCards } };
-                                });
-                              }
-                            }}>
-                            {card?.variant !== "full" && <>{card.print_side === "back" ? "Show front" : "Show back"}</>}
-                          </Button>
+                          {card?.variant !== "full" && (
+                            <Button
+                              type={"primary"}
+                              onClick={() => {
+                                if (card.print_side === "back") {
+                                  setSharedStorage((prev) => {
+                                    const oldCards = clone(prev.category.cards);
+                                    oldCards[index].print_side = "front";
+                                    return { ...prev, category: { ...prev.category, cards: oldCards } };
+                                  });
+                                } else {
+                                  setSharedStorage((prev) => {
+                                    const oldCards = clone(prev.category.cards);
+                                    oldCards[index].print_side = "back";
+                                    return { ...prev, category: { ...prev.category, cards: oldCards } };
+                                  });
+                                }
+                              }}>
+                              {card.print_side === "back" ? "Show front" : "Show back"}
+                            </Button>
+                          )}
                         </>
                       )}
                     </Col>

--- a/src/Pages/Shared.jsx
+++ b/src/Pages/Shared.jsx
@@ -181,7 +181,7 @@ export const Shared = () => {
                                 });
                               }
                             }}>
-                            {card.print_side === "back" ? "Show front" : "Show back"}
+                            {card?.variant !== "full" && <>{card.print_side === "back" ? "Show front" : "Show back"}</>}
                           </Button>
                         </>
                       )}

--- a/src/Pages/Viewer.jsx
+++ b/src/Pages/Viewer.jsx
@@ -290,7 +290,9 @@ export const Viewer = () => {
                               return "front";
                             });
                           }}>
-                          {side === "back" ? "Show front" : "Show back"}
+                          {settings.showCardsAsDoubleSided === false && activeCard?.variant !== "full" && (
+                            <>{side === "back" ? "Show front" : "Show back"}</>
+                          )}
                         </Button>
                       </Space>
                     )}

--- a/src/Pages/Viewer.jsx
+++ b/src/Pages/Viewer.jsx
@@ -23,6 +23,7 @@ import { Discord } from "../Icons/Discord";
 
 import logo from "../Images/logo.png";
 import "../style.less";
+import "../mobile.less";
 
 const { Header, Content } = Layout;
 const { Option } = Select;

--- a/src/Pages/Viewer.jsx
+++ b/src/Pages/Viewer.jsx
@@ -280,20 +280,20 @@ export const Viewer = () => {
                             }}
                           />
                         </Space.Compact>
-                        <Button
-                          type={"primary"}
-                          onClick={() => {
-                            setSide((current) => {
-                              if (current === "front") {
-                                return "back";
-                              }
-                              return "front";
-                            });
-                          }}>
-                          {settings.showCardsAsDoubleSided === false && activeCard?.variant !== "full" && (
-                            <>{side === "back" ? "Show front" : "Show back"}</>
-                          )}
-                        </Button>
+                        {settings.showCardsAsDoubleSided !== true && activeCard?.variant !== "full" && (
+                          <Button
+                            type={"primary"}
+                            onClick={() => {
+                              setSide((current) => {
+                                if (current === "front") {
+                                  return "back";
+                                }
+                                return "front";
+                              });
+                            }}>
+                            {side === "back" ? "Show front" : "Show back"}
+                          </Button>
+                        )}
                       </Space>
                     )}
                   </Col>

--- a/src/mobile.less
+++ b/src/mobile.less
@@ -1,0 +1,58 @@
+html {
+  font-size: 17px !important;
+  .ant-list-item,
+  .ant-select,
+  .ant-select-item-option-content,
+  .ant-collapse,
+  .ant-drawer-title {
+    font-size: 1rem;
+  }
+  .weapon {
+    .line {
+      .value {
+        text-overflow: ellipsis ellipsis;
+
+        font-size: 1rem !important;
+      }
+    }
+  }
+  .special {
+    .description {
+      padding-left: 4px !important;
+      font-size: 0.9rem !important;
+    }
+    .ability {
+      padding-left: 8px !important;
+      .description {
+        padding-left: 4px !important;
+        font-size: 0.9rem !important;
+      }
+    }
+  }
+  .damaged {
+    .description {
+      font-size: 0.9rem !important;
+    }
+  }
+  .keywords {
+    .value {
+      font-size: 0.8rem !important;
+    }
+  }
+  .factions {
+    .value {
+      font-size: 0.8rem !important;
+    }
+  }
+  .ability {
+    .description,
+    .value,
+    .name {
+      font-size: 0.9rem !important;
+    }
+    .title {
+      padding-right: 4px;
+      font-size: 0.9rem !important;
+    }
+  }
+}

--- a/src/mobile.less
+++ b/src/mobile.less
@@ -1,58 +1,61 @@
-html {
-  font-size: 17px !important;
-  .ant-list-item,
-  .ant-select,
-  .ant-select-item-option-content,
-  .ant-collapse,
-  .ant-drawer-title {
-    font-size: 1rem;
-  }
-  .weapon {
-    .line {
-      .value {
-        text-overflow: ellipsis ellipsis;
+// html {
+//   // font-size: 17px !important;
 
-        font-size: 1rem !important;
-      }
-    }
-  }
-  .special {
-    .description {
-      padding-left: 4px !important;
-      font-size: 0.9rem !important;
-    }
-    .ability {
-      padding-left: 8px !important;
-      .description {
-        padding-left: 4px !important;
-        font-size: 0.9rem !important;
-      }
-    }
-  }
-  .damaged {
-    .description {
-      font-size: 0.9rem !important;
-    }
-  }
-  .keywords {
-    .value {
-      font-size: 0.8rem !important;
-    }
-  }
-  .factions {
-    .value {
-      font-size: 0.8rem !important;
-    }
-  }
-  .ability {
-    .description,
-    .value,
-    .name {
-      font-size: 0.9rem !important;
-    }
-    .title {
-      padding-right: 4px;
-      font-size: 0.9rem !important;
-    }
-  }
-}
+//   .viewer {
+//     .ant-list-item,
+//     .ant-select,
+//     .ant-select-item-option-content,
+//     .ant-collapse,
+//     .ant-drawer-title {
+//       font-size: 1rem;
+//     }
+//     .weapon {
+//       .line {
+//         .value {
+//           text-overflow: ellipsis ellipsis;
+
+//           font-size: 1rem !important;
+//         }
+//       }
+//     }
+//     .special {
+//       .description {
+//         padding-left: 4px !important;
+//         font-size: 0.9rem !important;
+//       }
+//       .ability {
+//         padding-left: 8px !important;
+//         .description {
+//           padding-left: 4px !important;
+//           font-size: 0.9rem !important;
+//         }
+//       }
+//     }
+//     .damaged {
+//       .description {
+//         font-size: 0.9rem !important;
+//       }
+//     }
+//     .keywords {
+//       .value {
+//         font-size: 0.8rem !important;
+//       }
+//     }
+//     .factions {
+//       .value {
+//         font-size: 0.8rem !important;
+//       }
+//     }
+//     .ability {
+//       .description,
+//       .value,
+//       .name {
+//         font-size: 0.9rem !important;
+//       }
+//       .title {
+//         padding-right: 4px;
+//         font-size: 0.9rem !important;
+//       }
+//     }
+//   }
+// }

--- a/src/styles/40k-10e.less
+++ b/src/styles/40k-10e.less
@@ -899,7 +899,7 @@
       .invul_container {
         z-index: 2;
         position: relative;
-        padding-left: 121px;
+        padding-left: 120px;
         display: flex;
         flex-direction: column;
 
@@ -918,7 +918,7 @@
 
           display: flex;
           flex-direction: row;
-          justify-content: space-between;
+          justify-content: start;
           align-items: center;
 
           &::before {

--- a/src/styles/40k-10e.less
+++ b/src/styles/40k-10e.less
@@ -267,7 +267,8 @@
         }
         .text {
           color: black;
-          font-size: 14px;
+          font-size: 0.9rem;
+          line-height: 0.9rem;
         }
       }
     }
@@ -307,6 +308,7 @@
   html {
     font-size: 15px;
   }
+
   .welcome-background {
     border-radius: 4px;
     width: 100%;
@@ -1259,8 +1261,18 @@
 
               .content {
                 grid-template-rows: auto !important;
-                grid-template-columns: 1fr 1fr !important;
+                grid-template-columns: 1fr !important;
                 grid-auto-flow: row !important;
+
+                ul {
+                  list-style: none;
+                  padding: 0;
+                  li::before {
+                    content: "◦"; /* Insert content that looks like bullets */
+                    padding-right: 8px;
+                    list-style-position: inside;
+                  }
+                }
               }
             }
             .extra {
@@ -1518,6 +1530,7 @@
           position: relative;
           display: flex;
           flex-direction: column;
+
           gap: 16px;
 
           .wargear {
@@ -2127,6 +2140,7 @@
       flex-direction: column;
       align-items: center;
       position: relative;
+      font-size: 1rem;
 
       .header {
         width: 100%;
@@ -2432,7 +2446,7 @@
           .extra {
             grid-area: extra;
             padding-bottom: 16px !important;
-            
+
             div:last-child {
               padding-bottom: 0px;
             }

--- a/src/styles/40k-10e.less
+++ b/src/styles/40k-10e.less
@@ -1258,7 +1258,9 @@
               border-right: none;
 
               .content {
-                grid-template-rows: 1fr;
+                grid-template-rows: auto !important;
+                grid-template-columns: 1fr 1fr !important;
+                grid-auto-flow: row !important;
               }
             }
             .extra {

--- a/src/styles/40k-10e.less
+++ b/src/styles/40k-10e.less
@@ -897,7 +897,7 @@
       .invul_container {
         z-index: 2;
         position: relative;
-        padding-left: 120px;
+        padding-left: 121px;
         display: flex;
         flex-direction: column;
 
@@ -936,7 +936,10 @@
             letter-spacing: 0.1rem;
             z-index: 2;
 
+            white-space: nowrap;
+
             padding-left: 8px;
+            padding-right: 8px;
           }
 
           .value_container {
@@ -1195,7 +1198,102 @@
         }
       }
     }
+    &.full {
+      height: auto;
+      min-height: calc(714px);
+      margin-bottom: 64px;
+      .footer {
+        position: initial;
+        margin-top: -32px;
+        z-index: 200;
+      }
+      .faction {
+        z-index: 201;
+        position: initial;
+        margin-top: -64px;
+        margin-left: 339px;
+      }
+      .extra {
+        height: initial !important;
+        border-bottom: 2px solid var(--header-colour);
+        & > div:last-child {
+          padding-bottom: 32px;
+        }
+      }
+      .data_container {
+        height: auto;
+        min-height: 468px;
 
+        .data {
+          height: auto;
+          min-height: 468px;
+
+          display: grid;
+          grid-template-areas:
+            " weapons extra "
+            " multi-data extra";
+
+          .weapons {
+            grid-area: weapons;
+            height: auto;
+          }
+
+          .multi-data {
+            grid-area: multi-data;
+          }
+          .extra {
+            grid-area: extra;
+          }
+
+          .multi-data {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            border-right: 2px solid var(--header-colour);
+            padding-bottom: 48px;
+
+            .wargear_container {
+              padding: 0px;
+              height: auto;
+              border-right: none;
+
+              .content {
+                grid-template-rows: 1fr;
+              }
+            }
+            .extra {
+              padding: 0px;
+              height: auto;
+              border-right: none;
+              border-bottom: none;
+              .heading:nth-of-type(1) {
+                margin-top: 0px;
+              }
+              .heading {
+                margin-top: 16px;
+              }
+              .ledBy {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+                grid-template-rows: 1fr;
+                grid-column-gap: 0px;
+                grid-row-gap: 0px;
+
+                .description {
+                  grid-column: span 2;
+                }
+              }
+              .composition_container > div {
+                padding-left: 16px;
+                .description {
+                  padding-left: 0px;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
     .data_container {
       position: relative;
       height: 468px;
@@ -1218,7 +1316,7 @@
 
         display: grid;
         grid-template-columns: 2fr 1fr;
-        grid-template-rows: 1fr;
+        grid-template-rows: auto auto;
         grid-column-gap: 0px;
         grid-row-gap: 0px;
 
@@ -1230,6 +1328,7 @@
           display: flex;
           flex-direction: column;
           gap: 16px;
+          padding-bottom: 16px;
 
           .ranged {
             position: relative;
@@ -2134,6 +2233,13 @@
           grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
           grid-gap: 2px;
 
+          .invul_container {
+            padding-left: 0px;
+            grid-column-start: column-3;
+            grid-column-end: column-5;
+            margin-left: -4px;
+          }
+
           grid-template-areas:
             "column-7 column-7 column-7 column-7 column-7 column-7"
             "column-1 column-2 column-3 column-4 column-5 column-6";
@@ -2303,10 +2409,32 @@
           clip-path: initial;
 
           display: grid;
-          grid-template-columns: 1fr;
           grid-template-rows: 1fr;
+          grid-template-columns: 1fr;
           grid-column-gap: 0px;
           grid-row-gap: 0px;
+
+          display: grid;
+          grid-template-areas:
+            " weapons "
+            " extra "
+            " multi-data ";
+
+          .weapons {
+            grid-area: weapons;
+          }
+          .multi-data {
+            grid-area: multi-data;
+            border-right: none;
+          }
+          .extra {
+            grid-area: extra;
+            padding-bottom: 16px !important;
+            
+            div:last-child {
+              padding-bottom: 0px;
+            }
+          }
 
           .weapons {
             height: auto;


### PR DESCRIPTION
### Features
## Full sized cards display
Finally! The technology has arrived to display Warhammer 10e cards in a single full sized card side. This is a feature that has been requested for a long time and is finally here. You can toggle the feature per card (as a Variant) or globally in the settings.
The settings option can be found next to the faction selection dropdown on desktop and in the settings menu on mobile. Please note this overrides any options regarding the back & front options of a card.
## Complete and thorough cleanup of datasources
We have set all our servitors to work and managed to automate the error checking and cleanup of our datasources. This means we are now able to provide a more consistent and reliable experience with your datacards!
During this setup we also changed all cards to default to the invulnerable save at the top of the card. Your old cards are unfortunately not updated to this new standard and need a manual update or create a new duplicate card.
### Known issues
## Printing full sized cards
Unfortunately the full sized cards currently do not play nice with other cards while printing. This means when you try to print multiple cards on a page they might take up more space then you wish. You can still print them, but min/maxing the page might be tricky. We are working on a fix and will keep you updated.