### PR TITLE
Version 2.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-datacards",
-  "version": "2.9.3",
+  "version": "2.10.0",
   "description": "The only tool you will ever need for your custom datacards",
   "private": false,
   "homepage": "https://game-datacards.eu",
@@ -52,6 +52,7 @@
     "remark-gfm": "^3.0.1",
     "remark-stringify": "^10.0.2",
     "string-width": "^5.1.2",
+    "styled-components": "^6.1.18",
     "timers-browserify": "^2.0.12",
     "uuid": "^8.3.2",
     "web-vitals": "^2.1.4",

--- a/src/Components/TreeCategory.jsx
+++ b/src/Components/TreeCategory.jsx
@@ -14,8 +14,16 @@ import { List } from "../Icons/List";
 const { confirm } = Modal;
 
 export function TreeCategory({ category, selectedTreeIndex, setSelectedTreeIndex, children }) {
-  const { cardStorage, setActiveCard, setActiveCategory, removeCategory, renameCategory, cardUpdated, updateCategory } =
-    useCardStorage();
+  const {
+    cardStorage,
+    setActiveCard,
+    setActiveCategory,
+    removeCategory,
+    saveActiveCard,
+    renameCategory,
+    cardUpdated,
+    updateCategory,
+  } = useCardStorage();
 
   const inputRef = useRef(null);
 
@@ -118,12 +126,12 @@ export function TreeCategory({ category, selectedTreeIndex, setSelectedTreeIndex
                   if (cardUpdated) {
                     confirm({
                       title: "You have unsaved changes",
-                      content: "Are you sure you want to discard your changes?",
+                      content: "Do you want to save before switching?",
                       icon: <ExclamationCircleOutlined />,
-                      okText: "Yes",
-                      okType: "danger",
-                      cancelText: "No",
+                      okText: "Save",
+                      cancelText: "Cancel",
                       onOk: () => {
+                        saveActiveCard();
                         onSelect();
                       },
                     });

--- a/src/Components/TreeItem.jsx
+++ b/src/Components/TreeItem.jsx
@@ -35,6 +35,7 @@ export function TreeItem({ card, category, selectedTreeIndex, setSelectedTreeInd
     removeCardFromCategory,
     addCardToCategory,
     saveCard,
+    saveActiveCard,
   } = useCardStorage();
   const cardIndex = `card-${card.uuid}`;
   const { dataSource } = useDataSourceStorage();
@@ -178,12 +179,12 @@ export function TreeItem({ card, category, selectedTreeIndex, setSelectedTreeInd
                   if (cardUpdated) {
                     confirm({
                       title: "You have unsaved changes",
-                      content: "Are you sure you want to discard your changes?",
+                      content: "Do you want to save before switching?",
                       icon: <ExclamationCircleOutlined />,
-                      okText: "Yes",
-                      okType: "danger",
-                      cancelText: "No",
+                      okText: "Save",
+                      cancelText: "Cancel",
                       onOk: () => {
+                        saveActiveCard();
                         onSelect();
                       },
                     });

--- a/src/Components/Warhammer40k-10e/FactionSelect.jsx
+++ b/src/Components/Warhammer40k-10e/FactionSelect.jsx
@@ -10,6 +10,7 @@ export const FactionSelect = ({ value, onChange }) => {
       <Option value="basic">Basic</Option>
       <Option value="AC">Adeptus Custodes</Option>
       <Option value="AE">Aeldari</Option>
+      <Option value="AoI">Agents of the Imperium</Option>
       <Option value="LGAL">Alpha Legion</Option>
       <Option value="AM">Astra Militarum</Option>
       <Option value="AS">Adepta Sororitas</Option>

--- a/src/Components/Warhammer40k-10e/StratagemCard.jsx
+++ b/src/Components/Warhammer40k-10e/StratagemCard.jsx
@@ -38,11 +38,11 @@ export const StratagemCard = ({
             </ReactFitty>
           </div>
           <div className="type">
-            <ReactFitty maxSize={10} minSize={8}>
+            <ReactFitty maxSize={10} minSize={2}>
               {stratagem.detachment} - {stratagem.type}
             </ReactFitty>
           </div>
-          <div className="content">
+          <div className="content" style={{ fontSize: stratagem?.textSize ?? "16px" }}>
             {stratagem.when && (
               <div className="section">
                 <span className="title">When:</span>

--- a/src/Components/Warhammer40k-10e/StratagemEditor.jsx
+++ b/src/Components/Warhammer40k-10e/StratagemEditor.jsx
@@ -1,6 +1,7 @@
 import { Collapse } from "antd";
 import { StratagemBasicInfo } from "./StratagemEditor/StratagemBasicInfo";
 import { StratagemCardInfo } from "./StratagemEditor/StratagemCardInfo";
+import { StratagemStylingInfo } from "./StratagemEditor/StratagemStylingInfo";
 
 const { Panel } = Collapse;
 
@@ -10,7 +11,10 @@ export const StratagemEditor = () => {
       <Panel header="Basic information" style={{ width: "100%" }} key="1">
         <StratagemBasicInfo />
       </Panel>
-      <Panel header="Detailed information" style={{ width: "100%" }} key="2">
+      <Panel header="Styling" style={{ width: "100%" }} key="2">
+        <StratagemStylingInfo />
+      </Panel>
+      <Panel header="Detailed information" style={{ width: "100%" }} key="3">
         <StratagemCardInfo />
       </Panel>
     </Collapse>

--- a/src/Components/Warhammer40k-10e/StratagemEditor/StratagemBasicInfo.jsx
+++ b/src/Components/Warhammer40k-10e/StratagemEditor/StratagemBasicInfo.jsx
@@ -1,4 +1,4 @@
-import { Form, Input, Select } from "antd";
+import { Form, Input, Select, Slider } from "antd";
 import React from "react";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
 import { FactionSelect } from "../FactionSelect";
@@ -7,7 +7,7 @@ const { Option } = Select;
 
 export function StratagemBasicInfo() {
   const { activeCard, updateActiveCard } = useCardStorage();
-
+  console.log(activeCard);
   return (
     <Form>
       <Form.Item label={"Name"}>
@@ -51,6 +51,42 @@ export function StratagemBasicInfo() {
           type={"text"}
           value={activeCard.cost}
           onChange={(e) => updateActiveCard({ ...activeCard, cost: e.target.value })}
+        />
+      </Form.Item>
+      <Form.Item label={"Phases"}>
+        <Select
+          mode="multiple"
+          allowClear
+          style={{ width: "100%" }}
+          placeholder="Select a phase"
+          value={[...activeCard.phase]}
+          onChange={(val) => updateActiveCard({ ...activeCard, phase: val })}
+          options={[
+            {
+              label: "Any phase",
+              value: "any",
+            },
+            {
+              label: "Charge phase",
+              value: "charge",
+            },
+            {
+              label: "Fight phase",
+              value: "fight",
+            },
+            {
+              label: "Command phase",
+              value: "command",
+            },
+            {
+              label: "Movement phase",
+              value: "movement",
+            },
+            {
+              label: "Shooting phase",
+              value: "shooting",
+            },
+          ]}
         />
       </Form.Item>
     </Form>

--- a/src/Components/Warhammer40k-10e/StratagemEditor/StratagemStylingInfo.jsx
+++ b/src/Components/Warhammer40k-10e/StratagemEditor/StratagemStylingInfo.jsx
@@ -1,0 +1,23 @@
+import { Form, Input, Select, Slider } from "antd";
+import React from "react";
+import { useCardStorage } from "../../../Hooks/useCardStorage";
+import { FactionSelect } from "../FactionSelect";
+
+const { Option } = Select;
+
+export function StratagemStylingInfo() {
+  const { activeCard, updateActiveCard } = useCardStorage();
+  console.log(activeCard);
+  return (
+    <Form>
+      <Form.Item label={"Text size"}>
+        <Slider
+          min={4}
+          max={32}
+          step={1}
+          onChange={(val) => updateActiveCard({ ...activeCard, textSize: val })}
+          value={activeCard.textSize || "16"}></Slider>
+      </Form.Item>
+    </Form>
+  );
+}

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitName.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitName.jsx
@@ -1,8 +1,24 @@
+import styled from "styled-components";
 import { UnitPoints } from "./UnitPoints";
 
-export const UnitName = ({ name, subname, points, legends, combatPatrol }) => {
+const HeaderContainer = styled.div`
+  &:before {
+    content: " ";
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 380px;
+    height: 196px;
+    background-color: black;
+    background: top right no-repeat;
+    background-size: contain;
+    background-image: url(${(props) => props.externalimage});
+  }
+`;
+
+export const UnitName = ({ name, subname, points, legends, combatPatrol, externalImage }) => {
   return (
-    <div className="header_container">
+    <HeaderContainer className="header_container" externalimage={externalImage}>
       <div className="name_container">
         <div className="name">{name}</div>
         {subname && <div className="subname">{subname}</div>}
@@ -10,6 +26,6 @@ export const UnitName = ({ name, subname, points, legends, combatPatrol }) => {
       {legends && <div className="legends" />}
       {combatPatrol && <div className="combatpatrol" />}
       <UnitPoints points={points} />
-    </div>
+    </HeaderContainer>
   );
 };

--- a/src/Components/Warhammer40k-10e/UnitCardEditor.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCardEditor.jsx
@@ -10,6 +10,7 @@ import { UnitPoints } from "./UnitCardEditor/UnitPoints";
 import { UnitPrimarchAbilities } from "./UnitCardEditor/UnitPrimarchAbilities";
 import { UnitStats } from "./UnitCardEditor/UnitStats";
 import { UnitWeapons } from "./UnitCardEditor/UnitWeapons";
+import { UnitStylingInfo } from "./UnitCardEditor/UnitStylingInfo";
 
 const { Panel } = Collapse;
 
@@ -20,6 +21,9 @@ export const UnitCardEditor = () => {
     <Collapse defaultActiveKey={["1"]}>
       <Panel header="Basic information" style={{ width: "100%" }} key="1">
         <UnitBasicInfo />
+      </Panel>
+      <Panel header="Styling" style={{ width: "100%" }} key="styling">
+        <UnitStylingInfo />
       </Panel>
       <Panel header="Datasheets" style={{ width: "100%" }} key="2">
         <UnitStats />

--- a/src/Components/Warhammer40k-10e/UnitCardEditor/UnitStylingInfo.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCardEditor/UnitStylingInfo.jsx
@@ -1,0 +1,25 @@
+import { Form, Input, Select, Switch } from "antd";
+import React from "react";
+import { useCardStorage } from "../../../Hooks/useCardStorage";
+import { FactionSelect } from "../FactionSelect";
+import { settings } from "firebase/analytics";
+import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
+
+const { Option } = Select;
+
+export function UnitStylingInfo() {
+  const { activeCard, updateActiveCard } = useCardStorage();
+  const { settings, updateSettings } = useSettingsStorage();
+
+  return (
+    <Form>
+      <Form.Item label={"External Image"}>
+        <Input
+          type={"text"}
+          value={activeCard.externalImage}
+          onChange={(e) => updateActiveCard({ ...activeCard, externalImage: e.target.value })}
+        />
+      </Form.Item>
+    </Form>
+  );
+}

--- a/src/Components/Warhammer40k-10e/UnitCardFront.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCardFront.jsx
@@ -24,6 +24,7 @@ export const UnitCardFront = ({ unit, cardStyle, paddingTop = "32px", className 
             points={unit.points}
             legends={unit.legends}
             combatPatrol={unit.combatPatrol}
+            externalImage={unit.externalImage}
           />
           <UnitStats stats={unit.stats} />
           <div className="stats_container" key={`stat-line-invul`}>

--- a/src/Components/Warhammer40k-10e/UnitCardFull.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCardFull.jsx
@@ -26,6 +26,7 @@ export const UnitCardFull = ({ unit, cardStyle, paddingTop = "32px", className }
             points={unit.points}
             legends={unit.legends}
             combatPatrol={unit.combatPatrol}
+            externalImage={unit.externalImage}
           />
           <UnitStats stats={unit.stats} />
           <div className="stats_container" key={`stat-line-invul`}>

--- a/src/Components/Warhammer40k/FactionSelect.jsx
+++ b/src/Components/Warhammer40k/FactionSelect.jsx
@@ -9,6 +9,7 @@ export const FactionSelect = ({ value, onChange }) => {
       <Option value="NONE">None</Option>
       <Option value="basic">Basic</Option>
       <Option value="AC">Adeptus Custodes</Option>
+      <Option value="AoI">Agents of the Imperium</Option>
       <Option value="AE">Asuryani</Option>
       <Option value="LGAL">Alpha Legion</Option>
       <Option value="AM">Astra Militarum</Option>

--- a/src/Components/WhatsNew.jsx
+++ b/src/Components/WhatsNew.jsx
@@ -45,7 +45,7 @@ export const WhatsNew = () => {
                   fontSize: "32px",
                   color: "white",
                 }}>
-                Whats new in 2.9.3
+                Whats new in 2.10.0
               </h1>
             </div>
             <div className="welcome-cover">
@@ -56,32 +56,39 @@ export const WhatsNew = () => {
                     <Typography.Paragraph style={{ fontSize: "16px" }}>
                       <ul>
                         <li>
-                          <strong>html-data tags for external CSS</strong>
+                          <strong>Added external image option for 10e Unit Cards</strong>
                           <br />
-                          Thanks to ambre-m we have now added html-data tags to the Datacards that allow you to use
-                          custom CSS and finetune cards to your liking. Join us on Discord if you want an example or
-                          help!
+                          Based on our previous update, we added the option to add an external image to your 10e cards.
+                          This image has to be hosted on an external website and have a direct link to the image. You
+                          can add this image in the card editor.
+                        </li>
+                        <li>
+                          <strong>Text Size option for 10e Stratagem Cards</strong>
+                          <br />
+                          You can now manually set the text size for your stratagem cards. This is useful if you want to
+                          make sure the text fits on the card.
                         </li>
                       </ul>
                     </Typography.Paragraph>
-                    <Typography.Title level={4}>Updated</Typography.Title>
+                    <Typography.Title level={4}>Fixes</Typography.Title>
                     <Typography.Paragraph style={{ fontSize: "16px" }}>
                       <ul>
                         <li>
-                          <strong>Latest Coded support</strong>
+                          <strong>Unsaved changes popup</strong>
                           <br />
-                          We have updated to the latest Pointy-eared Codex!
+                          We have changed the logic when the unsaved changes popup is shown. It will now give you the
+                          option to immediately save your changes and continue or cancel the action.
                         </li>
-                      </ul>
-                    </Typography.Paragraph>
-                    <Typography.Title level={4}>Fixed</Typography.Title>
-                    <Typography.Paragraph style={{ fontSize: "16px" }}>
-                      <ul>
                         <li>
-                          <strong>Double Sided cards on Mobile</strong>
+                          <strong>10e Stratagem Card type</strong>
                           <br />
-                          Somehow we missed that new users would not get the button to swap between front / back of
-                          mobile cards. That has now been fixed.
+                          The text size of a Stratagem Card&apos;s type will now auto scale based on the available
+                          space.
+                        </li>
+                        <li>
+                          <strong>Agents of the Imperium</strong>
+                          <br />
+                          Agents of the Imperium are now correctly displayed in the list of factions.
                         </li>
                       </ul>
                     </Typography.Paragraph>

--- a/src/styles/40k-10e.less
+++ b/src/styles/40k-10e.less
@@ -199,7 +199,7 @@
         position: absolute;
         top: 35.9px;
         left: 52.91px;
-        width: 188.97;
+        width: 188.97px;
         font-size: 0.8rem;
         text-transform: uppercase;
         font-weight: 600;
@@ -210,7 +210,7 @@
         top: 56.69px;
         left: 52.91px;
         width: 188.97px;
-        height: auto;
+        height: 300px;
         padding-left: 4px;
         .section {
           padding-top: 4px;
@@ -627,7 +627,7 @@
           position: absolute;
           top: 35.9px;
           left: 52.91px;
-          width: 188.97;
+          width: 188.97px;
           font-size: 0.8rem;
           text-transform: uppercase;
           font-weight: 600;
@@ -638,21 +638,22 @@
           top: 56.69px;
           left: 52.91px;
           width: 188.97px;
-          height: auto;
+          height: 380px;
           padding-left: 4px;
           .section {
             padding-top: 4px;
             line-height: 1rem;
+            width: 188.97px;
             .title {
               text-transform: uppercase;
               color: var(--stratagem-colour);
-              font-size: 0.7rem;
+              font-size: 0.7em;
               font-weight: 600;
               padding-right: 4px;
             }
             .text {
               color: black;
-              font-size: 0.7rem;
+              font-size: 0.7em;
               font-weight: 400;
             }
           }
@@ -1023,6 +1024,8 @@
         justify-content: space-between;
         padding-top: 32px;
         padding-left: 32px;
+
+
         @media only screen and (max-width: 600px) {
           .legends {
             position: absolute;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,6 +1253,23 @@
   resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.6.0.tgz#53fa5fe9c34faee89469e48f91d51a3766108bc8"
   integrity sha512-/Z3l6pXthq0JvMYdUFyX9j0MaCltlIn6mfh9jLyQwg5aPKxkyNa0PTHtU1AlFXLNk55ZuAeJRcpvq+tmLfKmaQ==
 
+"@emotion/is-prop-valid@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz#d4175076679c6a26faa92b03bb786f9e52612337"
+  integrity sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==
+  dependencies:
+    "@emotion/memoize" "^0.8.1"
+
+"@emotion/memoize@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
+  integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
+
+"@emotion/unitless@0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.1.tgz#182b5a4704ef8ad91bde93f7a860a88fd92c79a3"
+  integrity sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -2751,6 +2768,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/stylis@4.2.5":
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/@types/stylis/-/stylis-4.2.5.tgz#1daa6456f40959d06157698a653a9ab0a70281df"
+  integrity sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==
+
 "@types/testing-library__jest-dom@^5.9.1":
   version "5.14.5"
   resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz#d113709c90b3c75fdb127ec338dad7d5f86c974f"
@@ -3937,6 +3959,11 @@ camelcase@^6.2.0, camelcase@^6.2.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
+camelize@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
+  integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
+
 caniuse-api@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-3.0.0.tgz#5e4d90e2274961d46291997df599e3ed008ee4c0"
@@ -4448,6 +4475,11 @@ css-box-model@^1.2.0:
   dependencies:
     tiny-invariant "^1.0.6"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
+
 css-declaration-sorter@^6.3.1:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz#630618adc21724484b3e9505bce812def44000ad"
@@ -4521,6 +4553,15 @@ css-selector-parser@^1.0.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/css-selector-parser/-/css-selector-parser-1.4.1.tgz#03f9cb8a81c3e5ab2c51684557d5aaf6d2569759"
   integrity sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==
+
+css-to-react-native@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.2.0.tgz#cdd8099f71024e149e4f6fe17a7d46ecd55f1e32"
+  integrity sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^4.0.2"
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -4635,6 +4676,11 @@ cssstyle@^2.3.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
+
+csstype@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
+  integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
 csstype@^3.0.2:
   version "3.1.2"
@@ -8717,6 +8763,11 @@ nanoid@^3.3.6:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
+nanoid@^3.3.7:
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+
 natural-compare-lite@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
@@ -9223,6 +9274,11 @@ picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
@@ -9807,10 +9863,19 @@ postcss-unique-selectors@^5.1.1:
   dependencies:
     postcss-selector-parser "^6.0.5"
 
-postcss-value-parser@^4.0.0, postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
+postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
+
+postcss@8.4.49:
+  version "8.4.49"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.49.tgz#4ea479048ab059ab3ae61d082190fabfd994fe19"
+  integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
+  dependencies:
+    nanoid "^3.3.7"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 postcss@^7.0.35:
   version "7.0.39"
@@ -11400,7 +11465,7 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shallowequal@^1.1.0:
+shallowequal@1.1.0, shallowequal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
@@ -11487,6 +11552,11 @@ source-map-js@^1.0.1, source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
 source-map-loader@^3.0.0:
   version "3.0.2"
@@ -11798,6 +11868,21 @@ style-to-object@^0.4.0:
   dependencies:
     inline-style-parser "0.1.1"
 
+styled-components@^6.1.18:
+  version "6.1.18"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-6.1.18.tgz#9647497a92326ba9d758051c914f15004d524bb9"
+  integrity sha512-Mvf3gJFzZCkhjY2Y/Fx9z1m3dxbza0uI9H1CbNZm/jSHCojzJhQ0R7bByrlFJINnMzz/gPulpoFFGymNwrsMcw==
+  dependencies:
+    "@emotion/is-prop-valid" "1.2.2"
+    "@emotion/unitless" "0.8.1"
+    "@types/stylis" "4.2.5"
+    css-to-react-native "3.2.0"
+    csstype "3.1.3"
+    postcss "8.4.49"
+    shallowequal "1.1.0"
+    stylis "4.3.2"
+    tslib "2.6.2"
+
 stylehacks@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-5.1.1.tgz#7934a34eb59d7152149fa69d6e9e56f2fc34bcc9"
@@ -11805,6 +11890,11 @@ stylehacks@^5.1.1:
   dependencies:
     browserslist "^4.21.4"
     postcss-selector-parser "^6.0.4"
+
+stylis@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.2.tgz#8f76b70777dd53eb669c6f58c997bf0a9972e444"
+  integrity sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==
 
 sucrase@^3.32.0:
   version "3.32.0"
@@ -12149,6 +12239,11 @@ tsconfig-paths@^3.14.1:
     json5 "^1.0.2"
     minimist "^1.2.6"
     strip-bom "^3.0.0"
+
+tslib@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
## Added
### Added external image option for 10e Unit Cards
Based on our previous update, we added the option to add an external image to your 10e cards. This image has to be hosted on an external website and have a direct link to the image. You can add this image in the card editor.
### Text Size option for 10e Stratagem Cards
You can now manually set the text size for your stratagem cards. This is useful if you want to make sure the text fits on the card.

## Fixes
### Unsaved changes popup
We have changed the logic when the unsaved changes popup is shown. It will now give you the option to immediately save your changes and continue or cancel the action.
### 10e Stratagem Card type
The text size of a Stratagem Card's type will now auto scale based on the available space.
### Agents of the Imperium
Agents of the Imperium are now correctly displayed in the list of factions.