### PR TITLE
Fix caret position jumping in card editor after first keystroke

### DIFF
--- a/src/Components/DatasourceEditor/__tests__/useDatasourceEditorState.test.jsx
+++ b/src/Components/DatasourceEditor/__tests__/useDatasourceEditorState.test.jsx
@@ -649,6 +649,45 @@ describe("useDatasourceEditorState", () => {
       expect(result.current.selectedItem.data.faction_id).toBe("faction-2");
     });
 
+    it("updateCard updates selectedItem synchronously, before persistence completes", async () => {
+      // Regression: when this hook awaited persistence before syncing
+      // selectedItem, the markdown editor used in the card editor saw a stale
+      // value during the interim render and snapped its caret to the end of
+      // the textarea after the first keystroke.
+      const { result } = renderHook(() => useDatasourceEditorState());
+
+      await act(async () => {
+        await result.current.openDatasource({ id: "custom-1" });
+      });
+
+      act(() => {
+        result.current.selectCard(fullDatasource.data[0].datasheets[0]);
+      });
+
+      expect(result.current.selectedItem.data.name).toBe("Test Unit");
+
+      // Make persistence hang so we can inspect state between the sync
+      // updates and the awaited persistence.
+      let resolvePersist;
+      mockUpdateDatasourceSyncState.mockImplementationOnce(() => new Promise((resolve) => (resolvePersist = resolve)));
+
+      const updated = { ...fullDatasource.data[0].datasheets[0], name: "Renamed Unit" };
+      let updatePromise;
+      act(() => {
+        updatePromise = result.current.updateCard(updated);
+      });
+
+      // selectedItem must reflect the new card *before* persistence resolves.
+      expect(result.current.selectedItem).toEqual({ type: "card", data: updated });
+
+      await act(async () => {
+        resolvePersist({ id: "custom-1" });
+        await updatePromise;
+      });
+
+      expect(result.current.selectedItem.data.name).toBe("Renamed Unit");
+    });
+
     it("clears selection when deleted card was selected", async () => {
       const { result } = renderHook(() => useDatasourceEditorState());
 

--- a/src/Components/DatasourceEditor/hooks/useDatasourceEditorState.js
+++ b/src/Components/DatasourceEditor/hooks/useDatasourceEditorState.js
@@ -246,11 +246,16 @@ export function useDatasourceEditorState() {
       });
 
       const updatedDatasource = { ...activeDatasource, data: updatedData };
-      await updateDatasource(updatedDatasource);
-      // Keep selected card in sync
+      // Keep selected card in sync synchronously, before any await. Awaiting
+      // here would split this state update into a separate React batch and
+      // some controlled editors (notably @uiw/react-md-editor) will see a
+      // stale `value` prop in the interim render, snap their internal state
+      // back to the old value, then re-sync and reset the textarea — which
+      // jumps the caret to the end after the first keystroke.
       if (selectedItem?.type === "card" && selectedItem?.data?.id === updatedCard.id) {
         setSelectedItem({ type: "card", data: updatedCard });
       }
+      await updateDatasource(updatedDatasource);
     },
     [activeDatasource, updateDatasource, selectedItem],
   );


### PR DESCRIPTION
## Summary
Fixed a regression where the markdown editor's caret would snap to the end of the textarea after the first keystroke when updating a card. The issue was caused by awaiting persistence before synchronously updating the selected item state, which split the state update into separate React batches and caused controlled editors to see stale values.

## Key Changes
- Moved the `setSelectedItem` state update to occur **before** the `await updateDatasource()` call in the `updateCard` function
- This ensures the selected card is synced synchronously within the same React batch, preventing interim renders with stale values
- Added detailed comments explaining why the synchronous update must happen before the async persistence

## Implementation Details
The fix reorders operations in `useDatasourceEditorState.js`:
- Previously: update datasource (await) → sync selected item
- Now: sync selected item → update datasource (await)

This prevents controlled editors like `@uiw/react-md-editor` from receiving stale `value` props during the interim render between the async operation and the state sync. The test verifies that `selectedItem` reflects the updated card before persistence completes.

https://claude.ai/code/session_01LUWxfmf1fKZHMYerJhjAvy