### PR TITLE
Add VP and PE ability cost units and auto-height card resizing

### DIFF
--- a/docs/custom datasource/datasource-schema-architecture.md
+++ b/docs/custom datasource/datasource-schema-architecture.md
@@ -273,7 +273,7 @@ When `baseSystem` is `"starcraft-tmg"`, ability categories gain these additional
 | Property         | Type    | Description                                                                                                   |
 |------------------|---------|---------------------------------------------------------------------------------------------------------------|
 | `hasType`        | boolean | Render a `PASSIVE` / `ACTIVE` / `REACTION` pill from `ability.type`.                                          |
-| `hasCost`        | boolean | Render cost chips from `ability.costs = [{ amount, unit }]`. Known units: `CP` (blue), `BM` (purple).         |
+| `hasCost`        | boolean | Render cost chips from `ability.costs = [{ amount, unit }]`. Known units: `CP` (green), `BM` (blue), `VP` (purple), `PE` (Protoss gold). |
 | `hasTriggerIcon` | boolean | Render an up-arrow glyph before the ability name when `ability.triggered === true`.                          |
 | `phaseStyle`     | string  | Phase icon in the section heading: `"movement"`, `"assault"`, `"combat"`, or `"special"`.                    |
 
@@ -299,6 +299,7 @@ Sections are optional content blocks rendered below weapons on unit cards. Each 
 | `pointsFormat`     | string  | `"per-model"` or `"per-unit"`. Only applies when `hasPoints` is true.  |
 | `bannerType`       | string  | Controls the header banner text. Only applies when `baseSystem` is not `"40k-10e"`. |
 | `bannerCustomText` | string  | Custom banner text. Only applies when `bannerType` is `"custom"`.       |
+| `hasAutoResize`    | boolean | Starcraft TMG only. Exposes a per-card "Auto-resize card" toggle in the Basic Information panel. When the card sets `styling.autoHeight = true`, the rendered card grows beyond its standard 714px frame to fit overflowing content. |
 
 #### Banner type values (AoS / non-40k only)
 

