### PR TITLE
Fix faction keywords + ability description display in custom datasour…

### DIFF
--- a/docs/custom datasource/datasource-schema-architecture.md
+++ b/docs/custom datasource/datasource-schema-architecture.md
@@ -280,7 +280,9 @@ Sections are optional content blocks rendered below weapons on unit cards. Each 
 | Property           | Type   | Description                                                              |
 |--------------------|--------|--------------------------------------------------------------------------|
 | `hasKeywords`      | boolean | Include a keywords bar at the bottom of the card.                       |
+| `keywordsLabel`    | string  | Optional. Override the keywords bar label (defaults to `"Keywords"`).  |
 | `hasFactionKeywords` | boolean | Include a faction keywords bar at the bottom of the card.            |
+| `factionKeywordsLabel` | string | Optional. Override the faction keywords bar label (defaults to `"Faction"`). |
 | `hasPoints`        | boolean | Include a points cost field on the card.                                |
 | `pointsFormat`     | string  | `"per-model"` or `"per-unit"`. Only applies when `hasPoints` is true.  |
 | `bannerType`       | string  | Controls the header banner text. Only applies when `baseSystem` is not `"40k-10e"`. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-datacards",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "The only tool you will ever need for your custom datacards",
   "private": false,
   "homepage": "https://game-datacards.eu",

