### PR TITLE
Forward custom schema flags to mobile editor sections

### DIFF
--- a/src/Components/Viewer/MobileEditor/MobileCardEditor.css
+++ b/src/Components/Viewer/MobileEditor/MobileCardEditor.css
@@ -969,6 +969,70 @@
 }
 
 /* ===========================================
+   CHIP LIST (ability costs, etc.)
+   =========================================== */
+.mobile-editor-chip-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.mobile-editor-chip-amount {
+  flex: 1;
+}
+
+.mobile-editor-chip-unit {
+  width: 90px;
+  flex-shrink: 0;
+}
+
+/* ===========================================
+   MODELS/SUPPLY TIER ROW
+   =========================================== */
+.mobile-editor-tier-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.mobile-editor-tier-row .mobile-editor-stat-cell {
+  flex: 1;
+}
+
+/* ===========================================
+   COLOR PICKER (ability strip colour)
+   =========================================== */
+.mobile-editor-color-input {
+  width: 44px;
+  height: 36px;
+  padding: 0;
+  border: 1px solid var(--me-border);
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+}
+
+/* ===========================================
+   PARENT-CHILD PROFILE INDICATOR
+   =========================================== */
+.mobile-editor-profile-item--upgrade {
+  margin-left: 16px;
+  position: relative;
+}
+
+.mobile-editor-profile-item--upgrade::before {
+  content: "";
+  position: absolute;
+  left: -10px;
+  top: 50%;
+  width: 8px;
+  height: 1px;
+  background: var(--me-border);
+}
+
+/* ===========================================
    REDUCED MOTION
    =========================================== */
 @media (prefers-reduced-motion: reduce) {

--- a/src/Components/Viewer/MobileEditor/__tests__/editorSchemaResolvers.test.js
+++ b/src/Components/Viewer/MobileEditor/__tests__/editorSchemaResolvers.test.js
@@ -283,4 +283,157 @@ describe("editorSchemaResolvers", () => {
       expect(sections[0].type).toBe("name");
     });
   });
+
+  describe("custom schema flag forwarding", () => {
+    const schemaWithFlags = {
+      version: "1.0.0",
+      baseSystem: "starcraft-tmg",
+      cardTypes: [
+        {
+          key: "unit",
+          label: "Unit",
+          baseType: "unit",
+          schema: {
+            stats: {
+              label: "Stats",
+              allowMultipleProfiles: false,
+              fields: [{ key: "hp", label: "HP", type: "string" }],
+            },
+            weaponTypes: {
+              label: "Weapons",
+              types: [
+                {
+                  key: "assault",
+                  label: "Assault Phase",
+                  hasKeywords: false,
+                  hasProfiles: true,
+                  profileRelation: "parent-child",
+                  profileChildLabel: "Upgrade",
+                  phaseStyle: "assault",
+                  linkedAbilityCategory: "assault",
+                  columns: [{ key: "rng", label: "RNG", type: "string" }],
+                },
+              ],
+            },
+            abilities: {
+              label: "Abilities",
+              categories: [
+                {
+                  key: "movement",
+                  label: "Movement",
+                  format: "name-description",
+                  layout: "half",
+                  phaseStyle: "movement",
+                  hasType: true,
+                  hasCost: true,
+                  hasTriggerIcon: true,
+                },
+              ],
+            },
+            sections: {
+              label: "Sections",
+              sections: [{ key: "tiers", label: "Models / Supply", format: "modelsSupplyTiers" }],
+            },
+            metadata: {
+              hasKeywords: true,
+              hasFactionKeywords: true,
+              keywordsLabel: "Tags",
+              factionKeywordsLabel: "Race",
+              hasPoints: true,
+              pointsFormat: "per-unit",
+              pointsLabel: "Models / Supply",
+              hasCombatRole: true,
+              hasArmySlot: true,
+              hasAutoResize: true,
+            },
+          },
+        },
+      ],
+    };
+    const card = { name: "Marine", cardType: "unit" };
+
+    it("surfaces metadata flags on the name section", () => {
+      const sections = resolveEditorSections(card, "my-ds", schemaWithFlags);
+      const nameSection = sections.find((s) => s.type === "name");
+      expect(nameSection.config.hasCombatRole).toBe(true);
+      expect(nameSection.config.hasArmySlot).toBe(true);
+      expect(nameSection.config.hasAutoResize).toBe(true);
+    });
+
+    it("forwards ability category flags (hasType / hasCost / hasTriggerIcon / layout / phaseStyle)", () => {
+      const sections = resolveEditorSections(card, "my-ds", schemaWithFlags);
+      const abilities = sections.find((s) => s.type === "abilities");
+      const cat = abilities.config.categories[0];
+      expect(cat.hasType).toBe(true);
+      expect(cat.hasCost).toBe(true);
+      expect(cat.hasTriggerIcon).toBe(true);
+      expect(cat.layout).toBe("half");
+      expect(cat.phaseStyle).toBe("movement");
+    });
+
+    it("forwards weapon profile relation and child label", () => {
+      const sections = resolveEditorSections(card, "my-ds", schemaWithFlags);
+      const weapons = sections.find((s) => s.type === "weapons");
+      const wt = weapons.config.types[0];
+      expect(wt.hasProfiles).toBe(true);
+      expect(wt.profileRelation).toBe("parent-child");
+      expect(wt.profileChildLabel).toBe("Upgrade");
+      expect(wt.phaseStyle).toBe("assault");
+      expect(wt.linkedAbilityCategory).toBe("assault");
+    });
+
+    it("forwards keyword labels and points label", () => {
+      const sections = resolveEditorSections(card, "my-ds", schemaWithFlags);
+      const keywords = sections.find((s) => s.type === "keywords");
+      expect(keywords.config.keywordsLabel).toBe("Tags");
+      expect(keywords.config.factionKeywordsLabel).toBe("Race");
+      const points = sections.find((s) => s.type === "points");
+      expect(points.label).toBe("Models / Supply");
+      expect(points.config.pointsLabel).toBe("Models / Supply");
+    });
+
+    it("preserves section format (modelsSupplyTiers, richtext, list) on custom sections", () => {
+      const sections = resolveEditorSections(card, "my-ds", schemaWithFlags);
+      const custom = sections.find((s) => s.type === "customSections");
+      expect(custom.config.sections[0].format).toBe("modelsSupplyTiers");
+    });
+  });
+
+  describe("custom datasource without metadata flags", () => {
+    const minimalSchema = {
+      version: "1.0.0",
+      baseSystem: "blank",
+      cardTypes: [
+        {
+          key: "unit",
+          label: "Unit",
+          baseType: "unit",
+          schema: {
+            stats: { label: "Stats", allowMultipleProfiles: false, fields: [{ key: "str", label: "STR" }] },
+            weaponTypes: { label: "Weapons", types: [{ key: "w", label: "W", columns: [] }] },
+            abilities: { label: "A", categories: [{ key: "c", label: "C", format: "name-description" }] },
+            metadata: { hasKeywords: false, hasFactionKeywords: false, hasPoints: false, pointsFormat: "per-unit" },
+          },
+        },
+      ],
+    };
+    const card = { name: "X", cardType: "unit" };
+
+    it("emits all category flags as explicit false rather than undefined", () => {
+      const sections = resolveEditorSections(card, "x", minimalSchema);
+      const cat = sections.find((s) => s.type === "abilities").config.categories[0];
+      expect(cat.hasType).toBe(false);
+      expect(cat.hasCost).toBe(false);
+      expect(cat.hasTriggerIcon).toBe(false);
+      expect(cat.hasPhase).toBe(false);
+      expect(cat.hasColor).toBe(false);
+    });
+
+    it("does not include keywords or points sections when metadata disables them", () => {
+      const sections = resolveEditorSections(card, "x", minimalSchema);
+      const types = sections.map((s) => s.type);
+      expect(types).not.toContain("keywords");
+      expect(types).not.toContain("points");
+    });
+  });
 });