--- a/src/Components/DatasourceEditor/cards/DsStarcraftUnitCard.jsx
+++ b/src/Components/DatasourceEditor/cards/DsStarcraftUnitCard.jsx
@@ -242,7 +242,7 @@ export const DsStarcraftUnitCard = ({ card, cardTypeDef, cardStyle, faction, isM
 
   return (
     <div className={`data-starcraft${isMobile ? " viewer" : ""}`} data-testid="ds-starcraft-unit" style={mergedStyle}>
-      <div className="ds-starcraft-card" data-name={card.name}>
+      <div className={`ds-starcraft-card${card.styling?.autoHeight ? " auto-height" : ""}`} data-name={card.name}>
         <div className="sc-bg-texture" aria-hidden="true" />
 
         {isMobile && onBack && (

--- a/src/Components/DatasourceEditor/cards/__tests__/DsStarcraftUnitCard.test.jsx
+++ b/src/Components/DatasourceEditor/cards/__tests__/DsStarcraftUnitCard.test.jsx
@@ -223,6 +223,21 @@ describe("DsStarcraftUnitCard", () => {
     expect(mobileTags.querySelector(".sc-mobile-faction-pill")).toBeTruthy();
   });
 
+  it("does not apply auto-height by default", () => {
+    const { container } = render(
+      <DsStarcraftUnitCard card={roach} cardTypeDef={cardTypeDef} cardStyle={{}} faction={zergFaction} />,
+    );
+    expect(container.querySelector(".ds-starcraft-card.auto-height")).toBeNull();
+  });
+
+  it("applies auto-height class when card.styling.autoHeight is true", () => {
+    const cardWithAutoHeight = { ...roach, styling: { autoHeight: true } };
+    const { container } = render(
+      <DsStarcraftUnitCard card={cardWithAutoHeight} cardTypeDef={cardTypeDef} cardStyle={{}} faction={zergFaction} />,
+    );
+    expect(container.querySelector(".ds-starcraft-card.auto-height")).toBeTruthy();
+  });
+
   it("accepts native abilities format (object keyed by category)", () => {
     const cardWithNative = {
       ...roach,

--- a/src/Components/DatasourceEditor/cards/starcraft/StarcraftAbility.jsx
+++ b/src/Components/DatasourceEditor/cards/starcraft/StarcraftAbility.jsx
@@ -6,7 +6,7 @@ const renderCostChips = (costs) => {
   return costs.map((cost, idx) => {
     if (!cost || cost.amount === "" || cost.amount === null || cost.amount === undefined) return null;
     const unit = (cost.unit || "").toUpperCase();
-    const chipClass = ["CP", "BM"].includes(unit) ? `sc-chip-${unit}` : "sc-chip-generic";
+    const chipClass = ["CP", "BM", "VP", "PE"].includes(unit) ? `sc-chip-${unit}` : "sc-chip-generic";
     return (
       <span key={`${idx}-${unit}`} className={`sc-chip ${chipClass}`}>
         {cost.amount} {unit}

--- a/src/Components/DatasourceEditor/editors/AbilitiesSchemaEditor.jsx
+++ b/src/Components/DatasourceEditor/editors/AbilitiesSchemaEditor.jsx
@@ -197,7 +197,7 @@ export const AbilitiesSchemaEditor = ({ schema, onChange, baseSystem }) => {
                   <CompactInput
                     label={<IconCoin size={10} stroke={1.5} />}
                     ariaLabel="Cost chip"
-                    tooltip="Show CP / BM cost chip"
+                    tooltip="Show CP / BM / VP / PE cost chip"
                     type="toggle"
                     value={category.hasCost !== false}
                     onChange={(val) => updateCategory(index, "hasCost", val)}

--- a/src/Components/DatasourceEditor/editors/MetadataSchemaEditor.jsx
+++ b/src/Components/DatasourceEditor/editors/MetadataSchemaEditor.jsx
@@ -10,6 +10,7 @@ import {
   IconTag,
   IconShield,
   IconSword,
+  IconResize,
 } from "@tabler/icons-react";
 import { Section, CompactInput } from "../components";
 import { Tooltip } from "../../Tooltip/Tooltip";
@@ -101,6 +102,16 @@ export const MetadataSchemaEditor = ({ schema, onChange, baseSystem }) => {
         value={!!metadata.hasArmySlot}
         onChange={(val) => updateMetadata({ hasArmySlot: val })}
       />
+      {baseSystem === "starcraft-tmg" && (
+        <CompactInput
+          label={<IconResize size={10} stroke={1.5} />}
+          ariaLabel="Auto-resize"
+          tooltip="Allow per-card toggle to auto-resize the card height to fit its content"
+          type="toggle"
+          value={!!metadata.hasAutoResize}
+          onChange={(val) => updateMetadata({ hasAutoResize: val })}
+        />
+      )}
       <CompactInput
         label={<IconCoin size={10} stroke={1.5} />}
         ariaLabel="Points cost"

--- a/src/Components/DatasourceEditor/editors/__tests__/MetadataSchemaEditor.test.jsx
+++ b/src/Components/DatasourceEditor/editors/__tests__/MetadataSchemaEditor.test.jsx
@@ -231,4 +231,27 @@ describe("MetadataSchemaEditor", () => {
       );
     });
   });
+
+  describe("auto-resize toggle (Starcraft TMG only)", () => {
+    it("hides the auto-resize toggle when baseSystem is not starcraft-tmg", () => {
+      render(<MetadataSchemaEditor schema={mockSchema} onChange={vi.fn()} baseSystem="40k-10e" />);
+      expect(screen.queryByLabelText("Auto-resize")).not.toBeInTheDocument();
+    });
+
+    it("shows the auto-resize toggle when baseSystem is starcraft-tmg", () => {
+      render(<MetadataSchemaEditor schema={mockSchema} onChange={vi.fn()} baseSystem="starcraft-tmg" />);
+      expect(screen.getByLabelText("Auto-resize")).toBeInTheDocument();
+    });
+
+    it("toggles hasAutoResize on checkbox change", () => {
+      const onChange = vi.fn();
+      render(<MetadataSchemaEditor schema={mockSchema} onChange={onChange} baseSystem="starcraft-tmg" />);
+      fireEvent.click(screen.getByLabelText("Auto-resize"));
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ hasAutoResize: true }),
+        }),
+      );
+    });
+  });
 });

--- a/src/Helpers/__tests__/customSchema.helpers.test.js
+++ b/src/Helpers/__tests__/customSchema.helpers.test.js
@@ -4,6 +4,7 @@ import {
   VALID_FIELD_TYPES,
   VALID_BASE_SYSTEMS,
   VALID_ABILITY_FORMATS,
+  VALID_ABILITY_COST_UNITS,
   VALID_POINTS_FORMATS,
   VALID_SECTION_FORMATS,
   SCHEMA_VERSION,
@@ -42,6 +43,10 @@ describe("customSchema.helpers - constants", () => {
 
   it("defines valid points formats", () => {
     expect(VALID_POINTS_FORMATS).toEqual(["per-model", "per-unit"]);
+  });
+
+  it("defines valid ability cost units (Starcraft TMG)", () => {
+    expect(VALID_ABILITY_COST_UNITS).toEqual(["CP", "BM", "VP", "PE"]);
   });
 
   it("defines schema version", () => {
@@ -415,6 +420,11 @@ describe("customSchema.helpers - createStarcraftTmgPreset", () => {
     expect(unit.schema.sections.sections).toEqual([]);
     expect(unit.schema.metadata.hasKeywords).toBe(true);
     expect(unit.schema.metadata.hasFactionKeywords).toBe(true);
+  });
+
+  it("opts into per-card auto-resize via metadata.hasAutoResize", () => {
+    const unit = createStarcraftTmgPreset().cardTypes[0];
+    expect(unit.schema.metadata.hasAutoResize).toBe(true);
   });
 
   it("passes validateSchema", () => {

--- a/src/Helpers/customSchema.helpers.js
+++ b/src/Helpers/customSchema.helpers.js
@@ -45,7 +45,7 @@ export const VALID_PROFILE_RELATIONS = ["equal", "parent-child"];
 export const VALID_ABILITY_TYPES = ["PASSIVE", "ACTIVE", "REACTION"];
 
 // Valid ability cost units (Starcraft TMG chip units)
-export const VALID_ABILITY_COST_UNITS = ["CP", "BM", "VP"];
+export const VALID_ABILITY_COST_UNITS = ["CP", "BM", "VP", "PE"];
 
 // Valid points formats
 export const VALID_POINTS_FORMATS = ["per-model", "per-unit"];
@@ -164,6 +164,7 @@ export const DEFAULT_DATASOURCE_COLOURS = Object.freeze({ header: "#1a1a2e", ban
  * @property {string} [factionKeywordsLabel] - Display label for the faction keywords bar (defaults to "Faction")
  * @property {boolean} hasPoints - Whether cards have points costs
  * @property {PointsFormat} pointsFormat - Points display format
+ * @property {boolean} [hasAutoResize] - Whether cards can opt into auto-resizing height to fit content (Starcraft TMG)
  */
 
 /**
@@ -1340,6 +1341,7 @@ export const createStarcraftTmgPreset = () => ({
           pointsLabel: "Models / Supply",
           hasCombatRole: true,
           hasArmySlot: true,
+          hasAutoResize: true,
         },
       },
     },

--- a/src/styles/starcraft-tmg.less
+++ b/src/styles/starcraft-tmg.less
@@ -29,6 +29,8 @@
   --sc-pill-reaction: #f3a623;
   --sc-chip-cp: #2eb24a;
   --sc-chip-bm: #2c79d6;
+  --sc-chip-vp: #a855f7;
+  --sc-chip-pe: #f5b400;
   --sc-chip-generic: #6b7280;
 
   font-family: "Inter", system-ui, sans-serif;
@@ -56,6 +58,27 @@
 
     @media print {
       transform-origin: 0 0;
+    }
+
+    // Auto-resize card height — opt-in flag (`card.styling.autoHeight`).
+    // The header stays absolute (top-anchored). The image rail anchors
+    // `bottom: 0` so it stretches with the card. The body switches to
+    // `position: relative` and uses margins to preserve the desktop offsets,
+    // letting the card grow vertically with its content while still keeping
+    // the standard 714px frame as a minimum.
+    &.auto-height {
+      height: auto;
+      min-height: 714px;
+      overflow: visible;
+
+      .sc-body {
+        position: relative;
+        top: auto;
+        left: auto;
+        right: auto;
+        bottom: auto;
+        margin: 116px 14px 14px 260px;
+      }
     }
   }
 
@@ -633,6 +656,13 @@
     }
     &.sc-chip-BM {
       background: var(--sc-chip-bm);
+    }
+    &.sc-chip-VP {
+      background: var(--sc-chip-vp);
+    }
+    &.sc-chip-PE {
+      background: var(--sc-chip-pe);
+      color: #1a1a2e;
     }
     &.sc-chip-generic {
       background: var(--sc-chip-generic);


### PR DESCRIPTION
## Summary
This PR extends Starcraft TMG support by adding two new ability cost chip units (VP and PE) and implementing an optional auto-height card resizing feature that allows cards to grow vertically to fit their content.

## Key Changes

- **New Ability Cost Units**: Added `VP` (purple, #a855f7) and `PE` (gold, #f5b400) chip colors to complement existing `CP` (green) and `BM` (blue) units
  - Updated `VALID_ABILITY_COST_UNITS` constant to include both new units
  - Added corresponding CSS color variables and styling rules
  - Updated ability cost chip rendering logic to recognize all four units
  - Updated documentation and tooltips to reflect all available cost units

- **Auto-Height Card Resizing**: Implemented opt-in per-card height auto-resizing for Starcraft TMG
  - Added `hasAutoResize` metadata flag to the Starcraft TMG preset (enabled by default)
  - Added UI toggle in MetadataSchemaEditor to control the feature per datasource
  - Implemented CSS `.auto-height` class that switches card body to relative positioning with margins, allowing vertical growth while maintaining 714px minimum height
  - Card applies auto-height class when `card.styling.autoHeight` is true

- **Tests**: Added comprehensive test coverage for both features
  - Tests for auto-resize toggle visibility based on baseSystem
  - Tests for auto-height class application on cards
  - Tests for new ability cost unit constant

## Implementation Details

The auto-height implementation uses a clever CSS approach: the card header remains absolutely positioned at the top, the image rail anchors to `bottom: 0` to stretch with the card, and the body switches to `position: relative` with margins to preserve desktop layout offsets while allowing the card to grow vertically with its content.

https://claude.ai/code/session_016Ri47u4BNpPqxjk9LGhDaq