--- a/src/Components/Custom/CustomUnitCard.jsx
+++ b/src/Components/Custom/CustomUnitCard.jsx
@@ -88,14 +88,14 @@ export const CustomUnitCard = ({ unit, cardTypeDef, cardStyle, isMobile }) => {
         <div className="footer">
           {schema.metadata?.hasKeywords && unit.keywords?.length > 0 && (
             <div className="keywords">
-              <span className="title">keywords</span>
+              <span className="title">{schema.metadata?.keywordsLabel || "keywords"}</span>
               <span className="value">{unit.keywords.join(", ")}</span>
             </div>
           )}
-          {schema.metadata?.hasFactionKeywords && unit.factions?.length > 0 && (
+          {schema.metadata?.hasFactionKeywords && (unit.factionKeywords || unit.factions)?.length > 0 && (
             <div className="factions">
-              <span className="title">faction keywords</span>
-              <span className="value">{unit.factions.join(", ")}</span>
+              <span className="title">{schema.metadata?.factionKeywordsLabel || "faction"}</span>
+              <span className="value">{(unit.factionKeywords || unit.factions).join(", ")}</span>
             </div>
           )}
         </div>

--- a/src/Components/Custom/__tests__/CustomUnitCard.test.jsx
+++ b/src/Components/Custom/__tests__/CustomUnitCard.test.jsx
@@ -171,10 +171,32 @@ describe("CustomUnitCard", () => {
     expect(screen.getByText("INFANTRY, IMPERIUM")).toBeInTheDocument();
   });
 
-  it("renders faction keywords when schema has hasFactionKeywords enabled", () => {
+  it("renders faction keywords from legacy `factions` field", () => {
     render(<CustomUnitCard unit={makeUnit()} cardTypeDef={makeCardTypeDef()} cardStyle={{}} />);
-    expect(screen.getByText("faction keywords")).toBeInTheDocument();
+    expect(screen.getByText("faction")).toBeInTheDocument();
     expect(screen.getByText("Adeptus Astartes")).toBeInTheDocument();
+  });
+
+  it("renders faction keywords from custom-datasource `factionKeywords` field", () => {
+    const unit = makeUnit({ factions: undefined, factionKeywords: ["Blessed Sisters 3.5.3"] });
+    render(<CustomUnitCard unit={unit} cardTypeDef={makeCardTypeDef()} cardStyle={{}} />);
+    expect(screen.getByText("Blessed Sisters 3.5.3")).toBeInTheDocument();
+  });
+
+  it("uses configured keywords/factionKeywords labels from schema metadata", () => {
+    const cardTypeDef = makeCardTypeDef({
+      metadata: {
+        hasKeywords: true,
+        hasFactionKeywords: true,
+        hasPoints: true,
+        pointsFormat: "per-model",
+        keywordsLabel: "Tags",
+        factionKeywordsLabel: "Allegiance",
+      },
+    });
+    render(<CustomUnitCard unit={makeUnit()} cardTypeDef={cardTypeDef} cardStyle={{}} />);
+    expect(screen.getByText("Tags")).toBeInTheDocument();
+    expect(screen.getByText("Allegiance")).toBeInTheDocument();
   });
 
   it("hides keywords when schema has hasKeywords disabled", () => {
@@ -183,7 +205,7 @@ describe("CustomUnitCard", () => {
     });
     render(<CustomUnitCard unit={makeUnit()} cardTypeDef={cardTypeDef} cardStyle={{}} />);
     expect(screen.queryByText("keywords")).not.toBeInTheDocument();
-    expect(screen.queryByText("faction keywords")).not.toBeInTheDocument();
+    expect(screen.queryByText("faction")).not.toBeInTheDocument();
   });
 
   it("applies card style CSS variables", () => {

--- a/src/Components/DatasourceEditor/cards/Ds40kUnitCard.jsx
+++ b/src/Components/DatasourceEditor/cards/Ds40kUnitCard.jsx
@@ -97,8 +97,15 @@ export const Ds40kUnitCard = ({ card, cardTypeDef, cardStyle, isMobile }) => {
             </div>
           </div>
           <div className="footer">
-            {schema.metadata?.hasKeywords !== false && <UnitKeywords keywords={card.keywords} />}
-            {schema.metadata?.hasFactionKeywords !== false && <UnitFactions factions={card.factions} />}
+            {schema.metadata?.hasKeywords !== false && (
+              <UnitKeywords keywords={card.keywords} label={schema.metadata?.keywordsLabel} />
+            )}
+            {schema.metadata?.hasFactionKeywords !== false && (
+              <UnitFactions
+                factions={card.factionKeywords || card.factions}
+                label={schema.metadata?.factionKeywordsLabel}
+              />
+            )}
           </div>
           <UnitFactionSymbol unit={card} />
         </div>

--- a/src/Components/DatasourceEditor/cards/__tests__/Ds40kUnitCard.test.jsx
+++ b/src/Components/DatasourceEditor/cards/__tests__/Ds40kUnitCard.test.jsx
@@ -104,7 +104,7 @@ describe("Ds40kUnitCard", () => {
     expect(screen.getByText("keywords")).toBeTruthy();
   });
 
-  it("renders faction keywords when schema enables them", () => {
+  it("renders faction keywords from legacy `factions` field", () => {
     const card = {
       name: "Unit",
       stats: [],
@@ -112,8 +112,44 @@ describe("Ds40kUnitCard", () => {
       factions: ["Adeptus Astartes"],
     };
     render(<Ds40kUnitCard card={card} cardTypeDef={cardTypeDef} cardStyle={{}} />);
-    expect(screen.getByText("faction keywords")).toBeTruthy();
+    expect(screen.getByText("faction")).toBeTruthy();
     expect(screen.getByText("Adeptus Astartes")).toBeTruthy();
+  });
+
+  it("renders faction keywords from custom-datasource `factionKeywords` field", () => {
+    const card = {
+      name: "Unit",
+      stats: [],
+      abilities: [],
+      factionKeywords: ["Blessed Sisters 3.5.3"],
+    };
+    render(<Ds40kUnitCard card={card} cardTypeDef={cardTypeDef} cardStyle={{}} />);
+    expect(screen.getByText("Blessed Sisters 3.5.3")).toBeTruthy();
+  });
+
+  it("uses configured keywords/factionKeywords labels from schema metadata", () => {
+    const customSchema = {
+      ...cardTypeDef,
+      schema: {
+        ...cardTypeDef.schema,
+        metadata: {
+          hasKeywords: true,
+          hasFactionKeywords: true,
+          keywordsLabel: "Tags",
+          factionKeywordsLabel: "Allegiance",
+        },
+      },
+    };
+    const card = {
+      name: "Unit",
+      stats: [],
+      abilities: [],
+      keywords: ["Infantry"],
+      factionKeywords: ["Imperium"],
+    };
+    render(<Ds40kUnitCard card={card} cardTypeDef={customSchema} cardStyle={{}} />);
+    expect(screen.getByText("Tags")).toBeTruthy();
+    expect(screen.getByText("Allegiance")).toBeTruthy();
   });
 
   it("has data-testid for testing", () => {

--- a/src/Components/DatasourceEditor/components/CompactInput.jsx
+++ b/src/Components/DatasourceEditor/components/CompactInput.jsx
@@ -20,6 +20,7 @@ export const CompactInput = ({
   max,
   step,
   style,
+  placeholder,
 }) => {
   const colorRef = useRef(null);
 
@@ -88,6 +89,7 @@ export const CompactInput = ({
         min={min}
         max={max}
         step={step}
+        placeholder={placeholder}
         className="props-compact-field"
         aria-label={ariaLabel || (typeof label === "string" ? label : undefined)}
       />

--- a/src/Components/DatasourceEditor/editors/MetadataSchemaEditor.jsx
+++ b/src/Components/DatasourceEditor/editors/MetadataSchemaEditor.jsx
@@ -37,6 +37,21 @@ export const MetadataSchemaEditor = ({ schema, onChange, baseSystem }) => {
         value={!!metadata.hasKeywords}
         onChange={(val) => updateMetadata({ hasKeywords: val })}
       />
+      {metadata.hasKeywords && (
+        <div className="props-tree-children">
+          <div className="props-tree-child">
+            <CompactInput
+              label={<IconTypography size={10} stroke={1.5} />}
+              ariaLabel="Keywords label"
+              tooltip="Label shown on the card (defaults to Keywords)"
+              type="text"
+              value={metadata.keywordsLabel || ""}
+              onChange={(val) => updateMetadata({ keywordsLabel: val || undefined })}
+              placeholder="Keywords"
+            />
+          </div>
+        </div>
+      )}
       <CompactInput
         label={<IconUsers size={10} stroke={1.5} />}
         ariaLabel="Faction keywords"
@@ -45,6 +60,21 @@ export const MetadataSchemaEditor = ({ schema, onChange, baseSystem }) => {
         value={!!metadata.hasFactionKeywords}
         onChange={(val) => updateMetadata({ hasFactionKeywords: val })}
       />
+      {metadata.hasFactionKeywords && (
+        <div className="props-tree-children">
+          <div className="props-tree-child">
+            <CompactInput
+              label={<IconTypography size={10} stroke={1.5} />}
+              ariaLabel="Faction keywords label"
+              tooltip="Label shown on the card (defaults to Faction)"
+              type="text"
+              value={metadata.factionKeywordsLabel || ""}
+              onChange={(val) => updateMetadata({ factionKeywordsLabel: val || undefined })}
+              placeholder="Faction"
+            />
+          </div>
+        </div>
+      )}
       <CompactInput
         label={<IconCoin size={10} stroke={1.5} />}
         ariaLabel="Points cost"

--- a/src/Components/DatasourceEditor/editors/__tests__/MetadataSchemaEditor.test.jsx
+++ b/src/Components/DatasourceEditor/editors/__tests__/MetadataSchemaEditor.test.jsx
@@ -152,4 +152,82 @@ describe("MetadataSchemaEditor", () => {
     expect(options[1].value).toBe("per-unit");
     expect(options[1].textContent).toBe("Per Unit");
   });
+
+  describe("custom labels", () => {
+    it("shows keywords label input when hasKeywords is true", () => {
+      render(<MetadataSchemaEditor schema={mockSchema} onChange={vi.fn()} />);
+      expect(screen.getByLabelText("Keywords label")).toBeInTheDocument();
+    });
+
+    it("hides keywords label input when hasKeywords is false", () => {
+      const schema = { metadata: { hasKeywords: false, hasFactionKeywords: false } };
+      render(<MetadataSchemaEditor schema={schema} onChange={vi.fn()} />);
+      expect(screen.queryByLabelText("Keywords label")).not.toBeInTheDocument();
+    });
+
+    it("shows faction keywords label input only when hasFactionKeywords is true", () => {
+      render(<MetadataSchemaEditor schema={mockSchema} onChange={vi.fn()} />);
+      expect(screen.getByLabelText("Faction keywords label")).toBeInTheDocument();
+    });
+
+    it("hides faction keywords label input when hasFactionKeywords is false", () => {
+      const schema = { metadata: { hasKeywords: false, hasFactionKeywords: false } };
+      render(<MetadataSchemaEditor schema={schema} onChange={vi.fn()} />);
+      expect(screen.queryByLabelText("Faction keywords label")).not.toBeInTheDocument();
+    });
+
+    it("renders keywordsLabel value when set", () => {
+      const schema = { metadata: { hasKeywords: true, hasFactionKeywords: true, keywordsLabel: "Tags" } };
+      render(<MetadataSchemaEditor schema={schema} onChange={vi.fn()} />);
+      expect(screen.getByLabelText("Keywords label").value).toBe("Tags");
+    });
+
+    it("renders factionKeywordsLabel value when set", () => {
+      const schema = {
+        metadata: { hasKeywords: true, hasFactionKeywords: true, factionKeywordsLabel: "Allegiance" },
+      };
+      render(<MetadataSchemaEditor schema={schema} onChange={vi.fn()} />);
+      expect(screen.getByLabelText("Faction keywords label").value).toBe("Allegiance");
+    });
+
+    it("uses default placeholders when no custom label is set", () => {
+      render(<MetadataSchemaEditor schema={mockSchema} onChange={vi.fn()} />);
+      expect(screen.getByLabelText("Keywords label").placeholder).toBe("Keywords");
+      expect(screen.getByLabelText("Faction keywords label").placeholder).toBe("Faction");
+    });
+
+    it("updates keywordsLabel on text change", () => {
+      const onChange = vi.fn();
+      render(<MetadataSchemaEditor schema={mockSchema} onChange={onChange} />);
+      fireEvent.change(screen.getByLabelText("Keywords label"), { target: { value: "Tags" } });
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ keywordsLabel: "Tags" }),
+        }),
+      );
+    });
+
+    it("clears keywordsLabel back to undefined when input is emptied", () => {
+      const schema = { metadata: { hasKeywords: true, hasFactionKeywords: true, keywordsLabel: "Tags" } };
+      const onChange = vi.fn();
+      render(<MetadataSchemaEditor schema={schema} onChange={onChange} />);
+      fireEvent.change(screen.getByLabelText("Keywords label"), { target: { value: "" } });
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ keywordsLabel: undefined }),
+        }),
+      );
+    });
+
+    it("updates factionKeywordsLabel on text change", () => {
+      const onChange = vi.fn();
+      render(<MetadataSchemaEditor schema={mockSchema} onChange={onChange} />);
+      fireEvent.change(screen.getByLabelText("Faction keywords label"), { target: { value: "Allegiance" } });
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ factionKeywordsLabel: "Allegiance" }),
+        }),
+      );
+    });
+  });
 });

--- a/src/Components/MobileWhatsNewWizard/versions/__tests__/v372Mobile.test.js
+++ b/src/Components/MobileWhatsNewWizard/versions/__tests__/v372Mobile.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { MOBILE_VERSION_CONFIG } from "../v3.7.2";
+
+describe("Mobile WhatsNewWizard v3.7.2 config", () => {
+  it("has version 3.7.2", () => {
+    expect(MOBILE_VERSION_CONFIG.version).toBe("3.7.2");
+  });
+
+  it("has the correct release name", () => {
+    expect(MOBILE_VERSION_CONFIG.releaseName).toBe("Custom Datasource Card Fixes");
+  });
+
+  it("has at least 1 step", () => {
+    expect(MOBILE_VERSION_CONFIG.steps.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("has unique keys for all steps", () => {
+    const keys = MOBILE_VERSION_CONFIG.steps.map((s) => s.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("has title and component on every step", () => {
+    MOBILE_VERSION_CONFIG.steps.forEach((step) => {
+      expect(step.title).toBeTruthy();
+      expect(step.component).toBeTruthy();
+    });
+  });
+
+  it("marks the last step as thankYou", () => {
+    expect(MOBILE_VERSION_CONFIG.steps[MOBILE_VERSION_CONFIG.steps.length - 1].isThankYou).toBe(true);
+  });
+});

--- a/src/Components/MobileWhatsNewWizard/versions/index.js
+++ b/src/Components/MobileWhatsNewWizard/versions/index.js
@@ -11,6 +11,7 @@ import v352Config from "./v3.5.2";
 import v360Config from "./v3.6.0";
 import v370Config from "./v3.7.0";
 import v371Config from "./v3.7.1";
+import v372Config from "./v3.7.2";
 
 /**
  * Registry of all mobile version wizard configurations
@@ -34,6 +35,7 @@ export const MOBILE_VERSION_REGISTRY = [
   v360Config,
   v370Config,
   v371Config,
+  v372Config,
 ]
   .filter((config) => config && config.version)
   .sort((a, b) => compareVersions(a.version, b.version));

--- a/src/Components/MobileWhatsNewWizard/versions/v3.7.2/StepPatchNotes.jsx
+++ b/src/Components/MobileWhatsNewWizard/versions/v3.7.2/StepPatchNotes.jsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { Wrench, Tag, Type, MessageSquareText } from "lucide-react";
+
+export const StepPatchNotes = () => (
+  <div className="mwnw-features">
+    <header className="mwnw-features-header">
+      <div className="mwnw-features-icon">
+        <Wrench size={28} />
+      </div>
+      <h2 className="mwnw-features-title">Custom Datasource Card Fixes</h2>
+      <p className="mwnw-features-subtitle">
+        Cards built with the Datasource Editor now correctly display the faction keywords and ability descriptions
+        you typed in. The keywords and faction labels are also customisable per datasource.
+      </p>
+    </header>
+
+    <div className="mwnw-features-list">
+      <div className="mwnw-feature-item">
+        <div className="mwnw-feature-item-icon">
+          <Tag size={20} />
+        </div>
+        <div className="mwnw-feature-item-content">
+          <span className="mwnw-feature-item-title">Faction Keywords Show on the Card</span>
+          <span className="mwnw-feature-item-desc">
+            Faction keywords entered in the editor now actually appear in the bottom bar of the rendered card. They
+            were being saved correctly but the renderer was reading the wrong field.
+          </span>
+        </div>
+      </div>
+
+      <div className="mwnw-feature-item">
+        <div className="mwnw-feature-item-icon">
+          <MessageSquareText size={20} />
+        </div>
+        <div className="mwnw-feature-item-content">
+          <span className="mwnw-feature-item-title">Ability Descriptions Render by Default</span>
+          <span className="mwnw-feature-item-desc">
+            New abilities in the schema-driven editor now show their description automatically. Existing abilities
+            with hidden descriptions will fix themselves the next time you edit the description field.
+          </span>
+        </div>
+      </div>
+
+      <div className="mwnw-feature-item">
+        <div className="mwnw-feature-item-icon">
+          <Type size={20} />
+        </div>
+        <div className="mwnw-feature-item-content">
+          <span className="mwnw-feature-item-title">Customise the Keywords &amp; Faction Labels</span>
+          <span className="mwnw-feature-item-desc">
+            The metadata editor in the Datasource Editor now lets you rename the &quot;Keywords&quot; and
+            &quot;Faction&quot; bars on the card. The faction bar default also changes from &quot;Faction
+            Keywords&quot; to the shorter &quot;Faction&quot;.
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default StepPatchNotes;

--- a/src/Components/MobileWhatsNewWizard/versions/v3.7.2/StepPatchNotes.jsx
+++ b/src/Components/MobileWhatsNewWizard/versions/v3.7.2/StepPatchNotes.jsx
@@ -9,8 +9,8 @@ export const StepPatchNotes = () => (
       </div>
       <h2 className="mwnw-features-title">Custom Datasource Card Fixes</h2>
       <p className="mwnw-features-subtitle">
-        Cards built with the Datasource Editor now correctly display the faction keywords and ability descriptions
-        you typed in. The keywords and faction labels are also customisable per datasource.
+        Cards built with the Datasource Editor now show the faction keywords and ability descriptions you typed in,
+        and you can rename the keywords and faction bars on each card.
       </p>
     </header>
 
@@ -22,8 +22,8 @@ export const StepPatchNotes = () => (
         <div className="mwnw-feature-item-content">
           <span className="mwnw-feature-item-title">Faction Keywords Show on the Card</span>
           <span className="mwnw-feature-item-desc">
-            Faction keywords entered in the editor now actually appear in the bottom bar of the rendered card. They
-            were being saved correctly but the renderer was reading the wrong field.
+            Faction keywords typed into the editor now show up in the faction bar at the bottom of the card.
+            Previously they stayed empty even after you saved the card.
           </span>
         </div>
       </div>
@@ -33,10 +33,10 @@ export const StepPatchNotes = () => (
           <MessageSquareText size={20} />
         </div>
         <div className="mwnw-feature-item-content">
-          <span className="mwnw-feature-item-title">Ability Descriptions Render by Default</span>
+          <span className="mwnw-feature-item-title">Ability Descriptions Show by Default</span>
           <span className="mwnw-feature-item-desc">
-            New abilities in the schema-driven editor now show their description automatically. Existing abilities
-            with hidden descriptions will fix themselves the next time you edit the description field.
+            New abilities in the Datasource Editor now show their description on the card straight away. Older
+            abilities with a hidden description fix themselves the next time you edit the description.
           </span>
         </div>
       </div>
@@ -48,9 +48,8 @@ export const StepPatchNotes = () => (
         <div className="mwnw-feature-item-content">
           <span className="mwnw-feature-item-title">Customise the Keywords &amp; Faction Labels</span>
           <span className="mwnw-feature-item-desc">
-            The metadata editor in the Datasource Editor now lets you rename the &quot;Keywords&quot; and
-            &quot;Faction&quot; bars on the card. The faction bar default also changes from &quot;Faction
-            Keywords&quot; to the shorter &quot;Faction&quot;.
+            The Datasource Editor now lets you rename the &quot;Keywords&quot; and &quot;Faction&quot; bars on the
+            card. The faction bar also defaults to &quot;Faction&quot; instead of &quot;Faction Keywords&quot;.
           </span>
         </div>
       </div>

--- a/src/Components/MobileWhatsNewWizard/versions/v3.7.2/index.js
+++ b/src/Components/MobileWhatsNewWizard/versions/v3.7.2/index.js
@@ -1,0 +1,18 @@
+import { Wrench } from "lucide-react";
+import { StepPatchNotes } from "./StepPatchNotes";
+
+export const MOBILE_VERSION_CONFIG = {
+  version: "3.7.2",
+  releaseName: "Custom Datasource Card Fixes",
+  steps: [
+    {
+      key: "3.7.2-patch-notes",
+      title: "Improvements & Fixes",
+      icon: Wrench,
+      component: StepPatchNotes,
+      isThankYou: true,
+    },
+  ],
+};
+
+export default MOBILE_VERSION_CONFIG;

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitFactions.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitFactions.jsx
@@ -1,7 +1,7 @@
-export const UnitFactions = ({ factions }) => {
+export const UnitFactions = ({ factions, label }) => {
   return (
     <div className="factions">
-      <span className="title">faction keywords</span>
+      <span className="title">{label || "faction"}</span>
       <span className="value">{factions?.join(", ")}</span>
     </div>
   );

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitKeywords.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitKeywords.jsx
@@ -1,7 +1,7 @@
-export const UnitKeywords = ({ keywords }) => {
+export const UnitKeywords = ({ keywords, label }) => {
   return (
     <div className="keywords">
-      <span className="title">keywords</span>
+      <span className="title">{label || "keywords"}</span>
       <span className="value">
         {keywords?.map((keyword, i, { length }) => {
           if (keyword?.includes(":")) {

--- a/src/Components/WhatsNewWizard/versions/__tests__/registry.test.js
+++ b/src/Components/WhatsNewWizard/versions/__tests__/registry.test.js
@@ -20,8 +20,8 @@ describe("WhatsNewWizard version registry", () => {
     }
   });
 
-  it("has v3.7.1 as the latest version", () => {
-    expect(getLatestWizardVersion()).toBe("3.7.1");
+  it("has v3.7.2 as the latest version", () => {
+    expect(getLatestWizardVersion()).toBe("3.7.2");
   });
 
   it("returns v3.2.2 config via getVersionConfig", () => {

--- a/src/Components/WhatsNewWizard/versions/__tests__/v372.test.js
+++ b/src/Components/WhatsNewWizard/versions/__tests__/v372.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { VERSION_CONFIG } from "../v3.7.2";
+
+describe("Desktop WhatsNewWizard v3.7.2 config", () => {
+  it("has version 3.7.2", () => {
+    expect(VERSION_CONFIG.version).toBe("3.7.2");
+  });
+
+  it("has the correct release name", () => {
+    expect(VERSION_CONFIG.releaseName).toBe("Custom Datasource Card Fixes");
+  });
+
+  it("has at least 1 step", () => {
+    expect(VERSION_CONFIG.steps.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("has unique keys for all steps", () => {
+    const keys = VERSION_CONFIG.steps.map((s) => s.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("has title and component on every step", () => {
+    VERSION_CONFIG.steps.forEach((step) => {
+      expect(step.title).toBeTruthy();
+      expect(step.component).toBeTruthy();
+    });
+  });
+
+  it("marks the last step as thankYou", () => {
+    expect(VERSION_CONFIG.steps[VERSION_CONFIG.steps.length - 1].isThankYou).toBe(true);
+  });
+});

--- a/src/Components/WhatsNewWizard/versions/index.js
+++ b/src/Components/WhatsNewWizard/versions/index.js
@@ -16,6 +16,7 @@ import v352Config from "./v3.5.2";
 import v360Config from "./v3.6.0";
 import v370Config from "./v3.7.0";
 import v371Config from "./v3.7.1";
+import v372Config from "./v3.7.2";
 
 /**
  * Registry of all version wizard configurations
@@ -44,6 +45,7 @@ export const VERSION_REGISTRY = [
   v360Config,
   v370Config,
   v371Config,
+  v372Config,
 ]
   .filter((config) => config && config.version)
   .sort((a, b) => compareVersions(a.version, b.version));

--- a/src/Components/WhatsNewWizard/versions/v3.7.2/StepPatchNotes.jsx
+++ b/src/Components/WhatsNewWizard/versions/v3.7.2/StepPatchNotes.jsx
@@ -12,8 +12,8 @@ export const StepPatchNotes = () => (
       </div>
     </div>
     <p className="wnw-feature-description">
-      Cards built with the Datasource Editor now correctly display the faction keywords and ability descriptions you
-      typed in. The keywords and faction labels are also customisable per datasource.
+      Cards built with the Datasource Editor now show the faction keywords and ability descriptions you typed in, and
+      you can rename the keywords and faction bars on each card.
     </p>
 
     <div className="wnw-feature-highlights">
@@ -25,8 +25,8 @@ export const StepPatchNotes = () => (
             Faction Keywords Show on the Card
           </strong>
           <p>
-            Faction keywords entered in the editor now actually appear in the bottom bar of the rendered card. They
-            were being saved correctly but the renderer was reading the wrong field.
+            Faction keywords typed into the editor now show up in the faction bar at the bottom of the card. Previously
+            they stayed empty even after you saved the card.
           </p>
         </div>
       </div>
@@ -35,11 +35,11 @@ export const StepPatchNotes = () => (
         <div>
           <strong>
             <MessageSquareText size={14} style={{ verticalAlign: -2, marginRight: 6 }} />
-            Ability Descriptions Render by Default
+            Ability Descriptions Show by Default
           </strong>
           <p>
-            New abilities in the schema-driven editor now show their description automatically. Existing abilities
-            with hidden descriptions will fix themselves the next time you edit the description field.
+            New abilities in the Datasource Editor now show their description on the card straight away. Older
+            abilities with a hidden description fix themselves the next time you edit the description.
           </p>
         </div>
       </div>
@@ -51,9 +51,8 @@ export const StepPatchNotes = () => (
             Customise the Keywords &amp; Faction Labels
           </strong>
           <p>
-            The metadata editor in the Datasource Editor now lets you rename the &quot;Keywords&quot; and
-            &quot;Faction&quot; bars on the card. The faction bar default also changes from &quot;Faction
-            Keywords&quot; to the shorter &quot;Faction&quot;.
+            The Datasource Editor now lets you rename the &quot;Keywords&quot; and &quot;Faction&quot; bars on the
+            card. The faction bar also defaults to &quot;Faction&quot; instead of &quot;Faction Keywords&quot;.
           </p>
         </div>
       </div>

--- a/src/Components/WhatsNewWizard/versions/v3.7.2/StepPatchNotes.jsx
+++ b/src/Components/WhatsNewWizard/versions/v3.7.2/StepPatchNotes.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { Wrench, Tag, Type, MessageSquareText } from "lucide-react";
+
+export const StepPatchNotes = () => (
+  <div className="wnw-step-subscription">
+    <div className="wnw-feature-header">
+      <div className="wnw-feature-icon">
+        <Wrench size={28} />
+      </div>
+      <div>
+        <h2 className="wnw-feature-title">Custom Datasource Card Fixes</h2>
+      </div>
+    </div>
+    <p className="wnw-feature-description">
+      Cards built with the Datasource Editor now correctly display the faction keywords and ability descriptions you
+      typed in. The keywords and faction labels are also customisable per datasource.
+    </p>
+
+    <div className="wnw-feature-highlights">
+      <div className="wnw-highlight-item">
+        <div className="wnw-highlight-dot" />
+        <div>
+          <strong>
+            <Tag size={14} style={{ verticalAlign: -2, marginRight: 6 }} />
+            Faction Keywords Show on the Card
+          </strong>
+          <p>
+            Faction keywords entered in the editor now actually appear in the bottom bar of the rendered card. They
+            were being saved correctly but the renderer was reading the wrong field.
+          </p>
+        </div>
+      </div>
+      <div className="wnw-highlight-item">
+        <div className="wnw-highlight-dot" />
+        <div>
+          <strong>
+            <MessageSquareText size={14} style={{ verticalAlign: -2, marginRight: 6 }} />
+            Ability Descriptions Render by Default
+          </strong>
+          <p>
+            New abilities in the schema-driven editor now show their description automatically. Existing abilities
+            with hidden descriptions will fix themselves the next time you edit the description field.
+          </p>
+        </div>
+      </div>
+      <div className="wnw-highlight-item">
+        <div className="wnw-highlight-dot" />
+        <div>
+          <strong>
+            <Type size={14} style={{ verticalAlign: -2, marginRight: 6 }} />
+            Customise the Keywords &amp; Faction Labels
+          </strong>
+          <p>
+            The metadata editor in the Datasource Editor now lets you rename the &quot;Keywords&quot; and
+            &quot;Faction&quot; bars on the card. The faction bar default also changes from &quot;Faction
+            Keywords&quot; to the shorter &quot;Faction&quot;.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default StepPatchNotes;

--- a/src/Components/WhatsNewWizard/versions/v3.7.2/index.js
+++ b/src/Components/WhatsNewWizard/versions/v3.7.2/index.js
@@ -1,0 +1,18 @@
+import { Wrench } from "lucide-react";
+import { StepPatchNotes } from "./StepPatchNotes";
+
+export const VERSION_CONFIG = {
+  version: "3.7.2",
+  releaseName: "Custom Datasource Card Fixes",
+  steps: [
+    {
+      key: "3.7.2-patch-notes",
+      title: "Improvements & Fixes",
+      icon: Wrench,
+      component: StepPatchNotes,
+      isThankYou: true,
+    },
+  ],
+};
+
+export default VERSION_CONFIG;

--- a/src/Helpers/customSchema.helpers.js
+++ b/src/Helpers/customSchema.helpers.js
@@ -139,6 +139,8 @@ export const DEFAULT_DATASOURCE_COLOURS = Object.freeze({ header: "#1a1a2e", ban
  * @typedef {Object} UnitMetadataDefinition
  * @property {boolean} hasKeywords - Whether cards have keywords
  * @property {boolean} hasFactionKeywords - Whether cards have faction keywords
+ * @property {string} [keywordsLabel] - Display label for the keywords bar (defaults to "Keywords")
+ * @property {string} [factionKeywordsLabel] - Display label for the faction keywords bar (defaults to "Faction")
  * @property {boolean} hasPoints - Whether cards have points costs
  * @property {PointsFormat} pointsFormat - Points display format
  */


### PR DESCRIPTION
…ce cards

- Read faction keywords from `card.factionKeywords` (the editor-saved field) with `card.factions` fallback, in both `Ds40kUnitCard` and `CustomUnitCard`.
- Add optional `label` prop to `UnitFactions` and `UnitKeywords` so the bottom bars can be relabelled per datasource. Default for `UnitFactions` changes from "faction keywords" to "faction" to match real W40K 10e datacards (CSS already adds the colon).
- Add `keywordsLabel` and `factionKeywordsLabel` inputs in the metadata schema editor; values flow through `schema.metadata` to the renderers.
- Document the new metadata fields in the schema architecture doc.