### PR TITLE
Fix SC2 auto-resize card content overlapping the header

### DIFF
--- a/src/styles/starcraft-tmg.less
+++ b/src/styles/starcraft-tmg.less
@@ -65,8 +65,11 @@
     // `bottom: 0` so it stretches with the card. The body switches to
     // `position: relative` and uses margins to preserve the desktop offsets,
     // letting the card grow vertically with its content while still keeping
-    // the standard 714px frame as a minimum.
+    // the standard 714px frame as a minimum. `display: flow-root` establishes
+    // a new block formatting context so the body's `margin-top` does not
+    // collapse into the card and slide the content under the header.
     &.auto-height {
+      display: flow-root;
       height: auto;
       min-height: 714px;
       overflow: visible;


### PR DESCRIPTION
## Summary

Follow-up to #212. When the per-card "Auto-resize card" toggle was switched on, the body content slid up under the header — the SPECIAL ABILITIES heading and the first few ability rows ended up hidden behind the absolute-positioned header bar.

## Cause

`.sc-body` switches to `position: relative` with `margin-top: 116px` in the `auto-height` modifier. `.ds-starcraft-card` has no top padding or border, so the body's top margin collapsed into the parent: the body started at the top of the card instead of 116px down, and the absolute header overlapped it.

## Fix

Add `display: flow-root` to `.ds-starcraft-card.auto-height`. That establishes a new block formatting context, which prevents the margin-top of `.sc-body` from collapsing into the card. The body now sits below the header as intended and the card grows downward to fit overflowing content.

## Test plan

- [x] `yarn lint`
- [x] `yarn test:ci` — all 138 files / 2534 tests pass
- [ ] Manual: reload `/datasources` with the SC2 datasource, toggle "Auto-resize card" on for a content-heavy unit; the SPECIAL ABILITIES heading and all ability rows are visible, the card grows below the standard 714px frame, and the toggle-off state is unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_016Ri47u4BNpPqxjk9LGhDaq)_