### PR TITLE
Fix mobile search header overflow on narrow viewports

### DIFF
--- a/src/Components/Viewer/MobileSearchHeader.css
+++ b/src/Components/Viewer/MobileSearchHeader.css
@@ -16,6 +16,9 @@
   left: 0;
   right: 0;
   z-index: 100;
+  /* Constrain children from overflowing on narrow viewports (e.g. Android display-zoom) */
+  overflow: hidden;
+  box-sizing: border-box;
 }
 
 /* ===========================================
@@ -34,7 +37,8 @@
    =========================================== */
 
 .mobile-search-input-wrapper {
-  flex: 1;
+  flex: 1 1 0;
+  min-width: 0;
   position: relative;
 }
 
@@ -45,6 +49,7 @@
   border-radius: 8px;
   padding: 0 12px;
   height: 40px;
+  min-width: 0;
   transition: all 0.2s ease;
 }
 
@@ -124,4 +129,31 @@
 
 .mobile-search-faction-btn:active {
   background: rgba(255, 255, 255, 0.1);
+}
+
+/* ===========================================
+   NARROW-VIEWPORT ADJUSTMENTS
+   Tightens spacing on very narrow CSS widths
+   (e.g. Android phones with high display-zoom)
+   =========================================== */
+
+@media (max-width: 380px) {
+  .mobile-search-header {
+    gap: 8px;
+    padding: 0 8px;
+  }
+
+  .mobile-search-logo {
+    width: 36px;
+    height: 36px;
+  }
+
+  .mobile-search-faction-btn {
+    width: 36px;
+    height: 36px;
+  }
+
+  .mobile-search-input-container {
+    padding: 0 10px;
+  }
 }


### PR DESCRIPTION
## Summary
This PR fixes layout issues in the mobile search header that occur on narrow viewports, particularly on Android devices with high display zoom levels. The changes ensure proper text truncation and prevent content overflow while maintaining a responsive design.

## Key Changes
- Added `overflow: hidden` and `box-sizing: border-box` to `.mobile-search-header` to constrain children from overflowing
- Updated `.mobile-search-input-wrapper` flex property from `flex: 1` to `flex: 1 1 0` and added `min-width: 0` to enable proper text truncation
- Added `min-width: 0` to `.mobile-search-input-container` to prevent flex item overflow
- Added new `@media (max-width: 380px)` breakpoint with narrow-viewport adjustments:
  - Reduced gap and padding on the header (8px)
  - Reduced logo and faction button sizes (36px)
  - Adjusted input container padding (10px)

## Implementation Details
The core issue was that flex items with `flex: 1` don't properly truncate text content without an explicit `min-width: 0`. By setting this property along with `overflow: hidden` on the parent, flex items can now shrink below their content size and trigger text truncation via ellipsis. The new media query provides additional spacing optimizations for devices with CSS widths of 380px or less, ensuring the UI remains usable on high-zoom Android displays.

https://claude.ai/code/session_01DrXRReyFVfRUYTtm4jqYPH