### PR TITLE
Support moving cards between factions in datasource editor

### DIFF
--- a/src/Components/DatasourceEditor/__tests__/useDatasourceEditorState.test.jsx
+++ b/src/Components/DatasourceEditor/__tests__/useDatasourceEditorState.test.jsx
@@ -483,6 +483,172 @@ describe("useDatasourceEditorState", () => {
       ];
     });
 
+    it("updateCard updates the card in place when faction_id is unchanged", async () => {
+      const twoFactionDs = {
+        ...fullDatasource,
+        data: [
+          {
+            id: "faction-1",
+            name: "Faction One",
+            datasheets: [{ id: "card-1", name: "Unit A", cardType: "infantry", faction_id: "faction-1" }],
+          },
+          {
+            id: "faction-2",
+            name: "Faction Two",
+            datasheets: [],
+          },
+        ],
+      };
+      mockGetCustomDatasourceData.mockResolvedValueOnce(twoFactionDs);
+
+      const { result } = renderHook(() => useDatasourceEditorState());
+
+      await act(async () => {
+        await result.current.openDatasource({ id: "custom-1" });
+      });
+
+      await act(async () => {
+        await result.current.updateCard({
+          id: "card-1",
+          name: "Unit A Renamed",
+          cardType: "infantry",
+          faction_id: "faction-1",
+        });
+      });
+
+      const data = result.current.activeDatasource.data;
+      expect(data[0].datasheets).toHaveLength(1);
+      expect(data[0].datasheets[0].name).toBe("Unit A Renamed");
+      expect(data[1].datasheets).toHaveLength(0);
+    });
+
+    it("updateCard moves the card to the new faction when faction_id changes", async () => {
+      const twoFactionDs = {
+        ...fullDatasource,
+        data: [
+          {
+            id: "faction-1",
+            name: "Faction One",
+            datasheets: [
+              { id: "card-1", name: "Unit A", cardType: "infantry", faction_id: "faction-1" },
+              { id: "card-2", name: "Unit B", cardType: "infantry", faction_id: "faction-1" },
+            ],
+          },
+          {
+            id: "faction-2",
+            name: "Faction Two",
+            datasheets: [{ id: "card-3", name: "Unit C", cardType: "infantry", faction_id: "faction-2" }],
+          },
+        ],
+      };
+      mockGetCustomDatasourceData.mockResolvedValueOnce(twoFactionDs);
+
+      const { result } = renderHook(() => useDatasourceEditorState());
+
+      await act(async () => {
+        await result.current.openDatasource({ id: "custom-1" });
+      });
+
+      await act(async () => {
+        await result.current.updateCard({
+          id: "card-1",
+          name: "Unit A",
+          cardType: "infantry",
+          faction_id: "faction-2",
+        });
+      });
+
+      const data = result.current.activeDatasource.data;
+      // Source faction no longer contains card-1
+      expect(data[0].datasheets.map((c) => c.id)).toEqual(["card-2"]);
+      // Target faction contains card-1 with the new faction_id
+      expect(data[1].datasheets.map((c) => c.id)).toEqual(["card-3", "card-1"]);
+      const moved = data[1].datasheets.find((c) => c.id === "card-1");
+      expect(moved.faction_id).toBe("faction-2");
+    });
+
+    it("updateCard keeps card in source faction when target faction_id does not exist", async () => {
+      const twoFactionDs = {
+        ...fullDatasource,
+        data: [
+          {
+            id: "faction-1",
+            name: "Faction One",
+            datasheets: [{ id: "card-1", name: "Unit A", cardType: "infantry", faction_id: "faction-1" }],
+          },
+          {
+            id: "faction-2",
+            name: "Faction Two",
+            datasheets: [],
+          },
+        ],
+      };
+      mockGetCustomDatasourceData.mockResolvedValueOnce(twoFactionDs);
+
+      const { result } = renderHook(() => useDatasourceEditorState());
+
+      await act(async () => {
+        await result.current.openDatasource({ id: "custom-1" });
+      });
+
+      await act(async () => {
+        await result.current.updateCard({
+          id: "card-1",
+          name: "Unit A",
+          cardType: "infantry",
+          faction_id: "ghost-faction",
+        });
+      });
+
+      const data = result.current.activeDatasource.data;
+      // Card stays in source faction; the unknown faction_id is preserved on the card
+      expect(data[0].datasheets).toHaveLength(1);
+      expect(data[0].datasheets[0].faction_id).toBe("ghost-faction");
+      expect(data[1].datasheets).toHaveLength(0);
+    });
+
+    it("updateCard keeps the moved card selected", async () => {
+      const twoFactionDs = {
+        ...fullDatasource,
+        data: [
+          {
+            id: "faction-1",
+            name: "Faction One",
+            datasheets: [{ id: "card-1", name: "Unit A", cardType: "infantry", faction_id: "faction-1" }],
+          },
+          {
+            id: "faction-2",
+            name: "Faction Two",
+            datasheets: [],
+          },
+        ],
+      };
+      mockGetCustomDatasourceData.mockResolvedValueOnce(twoFactionDs);
+
+      const { result } = renderHook(() => useDatasourceEditorState());
+
+      await act(async () => {
+        await result.current.openDatasource({ id: "custom-1" });
+      });
+
+      act(() => {
+        result.current.selectCard(twoFactionDs.data[0].datasheets[0]);
+      });
+
+      await act(async () => {
+        await result.current.updateCard({
+          id: "card-1",
+          name: "Unit A",
+          cardType: "infantry",
+          faction_id: "faction-2",
+        });
+      });
+
+      expect(result.current.selectedItem.type).toBe("card");
+      expect(result.current.selectedItem.data.id).toBe("card-1");
+      expect(result.current.selectedItem.data.faction_id).toBe("faction-2");
+    });
+
     it("clears selection when deleted card was selected", async () => {
       const { result } = renderHook(() => useDatasourceEditorState());
 

--- a/src/Components/DatasourceEditor/hooks/useDatasourceEditorState.js
+++ b/src/Components/DatasourceEditor/hooks/useDatasourceEditorState.js
@@ -203,22 +203,46 @@ export function useDatasourceEditorState() {
 
   /**
    * Update a card by ID — searches every faction for the matching card.
+   * If the updated card's `faction_id` no longer matches the faction it lives
+   * in, physically move it from the source faction's collection array into the
+   * target faction's collection array. This is what makes the card editor's
+   * Faction dropdown actually re-faction a card (not just re-skin its colour
+   * theme).
    */
   const updateCard = useCallback(
     async (updatedCard) => {
       if (!activeDatasource?.data?.length) return;
       const targetArray = getTargetArray(updatedCard.cardType);
-      let touched = false;
-      const updatedData = activeDatasource.data.map((faction) => {
-        const cards = faction[targetArray] || [];
-        if (!cards.some((c) => c.id === updatedCard.id)) return faction;
-        touched = true;
-        return {
-          ...faction,
-          [targetArray]: cards.map((c) => (c.id === updatedCard.id ? updatedCard : c)),
-        };
+      const factions = activeDatasource.data;
+      const sourceFaction = factions.find((f) => (f[targetArray] || []).some((c) => c.id === updatedCard.id));
+      if (!sourceFaction) return;
+
+      const desiredFactionId = updatedCard.faction_id;
+      const desiredFaction = desiredFactionId != null ? factions.find((f) => f.id === desiredFactionId) : null;
+      const isMoving = !!desiredFaction && desiredFaction.id !== sourceFaction.id;
+
+      const updatedData = factions.map((faction) => {
+        if (isMoving && faction.id === sourceFaction.id) {
+          return {
+            ...faction,
+            [targetArray]: (faction[targetArray] || []).filter((c) => c.id !== updatedCard.id),
+          };
+        }
+        if (isMoving && faction.id === desiredFaction.id) {
+          return {
+            ...faction,
+            [targetArray]: [...(faction[targetArray] || []), updatedCard],
+          };
+        }
+        if (!isMoving && faction.id === sourceFaction.id) {
+          return {
+            ...faction,
+            [targetArray]: (faction[targetArray] || []).map((c) => (c.id === updatedCard.id ? updatedCard : c)),
+          };
+        }
+        return faction;
       });
-      if (!touched) return;
+
       const updatedDatasource = { ...activeDatasource, data: updatedData };
       await updateDatasource(updatedDatasource);
       // Keep selected card in sync

--- a/src/Components/DatasourceEditor/hooks/useDatasourceEditorState.js
+++ b/src/Components/DatasourceEditor/hooks/useDatasourceEditorState.js
@@ -208,6 +208,8 @@ export function useDatasourceEditorState() {
    * target faction's collection array. This is what makes the card editor's
    * Faction dropdown actually re-faction a card (not just re-skin its colour
    * theme).
+  /**
+   * Update a card by ID — searches every faction for the matching card.
    */
   const updateCard = useCallback(
     async (updatedCard) => {


### PR DESCRIPTION
## Summary
Enhanced the `updateCard` function to support physically moving cards between factions when the `faction_id` property changes, rather than just updating the card in place.

## Key Changes
- **Card movement logic**: When a card's `faction_id` is updated to a different faction, the card is now removed from its source faction's collection and added to the target faction's collection
- **Graceful handling of invalid factions**: If the target `faction_id` doesn't exist in the datasource, the card remains in its source faction while preserving the new `faction_id` value on the card object
- **Selection persistence**: The selected card reference is kept in sync when a card is moved between factions, maintaining the selection state with updated faction information
- **Comprehensive test coverage**: Added four new test cases covering:
  - In-place updates when faction doesn't change
  - Moving cards to existing factions
  - Handling moves to non-existent factions
  - Maintaining card selection after moves

## Implementation Details
The updated `updateCard` function now:
1. Identifies the source faction containing the card
2. Determines if the card should move based on whether the target `faction_id` exists as a faction
3. Applies appropriate transformations:
   - Removes card from source faction if moving
   - Adds card to target faction if moving
   - Updates card in place if not moving
4. Maintains the selected item state to reflect the card's new location

https://claude.ai/code/session_01Qf9Bd1ZF5Nb9eRiJgAGhNQ