--- a/src/Components/Viewer/MobileEditor/editorSchemaResolvers.js
+++ b/src/Components/Viewer/MobileEditor/editorSchemaResolvers.js
@@ -378,12 +378,63 @@ function resolveAosSections(card) {
   return sections;
 }
 
+// Pull category fields onto the editor section in a stable, lossless shape.
+// Forwards every schema flag the desktop SchemaAbilitiesEditor reads so the
+// mobile AbilitiesCustom branch can offer identical controls.
+function mapAbilityCategory(cat) {
+  return {
+    key: cat.key,
+    label: cat.label,
+    format: cat.format || "name-description",
+    layout: cat.layout,
+    phaseStyle: cat.phaseStyle,
+    header: cat.header,
+    hasType: !!cat.hasType,
+    typeOptions: cat.typeOptions,
+    hasCost: !!cat.hasCost,
+    hasCostUnits: cat.hasCostUnits,
+    costUnitOptions: cat.costUnitOptions,
+    hasTriggerIcon: !!cat.hasTriggerIcon,
+    hasPhase: !!cat.hasPhase,
+    hasColor: !!cat.hasColor,
+  };
+}
+
+// Forward weapon-type definition fields the mobile editor reacts to (profile
+// relation, profile child label, phase style, linked ability category).
+function mapWeaponType(wt) {
+  return {
+    key: wt.key,
+    label: wt.label,
+    columns: wt.columns || [],
+    hasKeywords: wt.hasKeywords,
+    hasProfiles: !!wt.hasProfiles,
+    profileRelation: wt.profileRelation,
+    profileChildLabel: wt.profileChildLabel,
+    phaseStyle: wt.phaseStyle,
+    linkedAbilityCategory: wt.linkedAbilityCategory,
+  };
+}
+
 function resolveCustomSections(card, schema) {
   const cardTypeDef = schema.cardTypes?.find((ct) => ct.key === card.cardType);
   if (!cardTypeDef) return resolveGenericSections(card);
 
-  const sections = [{ key: "name", label: "Name", type: "name", config: {} }];
   const s = cardTypeDef.schema;
+  const metadata = s?.metadata || {};
+
+  const sections = [
+    {
+      key: "name",
+      label: "Name",
+      type: "name",
+      config: {
+        hasCombatRole: !!metadata.hasCombatRole,
+        hasArmySlot: !!metadata.hasArmySlot,
+        hasAutoResize: !!metadata.hasAutoResize,
+      },
+    },
+  ];
 
   if (cardTypeDef.baseType === "unit") {
     // Stats
@@ -402,18 +453,11 @@ function resolveCustomSections(card, schema) {
 
     // Weapons
     if (s.weaponTypes?.types?.length) {
-      const types = s.weaponTypes.types.map((wt) => ({
-        key: wt.key,
-        label: wt.label,
-        columns: wt.columns || [],
-        hasKeywords: wt.hasKeywords,
-        hasProfiles: wt.hasProfiles,
-      }));
       sections.push({
         key: "weapons",
         label: s.weaponTypes.label || "Weapons",
         type: "weapons",
-        config: { types, format: "custom" },
+        config: { types: s.weaponTypes.types.map(mapWeaponType), format: "custom" },
       });
     }
 
@@ -425,11 +469,7 @@ function resolveCustomSections(card, schema) {
         type: "abilities",
         config: {
           format: "custom",
-          categories: s.abilities.categories.map((cat) => ({
-            key: cat.key,
-            label: cat.label,
-            format: cat.format || "name-description",
-          })),
+          categories: s.abilities.categories.map(mapAbilityCategory),
         },
       });
     }
@@ -445,25 +485,27 @@ function resolveCustomSections(card, schema) {
     }
 
     // Keywords
-    if (s.metadata?.hasKeywords || s.metadata?.hasFactionKeywords) {
+    if (metadata.hasKeywords || metadata.hasFactionKeywords) {
       sections.push({
         key: "keywords",
         label: "Keywords",
         type: "keywords",
         config: {
-          keywordsPath: s.metadata?.hasKeywords ? "keywords" : null,
-          factionKeywordsPath: s.metadata?.hasFactionKeywords ? "factionKeywords" : null,
+          keywordsPath: metadata.hasKeywords ? "keywords" : null,
+          factionKeywordsPath: metadata.hasFactionKeywords ? "factionKeywords" : null,
+          keywordsLabel: metadata.keywordsLabel,
+          factionKeywordsLabel: metadata.factionKeywordsLabel,
         },
       });
     }
 
     // Points
-    if (s.metadata?.hasPoints) {
+    if (metadata.hasPoints) {
       sections.push({
         key: "points",
-        label: "Points",
+        label: metadata.pointsLabel || "Points",
         type: "points",
-        config: { format: s.metadata.pointsFormat || "per-unit" },
+        config: { format: metadata.pointsFormat || "per-unit", pointsLabel: metadata.pointsLabel },
       });
     }
   } else {

--- a/src/Components/Viewer/MobileEditor/sections/AbilitiesSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/AbilitiesSection.jsx
@@ -385,10 +385,8 @@ const AbilitiesCustom = ({ card, label, icon, replaceCard, config }) => {
                     <label className="mobile-editor-field-label">Strip Color</label>
                     <input
                       type="color"
-                      value={ability.color || "#4a5568"}
-                      onChange={(e) =>
-                        handleUpdate(cat.key, index, "color", e.target.value === "#4a5568" ? undefined : e.target.value)
-                      }
+                      value={ability.color ?? "#4a5568"}
+                      onChange={(e) => handleUpdate(cat.key, index, "color", e.target.value)}
                       className="mobile-editor-color-input"
                     />
                   </div>

--- a/src/Components/Viewer/MobileEditor/sections/AbilitiesSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/AbilitiesSection.jsx
@@ -3,7 +3,10 @@ import { EditorAccordion } from "../shared/EditorAccordion";
 import { EditorTextField } from "../shared/EditorTextField";
 import { EditorSelectField } from "../shared/EditorSelectField";
 import { EditorTagInput } from "../shared/EditorTagInput";
+import { EditorToggle } from "../shared/EditorToggle";
+import { EditorChipListField } from "../shared/EditorChipListField";
 import { AOS_PHASE_OPTIONS, AOS_ICON_OPTIONS } from "../../../AgeOfSigmar/constants";
+import { VALID_ABILITY_TYPES, VALID_ABILITY_COST_UNITS } from "../../../../Helpers/customSchema.helpers";
 
 export const AbilitiesSection = ({ card, config, label, icon, updateField, replaceCard }) => {
   const { format } = config;
@@ -231,7 +234,10 @@ const AbilitiesAos = ({ card, label, icon, replaceCard }) => {
   );
 };
 
-// Custom datasource abilities: categorized, format determined by schema
+// Custom datasource abilities: categorized, format and schema flags determined
+// by the resolver's `categories` config. Mirrors the desktop
+// SchemaAbilitiesEditor so the same fields (type/costs/triggered/phase/color)
+// round-trip between mobile and desktop edits.
 const AbilitiesCustom = ({ card, label, icon, replaceCard, config }) => {
   const { categories } = config;
   const abilities = card.abilities || {};
@@ -261,8 +267,12 @@ const AbilitiesCustom = ({ card, label, icon, replaceCard, config }) => {
     }
   };
 
-  const handleAdd = (categoryKey) => {
-    const newItem = { name: "New Ability", description: "" };
+  const handleAdd = (categoryKey, format) => {
+    const newItem = { name: "New Ability", showAbility: true };
+    if (format === "name-description") {
+      newItem.description = "";
+      newItem.showDescription = true;
+    }
     if (isArray) {
       replaceCard({ ...card, abilities: [...abilities, { ...newItem, category: categoryKey }] });
     } else {
@@ -309,6 +319,9 @@ const AbilitiesCustom = ({ card, label, icon, replaceCard, config }) => {
           );
         }
 
+        const typeOptions = (cat.typeOptions || VALID_ABILITY_TYPES).map((t) => ({ value: t, label: t }));
+        const costUnits = cat.costUnitOptions || VALID_ABILITY_COST_UNITS;
+
         return (
           <div key={cat.key} style={{ marginBottom: 16 }}>
             <label className="mobile-editor-field-label">{cat.label}</label>
@@ -328,19 +341,77 @@ const AbilitiesCustom = ({ card, label, icon, replaceCard, config }) => {
                     <Trash2 size={14} />
                   </button>
                 </div>
+                {cat.hasType && (
+                  <EditorSelectField
+                    label="Type pill"
+                    value={ability.type || ""}
+                    onChange={(value) => handleUpdate(cat.key, index, "type", value || undefined)}
+                    options={[{ value: "", label: "None" }, ...typeOptions]}
+                  />
+                )}
+                {cat.hasCost && (
+                  <EditorChipListField
+                    label="Cost chips"
+                    value={ability.costs}
+                    units={costUnits}
+                    onChange={(costs) => handleUpdate(cat.key, index, "costs", costs.length ? costs : undefined)}
+                    addLabel="Add cost"
+                  />
+                )}
+                {cat.hasTriggerIcon && (
+                  <>
+                    <EditorToggle
+                      label="Triggered"
+                      checked={!!ability.triggered}
+                      onChange={(value) => handleUpdate(cat.key, index, "triggered", value || undefined)}
+                    />
+                    <EditorToggle
+                      label="Upgrade"
+                      checked={!!ability.upgrade}
+                      onChange={(value) => handleUpdate(cat.key, index, "upgrade", value || undefined)}
+                    />
+                  </>
+                )}
+                {cat.hasPhase && (
+                  <EditorTextField
+                    label="Phase"
+                    value={ability.phase || ""}
+                    onChange={(value) => handleUpdate(cat.key, index, "phase", value || undefined)}
+                    placeholder="e.g. Hero, Movement, Passive"
+                  />
+                )}
+                {cat.hasColor && (
+                  <div className="mobile-editor-field">
+                    <label className="mobile-editor-field-label">Strip Color</label>
+                    <input
+                      type="color"
+                      value={ability.color || "#4a5568"}
+                      onChange={(e) =>
+                        handleUpdate(cat.key, index, "color", e.target.value === "#4a5568" ? undefined : e.target.value)
+                      }
+                      className="mobile-editor-color-input"
+                    />
+                  </div>
+                )}
                 {ability.description !== undefined && (
                   <EditorTextField
+                    label="Description"
                     value={ability.description}
                     onChange={(value) => handleUpdate(cat.key, index, "description", value)}
                     placeholder="Description"
                     multiline
                   />
                 )}
+                <EditorToggle
+                  label="Visible"
+                  checked={ability.showAbility !== false}
+                  onChange={(value) => handleUpdate(cat.key, index, "showAbility", value)}
+                />
               </div>
             ))}
-            <button className="mobile-editor-add-btn" onClick={() => handleAdd(cat.key)} type="button">
+            <button className="mobile-editor-add-btn" onClick={() => handleAdd(cat.key, cat.format)} type="button">
               <Plus size={14} />
-              <span>Add</span>
+              <span>Add {cat.label}</span>
             </button>
           </div>
         );

--- a/src/Components/Viewer/MobileEditor/sections/CustomSectionsEditor.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/CustomSectionsEditor.jsx
@@ -1,15 +1,76 @@
 import { Plus, Trash2 } from "lucide-react";
 import { EditorAccordion } from "../shared/EditorAccordion";
 import { EditorTextField } from "../shared/EditorTextField";
+import { EditorNumberField } from "../shared/EditorNumberField";
+
+const ModelsSupplyTiersField = ({ sectionDef, items, onChange }) => {
+  const rows = Array.isArray(items) ? items : [];
+
+  const setRow = (index, patch) => {
+    const next = [...rows];
+    next[index] = { ...(next[index] || {}), ...patch };
+    onChange(next);
+  };
+  const removeRow = (index) => onChange(rows.filter((_, i) => i !== index));
+  const addRow = () => onChange([...rows, { models: "", supply: "0" }]);
+
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <label className="mobile-editor-field-label">{sectionDef.label}</label>
+      {rows.map((row, index) => {
+        const value = typeof row === "object" && row !== null ? row : { models: String(row ?? ""), supply: "0" };
+        return (
+          <div key={index} className="mobile-editor-tier-row">
+            <EditorNumberField
+              label="Models"
+              value={value.models ?? ""}
+              onChange={(models) => setRow(index, { models })}
+            />
+            <EditorNumberField
+              label="Supply"
+              value={value.supply ?? ""}
+              onChange={(supply) => setRow(index, { supply })}
+            />
+            <button className="mobile-editor-weapon-delete" onClick={() => removeRow(index)} type="button">
+              <Trash2 size={14} />
+            </button>
+          </div>
+        );
+      })}
+      <button className="mobile-editor-add-btn" onClick={addRow} type="button">
+        <Plus size={14} />
+        <span>Add tier</span>
+      </button>
+    </div>
+  );
+};
 
 export const CustomSectionsEditor = ({ card, config, label, icon, replaceCard }) => {
   const { sections: sectionDefs } = config;
   const cardSections = card.sections || {};
 
+  const writeSection = (key, value) => {
+    replaceCard({
+      ...card,
+      sections: { ...cardSections, [key]: value },
+    });
+  };
+
   return (
     <EditorAccordion title={label} icon={icon}>
       {sectionDefs.map((sectionDef) => {
         const items = cardSections[sectionDef.key] || [];
+
+        if (sectionDef.format === "modelsSupplyTiers") {
+          return (
+            <ModelsSupplyTiersField
+              key={sectionDef.key}
+              sectionDef={sectionDef}
+              items={items}
+              onChange={(value) => writeSection(sectionDef.key, value)}
+            />
+          );
+        }
 
         if (sectionDef.format === "richtext") {
           return (
@@ -17,12 +78,7 @@ export const CustomSectionsEditor = ({ card, config, label, icon, replaceCard })
               <EditorTextField
                 label={sectionDef.label}
                 value={Array.isArray(items) ? items.join("\n") : items}
-                onChange={(value) => {
-                  replaceCard({
-                    ...card,
-                    sections: { ...cardSections, [sectionDef.key]: value },
-                  });
-                }}
+                onChange={(value) => writeSection(sectionDef.key, value)}
                 placeholder={sectionDef.label}
                 multiline
               />
@@ -41,24 +97,18 @@ export const CustomSectionsEditor = ({ card, config, label, icon, replaceCard })
                   onChange={(value) => {
                     const updated = [...items];
                     updated[index] = value;
-                    replaceCard({
-                      ...card,
-                      sections: { ...cardSections, [sectionDef.key]: updated },
-                    });
+                    writeSection(sectionDef.key, updated);
                   }}
                   placeholder={`${sectionDef.label} item`}
                 />
                 <button
                   className="mobile-editor-weapon-delete"
-                  onClick={() => {
-                    replaceCard({
-                      ...card,
-                      sections: {
-                        ...cardSections,
-                        [sectionDef.key]: items.filter((_, i) => i !== index),
-                      },
-                    });
-                  }}
+                  onClick={() =>
+                    writeSection(
+                      sectionDef.key,
+                      items.filter((_, i) => i !== index),
+                    )
+                  }
                   type="button">
                   <Trash2 size={14} />
                 </button>
@@ -66,12 +116,7 @@ export const CustomSectionsEditor = ({ card, config, label, icon, replaceCard })
             ))}
             <button
               className="mobile-editor-add-btn"
-              onClick={() => {
-                replaceCard({
-                  ...card,
-                  sections: { ...cardSections, [sectionDef.key]: [...items, ""] },
-                });
-              }}
+              onClick={() => writeSection(sectionDef.key, [...items, ""])}
               type="button">
               <Plus size={14} />
               <span>Add Item</span>

--- a/src/Components/Viewer/MobileEditor/sections/CustomSectionsEditor.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/CustomSectionsEditor.jsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from "react";
 import { Plus, Trash2 } from "lucide-react";
 import { EditorAccordion } from "../shared/EditorAccordion";
 import { EditorTextField } from "../shared/EditorTextField";
@@ -6,13 +7,30 @@ import { EditorNumberField } from "../shared/EditorNumberField";
 const ModelsSupplyTiersField = ({ sectionDef, items, onChange }) => {
   const rows = Array.isArray(items) ? items : [];
 
+  // Stable keys so removing a tier from the middle doesn't reuse the deleted row's DOM.
+  const counterRef = useRef(0);
+  const [keys, setKeys] = useState(() => rows.map(() => `tier-${counterRef.current++}`));
+  if (keys.length < rows.length) {
+    const next = [...keys];
+    while (next.length < rows.length) next.push(`tier-${counterRef.current++}`);
+    setKeys(next);
+  } else if (keys.length > rows.length) {
+    setKeys(keys.slice(0, rows.length));
+  }
+
   const setRow = (index, patch) => {
     const next = [...rows];
     next[index] = { ...(next[index] || {}), ...patch };
     onChange(next);
   };
-  const removeRow = (index) => onChange(rows.filter((_, i) => i !== index));
-  const addRow = () => onChange([...rows, { models: "", supply: "0" }]);
+  const removeRow = (index) => {
+    setKeys((prev) => prev.filter((_, i) => i !== index));
+    onChange(rows.filter((_, i) => i !== index));
+  };
+  const addRow = () => {
+    setKeys((prev) => [...prev, `tier-${counterRef.current++}`]);
+    onChange([...rows, { models: "", supply: "0" }]);
+  };
 
   return (
     <div style={{ marginBottom: 16 }}>
@@ -20,7 +38,7 @@ const ModelsSupplyTiersField = ({ sectionDef, items, onChange }) => {
       {rows.map((row, index) => {
         const value = typeof row === "object" && row !== null ? row : { models: String(row ?? ""), supply: "0" };
         return (
-          <div key={index} className="mobile-editor-tier-row">
+          <div key={keys[index]} className="mobile-editor-tier-row">
             <EditorNumberField
               label="Models"
               value={value.models ?? ""}

--- a/src/Components/Viewer/MobileEditor/sections/FieldCollectionSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/FieldCollectionSection.jsx
@@ -1,7 +1,7 @@
 import { Plus, Trash2 } from "lucide-react";
 import { EditorAccordion } from "../shared/EditorAccordion";
-import { EditorTextField } from "../shared/EditorTextField";
-import { EditorToggle } from "../shared/EditorToggle";
+import { SchemaFieldEditor } from "../shared/SchemaFieldEditor";
+import { getDefaultValueForType } from "../../../../Helpers/customSchema.helpers";
 
 export const FieldCollectionSection = ({ card, config, label, icon, replaceCard }) => {
   const { collectionPath, fields, allowMultiple } = config;
@@ -16,7 +16,7 @@ export const FieldCollectionSection = ({ card, config, label, icon, replaceCard 
   const handleAdd = () => {
     const blank = {};
     fields.forEach((f) => {
-      blank[f.key] = f.type === "boolean" ? false : "";
+      blank[f.key] = getDefaultValueForType(f);
     });
     replaceCard({ ...card, [collectionPath]: [...items, blank] });
   };
@@ -35,28 +35,14 @@ export const FieldCollectionSection = ({ card, config, label, icon, replaceCard 
               <Trash2 size={14} />
             </button>
           </div>
-          {fields.map((field) => {
-            if (field.type === "boolean") {
-              return (
-                <EditorToggle
-                  key={field.key}
-                  label={field.label}
-                  checked={!!item[field.key]}
-                  onChange={(value) => handleUpdate(index, field.key, value)}
-                />
-              );
-            }
-            return (
-              <EditorTextField
-                key={field.key}
-                label={field.label}
-                value={item[field.key]}
-                onChange={(value) => handleUpdate(index, field.key, value)}
-                placeholder={field.label}
-                multiline={field.type === "richtext"}
-              />
-            );
-          })}
+          {fields.map((field) => (
+            <SchemaFieldEditor
+              key={field.key}
+              field={field}
+              value={item[field.key]}
+              onChange={(value) => handleUpdate(index, field.key, value)}
+            />
+          ))}
         </div>
       ))}
       {(allowMultiple || items.length === 0) && (

--- a/src/Components/Viewer/MobileEditor/sections/FieldsSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/FieldsSection.jsx
@@ -1,6 +1,5 @@
 import { EditorAccordion } from "../shared/EditorAccordion";
-import { EditorTextField } from "../shared/EditorTextField";
-import { EditorToggle } from "../shared/EditorToggle";
+import { SchemaFieldEditor } from "../shared/SchemaFieldEditor";
 
 export const FieldsSection = ({ card, config, label, icon, updateField }) => {
   const { fields } = config;
@@ -8,49 +7,14 @@ export const FieldsSection = ({ card, config, label, icon, updateField }) => {
   return (
     <EditorAccordion title={label} icon={icon}>
       <div className="mobile-editor-fields-list">
-        {fields.map((field) => {
-          if (field.type === "boolean") {
-            return (
-              <EditorToggle
-                key={field.key}
-                label={field.label}
-                checked={!!card[field.key]}
-                onChange={(value) => updateField(field.key, value)}
-              />
-            );
-          }
-
-          if (field.type === "enum" && field.options) {
-            return (
-              <div key={field.key} className="mobile-editor-field">
-                <label className="mobile-editor-field-label">{field.label}</label>
-                <select
-                  className="mobile-editor-select"
-                  value={card[field.key] || ""}
-                  onChange={(e) => updateField(field.key, e.target.value)}>
-                  <option value="">Select...</option>
-                  {field.options.map((opt) => (
-                    <option key={opt} value={opt}>
-                      {opt}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            );
-          }
-
-          // string or richtext
-          return (
-            <EditorTextField
-              key={field.key}
-              label={field.label}
-              value={card[field.key]}
-              onChange={(value) => updateField(field.key, value)}
-              placeholder={field.label}
-              multiline={field.type === "richtext"}
-            />
-          );
-        })}
+        {fields.map((field) => (
+          <SchemaFieldEditor
+            key={field.key}
+            field={field}
+            value={card[field.key]}
+            onChange={(value) => updateField(field.key, value)}
+          />
+        ))}
       </div>
     </EditorAccordion>
   );

--- a/src/Components/Viewer/MobileEditor/sections/KeywordsSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/KeywordsSection.jsx
@@ -2,13 +2,13 @@ import { EditorAccordion } from "../shared/EditorAccordion";
 import { EditorTagInput } from "../shared/EditorTagInput";
 
 export const KeywordsSection = ({ card, config, label, icon, updateField }) => {
-  const { keywordsPath, factionKeywordsPath } = config;
+  const { keywordsPath, factionKeywordsPath, keywordsLabel, factionKeywordsLabel } = config;
 
   return (
     <EditorAccordion title={label} icon={icon}>
       {keywordsPath && (
         <EditorTagInput
-          label="Keywords"
+          label={keywordsLabel || "Keywords"}
           tags={card[keywordsPath] || []}
           onChange={(tags) => updateField(keywordsPath, tags)}
           placeholder="Add keyword"
@@ -17,7 +17,7 @@ export const KeywordsSection = ({ card, config, label, icon, updateField }) => {
       {factionKeywordsPath && (
         <div style={{ marginTop: keywordsPath ? 16 : 0 }}>
           <EditorTagInput
-            label="Faction Keywords"
+            label={factionKeywordsLabel || "Faction Keywords"}
             tags={card[factionKeywordsPath] || []}
             onChange={(tags) => updateField(factionKeywordsPath, tags)}
             placeholder="Add faction keyword"

--- a/src/Components/Viewer/MobileEditor/sections/NameSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/NameSection.jsx
@@ -1,6 +1,9 @@
 import { EditorTextField } from "../shared/EditorTextField";
+import { EditorToggle } from "../shared/EditorToggle";
 
-export const NameSection = ({ card, updateField }) => {
+export const NameSection = ({ card, config = {}, updateField, replaceCard }) => {
+  const { hasCombatRole, hasArmySlot, hasAutoResize } = config;
+
   return (
     <div className="mobile-editor-name-section">
       <EditorTextField
@@ -15,6 +18,34 @@ export const NameSection = ({ card, updateField }) => {
           onChange={(value) => updateField("subname", value)}
           placeholder="Subtitle"
           className="mobile-editor-subname-input"
+        />
+      )}
+      {hasCombatRole && (
+        <EditorTextField
+          label="Combat Role"
+          value={card.combatRole || ""}
+          onChange={(value) => updateField("combatRole", value || undefined)}
+          placeholder="e.g. Damage Dealer"
+        />
+      )}
+      {hasArmySlot && (
+        <EditorTextField
+          label="Army Slot"
+          value={card.armySlot || ""}
+          onChange={(value) => updateField("armySlot", value || undefined)}
+          placeholder="e.g. Core"
+        />
+      )}
+      {hasAutoResize && (
+        <EditorToggle
+          label="Auto-resize card"
+          checked={!!card.styling?.autoHeight}
+          onChange={(value) =>
+            replaceCard({
+              ...card,
+              styling: { ...(card.styling || {}), autoHeight: value },
+            })
+          }
         />
       )}
     </div>

--- a/src/Components/Viewer/MobileEditor/sections/PointsSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/PointsSection.jsx
@@ -13,7 +13,11 @@ export const PointsSection = ({ card, config, label, icon, updateField, replaceC
   // Scalar points (number or string)
   return (
     <EditorAccordion title={label} icon={icon}>
-      <EditorNumberField label="Points" value={card.points} onChange={(value) => updateField("points", value)} />
+      <EditorNumberField
+        label={config?.pointsLabel || "Points"}
+        value={card.points}
+        onChange={(value) => updateField("points", value)}
+      />
     </EditorAccordion>
   );
 };

--- a/src/Components/Viewer/MobileEditor/sections/StatsSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/StatsSection.jsx
@@ -2,6 +2,22 @@ import { Plus, Trash2 } from "lucide-react";
 import { EditorAccordion } from "../shared/EditorAccordion";
 import { EditorNumberField } from "../shared/EditorNumberField";
 import { EditorTextField } from "../shared/EditorTextField";
+import { EditorSelectField } from "../shared/EditorSelectField";
+import { EditorToggle } from "../shared/EditorToggle";
+
+// Stats are usually free-text values like "3+" or "2d6", so default to the
+// stat-cell number input. Enum / boolean schema types are explicitly handled
+// to mirror desktop SchemaFieldEditor while keeping the compact grid layout.
+const StatFieldInput = ({ field, value, onChange }) => {
+  if (field.type === "boolean") {
+    return <EditorToggle label={field.label} checked={!!value} onChange={onChange} />;
+  }
+  if (field.type === "enum" && Array.isArray(field.options) && field.options.length > 0) {
+    const options = field.options.map((opt) => ({ value: opt, label: opt }));
+    return <EditorSelectField label={field.label} value={value} onChange={onChange} options={options} />;
+  }
+  return <EditorNumberField label={field.label} value={value} onChange={onChange} />;
+};
 
 export const StatsSection = ({ card, config, label, icon, updateField, replaceCard }) => {
   const { fields, allowMultipleProfiles, dataPath, flatObject } = config;
@@ -56,9 +72,9 @@ export const StatsSection = ({ card, config, label, icon, updateField, replaceCa
         {stats.length > 0 && (
           <div className="mobile-editor-stat-grid">
             {fields.map((field) => (
-              <EditorNumberField
+              <StatFieldInput
                 key={field.key}
-                label={field.label}
+                field={field}
                 value={stats[0]?.[field.key]}
                 onChange={(value) => handleStatChange(0, field.key, value)}
               />
@@ -99,9 +115,9 @@ export const StatsSection = ({ card, config, label, icon, updateField, replaceCa
           </div>
           <div className="mobile-editor-stat-grid">
             {fields.map((field) => (
-              <EditorNumberField
+              <StatFieldInput
                 key={field.key}
-                label={field.label}
+                field={field}
                 value={profile[field.key]}
                 onChange={(value) => handleStatChange(index, field.key, value)}
               />
@@ -121,9 +137,9 @@ const FlatStatsSection = ({ card, fields, label, icon, dataPath, updateField }) 
     <EditorAccordion title={label} icon={icon}>
       <div className="mobile-editor-stat-grid">
         {fields.map((field) => (
-          <EditorNumberField
+          <StatFieldInput
             key={field.key}
-            label={field.label}
+            field={field}
             value={stats[field.key]}
             onChange={(value) => updateField(`${dataPath}.${field.key}`, value)}
           />

--- a/src/Components/Viewer/MobileEditor/shared/EditorChipListField.jsx
+++ b/src/Components/Viewer/MobileEditor/shared/EditorChipListField.jsx
@@ -1,0 +1,66 @@
+import { Plus, Trash2 } from "lucide-react";
+import { EditorTextField } from "./EditorTextField";
+import { EditorSelectField } from "./EditorSelectField";
+
+/**
+ * Editable list of {amount, unit} chips. Mirrors the cost-chip UX in the
+ * desktop SchemaAbilitiesEditor so the same data shape (e.g. ability.costs
+ * for Starcraft TMG) round-trips between the mobile and desktop editors.
+ *
+ * Props:
+ *  - label    Section label
+ *  - value    Array of { amount, unit } (defaults to [])
+ *  - units    Array of allowed unit strings (e.g. ["CP","BM","VP","PE"])
+ *  - onChange Called with the next array on every mutation
+ *  - addLabel Text shown on the add button
+ */
+export const EditorChipListField = ({ label, value, units, onChange, addLabel = "Add" }) => {
+  const items = Array.isArray(value) ? value : [];
+  const unitOptions = (units || []).map((u) => ({ value: u, label: u }));
+  const defaultUnit = units?.[0] ?? "";
+
+  const setAt = (index, patch) => {
+    const next = [...items];
+    next[index] = { ...next[index], ...patch };
+    onChange(next);
+  };
+  const removeAt = (index) => onChange(items.filter((_, i) => i !== index));
+  const add = () => onChange([...items, { amount: "", unit: defaultUnit }]);
+
+  return (
+    <div className="mobile-editor-field">
+      {label && <label className="mobile-editor-field-label">{label}</label>}
+      {items.map((chip, index) => (
+        <div key={index} className="mobile-editor-chip-row">
+          <div className="mobile-editor-chip-amount">
+            <EditorTextField
+              value={chip.amount ?? ""}
+              onChange={(amount) => setAt(index, { amount })}
+              placeholder="Amount"
+            />
+          </div>
+          {unitOptions.length > 0 ? (
+            <div className="mobile-editor-chip-unit">
+              <EditorSelectField
+                value={chip.unit ?? defaultUnit}
+                onChange={(unit) => setAt(index, { unit })}
+                options={unitOptions}
+              />
+            </div>
+          ) : (
+            <div className="mobile-editor-chip-unit">
+              <EditorTextField value={chip.unit ?? ""} onChange={(unit) => setAt(index, { unit })} placeholder="Unit" />
+            </div>
+          )}
+          <button className="mobile-editor-weapon-delete" onClick={() => removeAt(index)} type="button">
+            <Trash2 size={14} />
+          </button>
+        </div>
+      ))}
+      <button className="mobile-editor-add-btn" onClick={add} type="button">
+        <Plus size={14} />
+        <span>{addLabel}</span>
+      </button>
+    </div>
+  );
+};

--- a/src/Components/Viewer/MobileEditor/shared/EditorChipListField.jsx
+++ b/src/Components/Viewer/MobileEditor/shared/EditorChipListField.jsx
@@ -1,37 +1,46 @@
+import { useRef, useState } from "react";
 import { Plus, Trash2 } from "lucide-react";
 import { EditorTextField } from "./EditorTextField";
 import { EditorSelectField } from "./EditorSelectField";
 
-/**
- * Editable list of {amount, unit} chips. Mirrors the cost-chip UX in the
- * desktop SchemaAbilitiesEditor so the same data shape (e.g. ability.costs
- * for Starcraft TMG) round-trips between the mobile and desktop editors.
- *
- * Props:
- *  - label    Section label
- *  - value    Array of { amount, unit } (defaults to [])
- *  - units    Array of allowed unit strings (e.g. ["CP","BM","VP","PE"])
- *  - onChange Called with the next array on every mutation
- *  - addLabel Text shown on the add button
- */
+// Editable list of {amount, unit} chips matching the desktop SchemaAbilitiesEditor cost-chip UX.
 export const EditorChipListField = ({ label, value, units, onChange, addLabel = "Add" }) => {
   const items = Array.isArray(value) ? value : [];
   const unitOptions = (units || []).map((u) => ({ value: u, label: u }));
   const defaultUnit = units?.[0] ?? "";
+
+  // Maintain a parallel array of stable React keys so removing a chip from the
+  // middle doesn't reuse the deleted row's DOM (and pending debounce state) for
+  // the chip that shifts up to take its place.
+  const counterRef = useRef(0);
+  const [keys, setKeys] = useState(() => items.map(() => `chip-${counterRef.current++}`));
+  if (keys.length < items.length) {
+    const next = [...keys];
+    while (next.length < items.length) next.push(`chip-${counterRef.current++}`);
+    setKeys(next);
+  } else if (keys.length > items.length) {
+    setKeys(keys.slice(0, items.length));
+  }
 
   const setAt = (index, patch) => {
     const next = [...items];
     next[index] = { ...next[index], ...patch };
     onChange(next);
   };
-  const removeAt = (index) => onChange(items.filter((_, i) => i !== index));
-  const add = () => onChange([...items, { amount: "", unit: defaultUnit }]);
+  const removeAt = (index) => {
+    setKeys((prev) => prev.filter((_, i) => i !== index));
+    onChange(items.filter((_, i) => i !== index));
+  };
+  const add = () => {
+    setKeys((prev) => [...prev, `chip-${counterRef.current++}`]);
+    onChange([...items, { amount: "", unit: defaultUnit }]);
+  };
 
   return (
     <div className="mobile-editor-field">
       {label && <label className="mobile-editor-field-label">{label}</label>}
       {items.map((chip, index) => (
-        <div key={index} className="mobile-editor-chip-row">
+        <div key={keys[index]} className="mobile-editor-chip-row">
           <div className="mobile-editor-chip-amount">
             <EditorTextField
               value={chip.amount ?? ""}

--- a/src/Components/Viewer/MobileEditor/shared/SchemaFieldEditor.jsx
+++ b/src/Components/Viewer/MobileEditor/shared/SchemaFieldEditor.jsx
@@ -2,18 +2,8 @@ import { EditorTextField } from "./EditorTextField";
 import { EditorSelectField } from "./EditorSelectField";
 import { EditorToggle } from "./EditorToggle";
 
-/**
- * Schema-aware field editor that mirrors the desktop SchemaFieldEditor in
- * premium. Switches on `field.type` so the same primitive can drive stats,
- * weapon columns, fields, and collection entries from a custom datasource
- * schema.
- *
- * - boolean → EditorToggle
- * - enum    → EditorSelectField (uses field.options)
- * - richtext → multiline EditorTextField
- * - string (default) → single-line EditorTextField
- */
-export const SchemaFieldEditor = ({ field, value, onChange, label, className = "" }) => {
+// Schema-typed field input: boolean -> toggle, enum -> select, richtext/string -> text.
+export const SchemaFieldEditor = ({ field, value, onChange, label }) => {
   const resolvedLabel = label ?? field.label;
 
   if (field.type === "boolean") {
@@ -22,15 +12,7 @@ export const SchemaFieldEditor = ({ field, value, onChange, label, className = "
 
   if (field.type === "enum" && Array.isArray(field.options) && field.options.length > 0) {
     const options = field.options.map((opt) => ({ value: opt, label: opt }));
-    return (
-      <EditorSelectField
-        label={resolvedLabel}
-        value={value}
-        onChange={onChange}
-        options={options}
-        className={className}
-      />
-    );
+    return <EditorSelectField label={resolvedLabel} value={value} onChange={onChange} options={options} />;
   }
 
   return (
@@ -40,7 +22,6 @@ export const SchemaFieldEditor = ({ field, value, onChange, label, className = "
       onChange={onChange}
       placeholder={resolvedLabel}
       multiline={field.type === "richtext"}
-      className={className}
     />
   );
 };

--- a/src/Components/Viewer/MobileEditor/shared/SchemaFieldEditor.jsx
+++ b/src/Components/Viewer/MobileEditor/shared/SchemaFieldEditor.jsx
@@ -1,0 +1,46 @@
+import { EditorTextField } from "./EditorTextField";
+import { EditorSelectField } from "./EditorSelectField";
+import { EditorToggle } from "./EditorToggle";
+
+/**
+ * Schema-aware field editor that mirrors the desktop SchemaFieldEditor in
+ * premium. Switches on `field.type` so the same primitive can drive stats,
+ * weapon columns, fields, and collection entries from a custom datasource
+ * schema.
+ *
+ * - boolean → EditorToggle
+ * - enum    → EditorSelectField (uses field.options)
+ * - richtext → multiline EditorTextField
+ * - string (default) → single-line EditorTextField
+ */
+export const SchemaFieldEditor = ({ field, value, onChange, label, className = "" }) => {
+  const resolvedLabel = label ?? field.label;
+
+  if (field.type === "boolean") {
+    return <EditorToggle label={resolvedLabel} checked={!!value} onChange={onChange} />;
+  }
+
+  if (field.type === "enum" && Array.isArray(field.options) && field.options.length > 0) {
+    const options = field.options.map((opt) => ({ value: opt, label: opt }));
+    return (
+      <EditorSelectField
+        label={resolvedLabel}
+        value={value}
+        onChange={onChange}
+        options={options}
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <EditorTextField
+      label={resolvedLabel}
+      value={value}
+      onChange={onChange}
+      placeholder={resolvedLabel}
+      multiline={field.type === "richtext"}
+      className={className}
+    />
+  );
+};

--- a/src/Components/Viewer/MobileEditor/weapons/WeaponListView.jsx
+++ b/src/Components/Viewer/MobileEditor/weapons/WeaponListView.jsx
@@ -1,27 +1,30 @@
 import { ChevronRight, Plus, Trash2 } from "lucide-react";
 import { getWeaponsArray, setWeaponsOnCard } from "./weaponHelpers";
 
+const usesProfiles = (config) => config?.format === "40k" || (config?.format === "custom" && config?.hasProfiles);
+
 export const WeaponListView = ({ card, weaponTypeKey, config, replaceCard, onEditWeapon }) => {
   const { format, columns, label } = config;
   const weapons = getWeaponsArray(card, weaponTypeKey, format);
+  const profileBased = usesProfiles(config);
 
   const setWeapons = (updated) => {
     replaceCard(setWeaponsOnCard(card, weaponTypeKey, updated, format));
   };
 
   const handleAdd = () => {
-    const blank = { name: "New Weapon", active: true };
-    if (format === "40k") {
+    if (profileBased) {
       const profile = { name: "New Weapon", active: true, keywords: [] };
       columns?.forEach((col) => (profile[col.key] = ""));
-      blank.profiles = [profile];
-      blank.abilities = [];
-    } else {
-      columns?.forEach((col) => (blank[col.key] = ""));
-      if (config.hasKeywords) {
-        blank.keywords = [];
-      }
+      const blank = { active: true, profiles: [profile] };
+      if (format === "40k") blank.abilities = [];
+      setWeapons([...weapons, blank]);
+      return;
     }
+
+    const blank = { name: "New Weapon", active: true };
+    columns?.forEach((col) => (blank[col.key] = ""));
+    if (config.hasKeywords) blank.keywords = [];
     setWeapons([...weapons, blank]);
   };
 
@@ -30,18 +33,22 @@ export const WeaponListView = ({ card, weaponTypeKey, config, replaceCard, onEdi
   };
 
   const getWeaponDisplayName = (weapon) => {
-    if (format === "40k" && weapon.profiles?.length) {
+    if (profileBased && weapon.profiles?.length) {
       return weapon.profiles[0]?.name || weapon.name || "Untitled weapon";
     }
     return weapon.name || "Untitled weapon";
   };
 
   const getWeaponSummary = (weapon) => {
-    if (format === "40k") {
-      const profileCount = weapon.profiles?.length || 0;
-      return profileCount > 1 ? `${profileCount} profiles` : "";
+    if (!profileBased) return "";
+    const profileCount = weapon.profiles?.length || 0;
+    if (profileCount <= 1) return "";
+    if (config.profileRelation === "parent-child") {
+      const childLabel = (config.profileChildLabel || "Upgrade").toLowerCase();
+      const extras = profileCount - 1;
+      return `${extras} ${childLabel}${extras === 1 ? "" : "s"}`;
     }
-    return "";
+    return `${profileCount} profiles`;
   };
 
   return (

--- a/src/Components/Viewer/MobileEditor/weapons/WeaponProfileEditor.jsx
+++ b/src/Components/Viewer/MobileEditor/weapons/WeaponProfileEditor.jsx
@@ -1,12 +1,33 @@
 import { Plus, Trash2 } from "lucide-react";
 import { EditorTextField } from "../shared/EditorTextField";
 import { EditorNumberField } from "../shared/EditorNumberField";
+import { EditorSelectField } from "../shared/EditorSelectField";
 import { EditorTagInput } from "../shared/EditorTagInput";
 import { EditorToggle } from "../shared/EditorToggle";
 import { getWeaponsArray, setWeaponsOnCard } from "./weaponHelpers";
 
 // Columns that store arrays and need special handling
 const ARRAY_COLUMNS = new Set(["abilities"]);
+
+/**
+ * Render a single weapon column input using the schema field type so enum
+ * columns get a Select (matching desktop SchemaFieldEditor) while string /
+ * richtext stay on the stat-cell EditorNumberField that already styles the
+ * grid layout for stat-like values.
+ */
+const ColumnInput = ({ column, value, onChange }) => {
+  if (column.type === "boolean") {
+    return <EditorToggle label={column.label} checked={!!value} onChange={onChange} />;
+  }
+  if (column.type === "enum" && Array.isArray(column.options) && column.options.length > 0) {
+    const options = column.options.map((opt) => ({ value: opt, label: opt }));
+    return <EditorSelectField label={column.label} value={value} onChange={onChange} options={options} />;
+  }
+  if (column.type === "richtext") {
+    return <EditorTextField label={column.label} value={value} onChange={onChange} multiline />;
+  }
+  return <EditorNumberField label={column.label} value={value} onChange={onChange} />;
+};
 
 export const WeaponProfileEditor = ({
   card,
@@ -17,7 +38,7 @@ export const WeaponProfileEditor = ({
   replaceCard,
   onSelectProfile,
 }) => {
-  const { format, columns } = config;
+  const { format, columns, hasProfiles } = config;
   const weapons = getWeaponsArray(card, weaponTypeKey, format);
 
   const setWeapons = (updated) => {
@@ -26,21 +47,24 @@ export const WeaponProfileEditor = ({
   const weapon = weapons[weaponIndex];
   if (!weapon) return null;
 
-  // 40k: weapons have profiles array
-  if (format === "40k") {
+  // 40k always uses profiles; custom uses profiles when its weapon type declares
+  // hasProfiles=true. AoS and the flat custom fallback edit the weapon directly.
+  const useProfiles = format === "40k" || (format === "custom" && hasProfiles);
+
+  if (useProfiles) {
     return (
-      <FortyKProfileEditor
+      <ProfileWeaponEditor
         weapons={weapons}
         weaponIndex={weaponIndex}
         profileIndex={profileIndex}
         columns={columns}
+        config={config}
         setWeapons={setWeapons}
         onSelectProfile={onSelectProfile}
       />
     );
   }
 
-  // AoS / custom: flat weapon properties
   return (
     <FlatWeaponEditor
       weapons={weapons}
@@ -52,11 +76,15 @@ export const WeaponProfileEditor = ({
   );
 };
 
-const FortyKProfileEditor = ({ weapons, weaponIndex, profileIndex, columns, setWeapons, onSelectProfile }) => {
+const ProfileWeaponEditor = ({ weapons, weaponIndex, profileIndex, columns, config, setWeapons, onSelectProfile }) => {
   const weapon = weapons[weaponIndex];
   const profiles = weapon.profiles || [];
   const profile = profiles[profileIndex];
   if (!profile) return null;
+
+  const hasKeywords = config.hasKeywords !== false;
+  const isParentChild = config.profileRelation === "parent-child";
+  const childLabel = config.profileChildLabel || "Upgrade";
 
   const updateProfile = (field, value) => {
     const updatedProfiles = [...profiles];
@@ -67,7 +95,10 @@ const FortyKProfileEditor = ({ weapons, weaponIndex, profileIndex, columns, setW
   };
 
   const addProfile = () => {
-    const blank = { name: "New Profile", active: true, keywords: [] };
+    const isUpgrade = isParentChild;
+    const baseName = isUpgrade ? `${childLabel} ${profiles.length}` : `Profile ${profiles.length + 1}`;
+    const blank = { name: baseName, active: true, keywords: [] };
+    if (isUpgrade) blank.upgrade = true;
     columns?.forEach((col) => (blank[col.key] = ""));
     const updatedWeapons = [...weapons];
     updatedWeapons[weaponIndex] = { ...weapon, profiles: [...profiles, blank] };
@@ -84,6 +115,15 @@ const FortyKProfileEditor = ({ weapons, weaponIndex, profileIndex, columns, setW
     onSelectProfile?.(clampedIndex);
   };
 
+  // Parent-child shows the base flush and additional rows as indented upgrades;
+  // mirror that visual rhythm on the add button label so editors know what
+  // they'll create.
+  const addButtonLabel = isParentChild
+    ? profiles.length === 0
+      ? "Add weapon"
+      : `Add ${childLabel.toLowerCase()}`
+    : "Add Profile";
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
       <EditorTextField
@@ -95,9 +135,9 @@ const FortyKProfileEditor = ({ weapons, weaponIndex, profileIndex, columns, setW
 
       <div className="mobile-editor-profile-grid">
         {columns?.map((col) => (
-          <EditorNumberField
+          <ColumnInput
             key={col.key}
-            label={col.label}
+            column={col}
             value={profile[col.key]}
             onChange={(value) => updateProfile(col.key, value)}
           />
@@ -110,17 +150,19 @@ const FortyKProfileEditor = ({ weapons, weaponIndex, profileIndex, columns, setW
         onChange={(value) => updateProfile("active", value)}
       />
 
-      <EditorTagInput
-        label="Keywords"
-        tags={profile.keywords || []}
-        onChange={(tags) => updateProfile("keywords", tags)}
-      />
+      {hasKeywords && (
+        <EditorTagInput
+          label="Keywords"
+          tags={profile.keywords || []}
+          onChange={(tags) => updateProfile("keywords", tags)}
+        />
+      )}
 
       {/* Profile management */}
       <div style={{ display: "flex", gap: 8 }}>
         <button className="mobile-editor-add-btn" onClick={addProfile} type="button" style={{ flex: 1 }}>
           <Plus size={14} />
-          <span>Add Profile</span>
+          <span>{addButtonLabel}</span>
         </button>
         {profiles.length > 1 && (
           <button className="mobile-editor-profile-delete-btn" onClick={removeProfile} type="button">
@@ -138,7 +180,9 @@ const FortyKProfileEditor = ({ weapons, weaponIndex, profileIndex, columns, setW
               <button
                 key={i}
                 type="button"
-                className={`mobile-editor-profile-item${i === profileIndex ? " active" : ""}`}
+                className={`mobile-editor-profile-item${i === profileIndex ? " active" : ""}${
+                  isParentChild && i > 0 ? " mobile-editor-profile-item--upgrade" : ""
+                }`}
                 onClick={() => onSelectProfile?.(i)}>
                 <span className="mobile-editor-profile-item-name">{p.name || `Profile ${i + 1}`}</span>
                 {i === profileIndex && <span className="mobile-editor-profile-item-badge">editing</span>}
@@ -173,9 +217,9 @@ const FlatWeaponEditor = ({ weapons, weaponIndex, columns, config, setWeapons })
         {columns
           ?.filter((col) => !ARRAY_COLUMNS.has(col.key))
           .map((col) => (
-            <EditorNumberField
+            <ColumnInput
               key={col.key}
-              label={col.label}
+              column={col}
               value={weapon[col.key]}
               onChange={(value) => updateWeapon(col.key, value)}
             />


### PR DESCRIPTION
## Summary

Extends the mobile editor's schema resolver to forward custom datasource configuration flags from the schema to editor sections, enabling feature parity with the desktop editor. This allows mobile editors to access and edit the same fields (ability types, costs, triggers, phases, colors, combat roles, army slots, etc.) that desktop editors support.

## Key Changes

- **Schema flag forwarding in `editorSchemaResolvers.js`**:
  - Added `mapAbilityCategory()` to forward all ability category flags (`hasType`, `hasCost`, `hasTriggerIcon`, `hasPhase`, `hasColor`, `layout`, `phaseStyle`, etc.) from schema to editor config
  - Added `mapWeaponType()` to forward weapon profile relation, child label, phase style, and linked ability category
  - Updated `resolveCustomSections()` to surface metadata flags (`hasCombatRole`, `hasArmySlot`, `hasAutoResize`) on the name section and keyword/points labels on their respective sections
  - Ensured all boolean flags are explicitly set to `false` rather than `undefined` for consistent schema contracts

- **Mobile editor UI components**:
  - **`AbilitiesSection.jsx`**: Enhanced `AbilitiesCustom` to render type pills, cost chips, trigger/upgrade toggles, phase fields, and color pickers based on category flags
  - **`NameSection.jsx`**: Added conditional fields for combat role, army slot, and auto-resize toggle
  - **`WeaponProfileEditor.jsx`**: Refactored to support both 40K and custom datasources with profiles; added parent-child profile visual indicator and dynamic profile naming
  - **`CustomSectionsEditor.jsx`**: Added `ModelsSupplyTiersField` component for the `modelsSupplyTiers` format
  - **`StatsSection.jsx`**: Added `StatFieldInput` to handle enum and boolean field types in stat grids
  - **`FieldsSection.jsx` & `FieldCollectionSection.jsx`**: Extracted schema-aware field rendering into new `SchemaFieldEditor` component for reuse across sections
  - **`KeywordsSection.jsx` & `PointsSection.jsx`**: Updated to use forwarded label overrides from metadata

- **New shared components**:
  - **`SchemaFieldEditor.jsx`**: Reusable schema-aware field editor that switches on field type (boolean → toggle, enum → select, richtext → multiline text, string → text)
  - **`EditorChipListField.jsx`**: New component for editing cost chips with amount/unit pairs, mirroring desktop ability cost UI

- **Styling**:
  - Added CSS for chip rows, tier rows, color picker, and parent-child profile indentation in `MobileCardEditor.css`

- **Test coverage**:
  - Added comprehensive test suite for custom schema flag forwarding, covering metadata flags, ability categories, weapon profiles, keywords/points labels, and section formats
  - Added tests for minimal schemas without metadata flags to ensure explicit `false` values

## Notable Implementation Details

- The `mapAbilityCategory()` and `mapWeaponType()` functions ensure all schema flags are explicitly forwarded in a stable shape, preventing undefined values from breaking mobile editor logic
- Parent-child weapon profiles now show visual indentation and use contextual naming (e.g., "Upgrade 1" vs "Profile 2")
- The `SchemaFieldEditor` component centralizes field type handling, reducing duplication across stats, fields, and collection sections
- Custom sections now support `modelsSupplyTiers` format for Starcraft TMG-style tier editing
- Mobile and desktop editors now share the same data shapes for abilities (type, costs, triggered, upgrade, phase, color) and weapons (profiles, keywords), enabling seamless round-tripping between editors

https://claude.ai/code/session_01QYA4BM6Xrxwj1mYRTAD7MS