### PR TITLE
Add auto-resize support for 40k-10e system

### DIFF
--- a/docs/custom datasource/datasource-schema-architecture.md
+++ b/docs/custom datasource/datasource-schema-architecture.md
@@ -299,7 +299,7 @@ Sections are optional content blocks rendered below weapons on unit cards. Each 
 | `pointsFormat`     | string  | `"per-model"` or `"per-unit"`. Only applies when `hasPoints` is true.  |
 | `bannerType`       | string  | Controls the header banner text. Only applies when `baseSystem` is not `"40k-10e"`. |
 | `bannerCustomText` | string  | Custom banner text. Only applies when `bannerType` is `"custom"`.       |
-| `hasAutoResize`    | boolean | Starcraft TMG only. Exposes a per-card "Auto-resize card" toggle in the Basic Information panel. When the card sets `styling.autoHeight = true`, the rendered card grows beyond its standard 714px frame to fit overflowing content. |
+| `hasAutoResize`    | boolean | Starcraft TMG and 40k-10e only. Exposes a per-card "Auto-resize card" toggle in the Basic Information panel. When the card sets `styling.autoHeight = true`, the rendered card grows beyond its standard 714px frame to fit overflowing content. |
 
 #### Banner type values (AoS / non-40k only)
 

--- a/src/Components/DatasourceEditor/cards/Ds40kUnitCard.jsx
+++ b/src/Components/DatasourceEditor/cards/Ds40kUnitCard.jsx
@@ -66,10 +66,15 @@ export const Ds40kUnitCard = ({ card, cardTypeDef, cardStyle, isMobile }) => {
   // Support invulnerable save from both flat and nested abilities format
   const invul = Array.isArray(card.abilities) ? null : card.abilities?.invul;
 
+  const autoHeight = !!card.styling?.autoHeight;
+
   return (
     <div className="data-40k-10e" data-testid="ds-40k-unit">
       <div className={`unit-card-front-wrapper ds-unit${isMobile ? " viewer" : ""}`} style={cardStyle}>
-        <div className="unit front" data-name={card.name} data-fullname={`${card.name} ${card.subname || ""}`}>
+        <div
+          className={`unit front${autoHeight ? " auto-height" : ""}`}
+          data-name={card.name}
+          data-fullname={`${card.name} ${card.subname || ""}`}>
           <div className="header">
             <UnitName
               name={card.name || "Untitled Unit"}

--- a/src/Components/DatasourceEditor/cards/Ds40kUnitCard.jsx
+++ b/src/Components/DatasourceEditor/cards/Ds40kUnitCard.jsx
@@ -66,7 +66,7 @@ export const Ds40kUnitCard = ({ card, cardTypeDef, cardStyle, isMobile }) => {
   // Support invulnerable save from both flat and nested abilities format
   const invul = Array.isArray(card.abilities) ? null : card.abilities?.invul;
 
-  const autoHeight = !!card.styling?.autoHeight;
+  const autoHeight = card.styling?.autoHeight;
 
   return (
     <div className="data-40k-10e" data-testid="ds-40k-unit">

--- a/src/Components/DatasourceEditor/cards/__tests__/Ds40kUnitCard.test.jsx
+++ b/src/Components/DatasourceEditor/cards/__tests__/Ds40kUnitCard.test.jsx
@@ -185,4 +185,16 @@ describe("Ds40kUnitCard", () => {
     const { container } = render(<Ds40kUnitCard card={card} cardTypeDef={cardTypeDef} cardStyle={{}} isMobile />);
     expect(container.querySelector(".unit-card-front-wrapper.ds-unit.viewer")).toBeTruthy();
   });
+
+  it("does not apply auto-height by default", () => {
+    const card = { name: "Unit", stats: [], abilities: [] };
+    const { container } = render(<Ds40kUnitCard card={card} cardTypeDef={cardTypeDef} cardStyle={{}} />);
+    expect(container.querySelector(".unit.front.auto-height")).toBeNull();
+  });
+
+  it("applies auto-height class when card.styling.autoHeight is true", () => {
+    const card = { name: "Unit", stats: [], abilities: [], styling: { autoHeight: true } };
+    const { container } = render(<Ds40kUnitCard card={card} cardTypeDef={cardTypeDef} cardStyle={{}} />);
+    expect(container.querySelector(".unit.front.auto-height")).toBeTruthy();
+  });
 });

--- a/src/Components/DatasourceEditor/editors/MetadataSchemaEditor.jsx
+++ b/src/Components/DatasourceEditor/editors/MetadataSchemaEditor.jsx
@@ -102,7 +102,7 @@ export const MetadataSchemaEditor = ({ schema, onChange, baseSystem }) => {
         value={!!metadata.hasArmySlot}
         onChange={(val) => updateMetadata({ hasArmySlot: val })}
       />
-      {baseSystem === "starcraft-tmg" && (
+      {(baseSystem === "starcraft-tmg" || baseSystem === "40k-10e") && (
         <CompactInput
           label={<IconResize size={10} stroke={1.5} />}
           ariaLabel="Auto-resize"

--- a/src/Components/DatasourceEditor/editors/__tests__/MetadataSchemaEditor.test.jsx
+++ b/src/Components/DatasourceEditor/editors/__tests__/MetadataSchemaEditor.test.jsx
@@ -232,9 +232,9 @@ describe("MetadataSchemaEditor", () => {
     });
   });
 
-  describe("auto-resize toggle (Starcraft TMG only)", () => {
-    it("hides the auto-resize toggle when baseSystem is not starcraft-tmg", () => {
-      render(<MetadataSchemaEditor schema={mockSchema} onChange={vi.fn()} baseSystem="40k-10e" />);
+  describe("auto-resize toggle (Starcraft TMG and 40k-10e)", () => {
+    it("hides the auto-resize toggle when baseSystem is not starcraft-tmg or 40k-10e", () => {
+      render(<MetadataSchemaEditor schema={mockSchema} onChange={vi.fn()} baseSystem="aos" />);
       expect(screen.queryByLabelText("Auto-resize")).not.toBeInTheDocument();
     });
 
@@ -243,9 +243,25 @@ describe("MetadataSchemaEditor", () => {
       expect(screen.getByLabelText("Auto-resize")).toBeInTheDocument();
     });
 
-    it("toggles hasAutoResize on checkbox change", () => {
+    it("shows the auto-resize toggle when baseSystem is 40k-10e", () => {
+      render(<MetadataSchemaEditor schema={mockSchema} onChange={vi.fn()} baseSystem="40k-10e" />);
+      expect(screen.getByLabelText("Auto-resize")).toBeInTheDocument();
+    });
+
+    it("toggles hasAutoResize on checkbox change (starcraft-tmg)", () => {
       const onChange = vi.fn();
       render(<MetadataSchemaEditor schema={mockSchema} onChange={onChange} baseSystem="starcraft-tmg" />);
+      fireEvent.click(screen.getByLabelText("Auto-resize"));
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ hasAutoResize: true }),
+        }),
+      );
+    });
+
+    it("toggles hasAutoResize on checkbox change (40k-10e)", () => {
+      const onChange = vi.fn();
+      render(<MetadataSchemaEditor schema={mockSchema} onChange={onChange} baseSystem="40k-10e" />);
       fireEvent.click(screen.getByLabelText("Auto-resize"));
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/Helpers/customSchema.helpers.js
+++ b/src/Helpers/customSchema.helpers.js
@@ -164,7 +164,7 @@ export const DEFAULT_DATASOURCE_COLOURS = Object.freeze({ header: "#1a1a2e", ban
  * @property {string} [factionKeywordsLabel] - Display label for the faction keywords bar (defaults to "Faction")
  * @property {boolean} hasPoints - Whether cards have points costs
  * @property {PointsFormat} pointsFormat - Points display format
- * @property {boolean} [hasAutoResize] - Whether cards can opt into auto-resizing height to fit content (Starcraft TMG)
+ * @property {boolean} [hasAutoResize] - Whether cards can opt into auto-resizing height to fit content (Starcraft TMG, 40k-10e)
  */
 
 /**

--- a/src/styles/40k-10e.less
+++ b/src/styles/40k-10e.less
@@ -2102,7 +2102,8 @@
         }
       }
     }
-    &.full {
+    &.full,
+    &.auto-height {
       height: auto;
       min-height: calc(714px);
       margin-bottom: 64px;


### PR DESCRIPTION
## Summary
Extends the auto-resize card height feature to support the 40k-10e system in addition to Starcraft TMG. This allows 40k-10e datasources to expose a per-card "Auto-resize card" toggle that enables cards to grow beyond their standard 714px frame to fit overflowing content.

## Key Changes
- **MetadataSchemaEditor**: Updated the conditional to show the auto-resize toggle for both `starcraft-tmg` and `40k-10e` base systems
- **Ds40kUnitCard**: Added logic to apply the `auto-height` CSS class when `card.styling.autoHeight` is true
- **Styling**: Extended the `.auto-height` selector in 40k-10e.less to work alongside the existing `.full` selector for dynamic height adjustment
- **Documentation**: Updated schema documentation to reflect that `hasAutoResize` now applies to both Starcraft TMG and 40k-10e systems
- **Tests**: Added comprehensive test coverage for:
  - Visibility of auto-resize toggle for 40k-10e system
  - Auto-height class application based on card styling
  - Toggle functionality for both supported systems

## Implementation Details
The auto-resize feature works by:
1. Exposing a metadata flag `hasAutoResize` in the datasource schema editor
2. Allowing individual cards to set `styling.autoHeight = true`
3. Applying the `auto-height` CSS class which sets `height: auto` and `min-height: 714px`, allowing the card to expand as needed

https://claude.ai/code/session_01T4AgGffKUc8WD11bCQXTiR