### PR TITLE
Show configured keywords/faction labels in tree view + fix faction bar wrap

### DIFF
--- a/src/Components/DatasourceEditor/SchemaTreeView.jsx
+++ b/src/Components/DatasourceEditor/SchemaTreeView.jsx
@@ -238,7 +238,7 @@ const UnitSchemaTree = ({ schema }) => {
             <div className="schema-tree-node">
               <div className="schema-tree-node-header schema-tree-flag" style={{ paddingLeft: 12 + 1 * 16 }}>
                 <span className="schema-tree-chevron-spacer" />
-                <span className="schema-tree-flag-label">Keywords enabled</span>
+                <span className="schema-tree-flag-label">Keywords ({schema.metadata.keywordsLabel || "Keywords"})</span>
               </div>
             </div>
           )}
@@ -246,7 +246,9 @@ const UnitSchemaTree = ({ schema }) => {
             <div className="schema-tree-node">
               <div className="schema-tree-node-header schema-tree-flag" style={{ paddingLeft: 12 + 1 * 16 }}>
                 <span className="schema-tree-chevron-spacer" />
-                <span className="schema-tree-flag-label">Faction keywords enabled</span>
+                <span className="schema-tree-flag-label">
+                  Faction keywords ({schema.metadata.factionKeywordsLabel || "Faction"})
+                </span>
               </div>
             </div>
           )}

--- a/src/Components/DatasourceEditor/__tests__/SchemaTreeView.test.jsx
+++ b/src/Components/DatasourceEditor/__tests__/SchemaTreeView.test.jsx
@@ -222,8 +222,8 @@ describe("SchemaTreeView", () => {
     it("renders metadata section with flags", () => {
       render(<SchemaTreeView selectedItem={selectedItem} activeDatasource={mockDatasource} />);
       expect(screen.getByText("Card Properties")).toBeInTheDocument();
-      expect(screen.getByText("Keywords enabled")).toBeInTheDocument();
-      expect(screen.getByText("Faction keywords enabled")).toBeInTheDocument();
+      expect(screen.getByText("Keywords (Keywords)")).toBeInTheDocument();
+      expect(screen.getByText("Faction keywords (Faction)")).toBeInTheDocument();
       expect(screen.getByText("Points (per-model)")).toBeInTheDocument();
     });
 

--- a/src/styles/40k-10e.less
+++ b/src/styles/40k-10e.less
@@ -2965,8 +2965,8 @@
       }
       .factions {
         display: flex;
-        flex-direction: column;
-        justify-content: center;
+        flex-direction: row;
+        align-items: center;
         position: relative;
         padding-left: 48px;
         background-color: var(--background-colour);
@@ -2979,6 +2979,7 @@
           font-weight: 400;
           padding-right: 4px;
           line-height: 1.1rem;
+          white-space: nowrap;
 
           &::after {
             content: ":";


### PR DESCRIPTION
## Summary

Follow-ups to v3.7.2 surfaced two issues in the Datasource Editor:

- The schema tree view still said **"Keywords enabled"** / **"Faction keywords enabled"** even after a user set custom labels. Now it shows the configured label in parentheses, matching the existing **"Points (per-model)"** pattern: `Keywords (Tests)` / `Faction keywords (Orders)`. Defaults to the standard label name when no override is set.
- The faction bar on the rendered card stacked the label above the value (label on row 1, value on row 2) while the keywords bar kept them side-by-side. The `.factions` CSS now uses `flex-direction: row` with `align-items: center` and `white-space: nowrap` on the title, matching the `.keywords` layout.

The companion change in `gdc-premium` (sidebar keyword editor labels) is in a separate PR there.

## Test plan

- [x] `yarn test:ci` (2490 tests pass)
- [ ] Open `/datasources`, set custom Keywords + Faction labels, confirm the tree view shows them in parentheses
- [ ] Confirm the bottom faction bar on the card preview keeps label and value on one line for both default and custom labels

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwJRrbYmn3GPcAoo7HDRqR)_