### PR TITLE
Consolidate game systems config into canonical mobile registry

### DIFF
--- a/src/Components/MobileWelcomeWizard/steps/StepGameSystem.jsx
+++ b/src/Components/MobileWelcomeWizard/steps/StepGameSystem.jsx
@@ -17,6 +17,14 @@ const GAME_SYSTEMS = [
     colorLight: "rgba(201, 162, 39, 0.12)",
     colorBorder: "rgba(201, 162, 39, 0.5)",
   },
+  {
+    id: "starcraft-tmg",
+    name: "Starcraft 2 TMG",
+    edition: "Tabletop Miniatures Game",
+    color: "#7c3aed",
+    colorLight: "rgba(124, 58, 237, 0.15)",
+    colorBorder: "rgba(124, 58, 237, 0.5)",
+  },
 ];
 
 export const StepGameSystem = ({ selectedSystem, onSelect }) => {

--- a/src/Components/MobileWelcomeWizard/steps/StepGameSystem.jsx
+++ b/src/Components/MobileWelcomeWizard/steps/StepGameSystem.jsx
@@ -1,31 +1,13 @@
 import { Database, AlertTriangle, Circle, CheckCircle2 } from "lucide-react";
+import { PRIMARY_MOBILE_SYSTEMS } from "../../Viewer/mobileGameSystems";
 
-const GAME_SYSTEMS = [
-  {
-    id: "40k-10e",
-    name: "Warhammer 40,000",
-    edition: "10th Edition",
-    color: "#8b2020",
-    colorLight: "rgba(139, 32, 32, 0.15)",
-    colorBorder: "rgba(139, 32, 32, 0.5)",
-  },
-  {
-    id: "aos",
-    name: "Age of Sigmar",
-    edition: "4th Edition",
-    color: "#c9a227",
-    colorLight: "rgba(201, 162, 39, 0.12)",
-    colorBorder: "rgba(201, 162, 39, 0.5)",
-  },
-  {
-    id: "starcraft-tmg",
-    name: "Starcraft 2 TMG",
-    edition: "Tabletop Miniatures Game",
-    color: "#7c3aed",
-    colorLight: "rgba(124, 58, 237, 0.15)",
-    colorBorder: "rgba(124, 58, 237, 0.5)",
-  },
-];
+const hexToRgba = (hex, alpha) => {
+  const h = hex.replace("#", "");
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
 
 export const StepGameSystem = ({ selectedSystem, onSelect }) => {
   return (
@@ -41,8 +23,10 @@ export const StepGameSystem = ({ selectedSystem, onSelect }) => {
       </header>
 
       <div className="mww-gamesystem-options">
-        {GAME_SYSTEMS.map((system, index) => {
+        {PRIMARY_MOBILE_SYSTEMS.map((system, index) => {
           const isSelected = selectedSystem === system.id;
+          const name = system.longName ?? system.name;
+          const edition = system.longMeta ?? system.meta;
           return (
             <button
               key={system.id}
@@ -51,14 +35,14 @@ export const StepGameSystem = ({ selectedSystem, onSelect }) => {
               type="button"
               style={{
                 "--system-color": system.color,
-                "--system-color-light": system.colorLight,
-                "--system-color-border": system.colorBorder,
+                "--system-color-light": hexToRgba(system.color, 0.15),
+                "--system-color-border": hexToRgba(system.color, 0.5),
                 animationDelay: `${0.1 + index * 0.05}s`,
               }}>
               <div className="mww-gamesystem-card-marker" />
               <div className="mww-gamesystem-card-content">
-                <span className="mww-gamesystem-card-name">{system.name}</span>
-                <span className="mww-gamesystem-card-edition">{system.edition}</span>
+                <span className="mww-gamesystem-card-name">{name}</span>
+                <span className="mww-gamesystem-card-edition">{edition}</span>
               </div>
               <div className="mww-gamesystem-card-check">{isSelected ? <CheckCircle2 /> : <Circle />}</div>
             </button>

--- a/src/Components/Viewer/mobileDatasourceConfig.jsx
+++ b/src/Components/Viewer/mobileDatasourceConfig.jsx
@@ -198,12 +198,7 @@ export const resolveMobileConfig = (datasourceId, dataSource) => {
   return buildCustomConfig(dataSource);
 };
 
-/**
- * Systems shown on the game system selector screen.
- * These are the primary systems with full support.
- */
-export const SELECTOR_SYSTEMS = [
-  { id: "40k-10e", name: "Warhammer 40,000", meta: "10th Edition", cssClass: "gss-option-40k" },
-  { id: "aos", name: "Age of Sigmar", meta: "4th Edition", cssClass: "gss-option-aos" },
-  { id: "starcraft-tmg", name: "Starcraft", meta: "TMG", cssClass: "gss-option-starcraft" },
-];
+// Systems shown on the mobile game system selector screen. Sourced from the
+// canonical mobile-systems registry so the welcome wizard and the selector
+// stay in sync — see ./mobileGameSystems.js.
+export { PRIMARY_MOBILE_SYSTEMS as SELECTOR_SYSTEMS } from "./mobileGameSystems";

--- a/src/Components/Viewer/mobileGameSystems.js
+++ b/src/Components/Viewer/mobileGameSystems.js
@@ -1,0 +1,37 @@
+// Canonical registry of "primary" built-in game systems shown in the mobile
+// UI: the welcome wizard's game-system step and the mobile selector screen.
+// Add a new system here once and it appears in both.
+//
+// Fields:
+//   id        - datasource id used by the rest of the app
+//   name      - short label rendered on the compact selector
+//   meta      - short subtitle rendered on the compact selector
+//   longName  - optional fuller label, used by the welcome wizard
+//   longMeta  - optional fuller subtitle, used by the welcome wizard
+//   cssClass  - per-system class consumed by selector CSS (gss-option-*)
+//   color     - hex used by the wizard for the accent bar / translucent fills
+export const PRIMARY_MOBILE_SYSTEMS = [
+  {
+    id: "40k-10e",
+    name: "Warhammer 40,000",
+    meta: "10th Edition",
+    cssClass: "gss-option-40k",
+    color: "#8b2020",
+  },
+  {
+    id: "aos",
+    name: "Age of Sigmar",
+    meta: "4th Edition",
+    cssClass: "gss-option-aos",
+    color: "#c9a227",
+  },
+  {
+    id: "starcraft-tmg",
+    name: "Starcraft",
+    meta: "TMG",
+    longName: "Starcraft 2 TMG",
+    longMeta: "Tabletop Miniatures Game",
+    cssClass: "gss-option-starcraft",
+    color: "#7c3aed",
+  },
+];


### PR DESCRIPTION
## Summary
Refactored game system configuration to use a single canonical source of truth for mobile UI systems. Previously, game system data was duplicated across the welcome wizard and mobile selector. Now both components reference a shared registry.

## Key Changes
- Created new `mobileGameSystems.js` file containing `PRIMARY_MOBILE_SYSTEMS` as the canonical registry for game systems displayed in mobile UI
- Updated `StepGameSystem.jsx` to import and use `PRIMARY_MOBILE_SYSTEMS` instead of local `GAME_SYSTEMS` constant
- Replaced hardcoded `colorLight` and `colorBorder` values with dynamic `hexToRgba()` utility function that derives them from the base `color` hex value
- Updated field names for consistency: `name`/`edition` → `name`/`meta`, with optional `longName`/`longMeta` for expanded wizard display
- Refactored `mobileDatasourceConfig.jsx` to re-export `PRIMARY_MOBILE_SYSTEMS` as `SELECTOR_SYSTEMS`, eliminating duplicate system definitions
- Added Starcraft TMG as a new system in the registry with extended metadata for the welcome wizard

## Implementation Details
- The `hexToRgba()` function converts hex color codes to RGBA format with configurable alpha values (0.15 for light, 0.5 for border)
- System objects now support optional `longName` and `longMeta` fields that fall back to `name` and `meta` if not provided, allowing the welcome wizard to display fuller descriptions while keeping the selector compact
- All color calculations are now dynamic, reducing maintenance burden when updating system colors

https://claude.ai/code/session_01KM1RHDeg1VwmvzF8UJ7vEE