### PR TITLE
Add parameterized keyword glossary matches

### DIFF
--- a/docs/custom datasource/datasource-schema-architecture.md
+++ b/docs/custom datasource/datasource-schema-architecture.md
@@ -62,7 +62,7 @@ keywordGlossary: [
     key: "anti",
     name: "Anti-",
     description: "An unmodified Wound roll of 'x+' against a target with the matching keyword scores a Critical Wound.",
-    matchType: "prefix",
+    matchType: "parameterized",
     appliesTo: ["weapons"],
     style: { casing: "uppercase", brackets: "square", weight: "bold" },
   },
@@ -74,7 +74,7 @@ keywordGlossary: [
 | `key`         | string   | Stable storage key, unique within the glossary. |
 | `name`        | string   | The keyword name as it appears on cards (e.g. `One Shot`, `Anti-`). |
 | `description` | string   | Explanation text rendered by consuming renderers. |
-| `matchType`   | string   | `"exact"` (default, case-insensitive equality) or `"prefix"` (case-insensitive `startsWith`; used for parametrised rules like `Anti-Infantry 4+` matching `Anti-`). |
+| `matchType`   | string   | `"exact"` (default, case-insensitive equality), `"prefix"` (case-insensitive `startsWith`), or `"parameterized"` (entry name plus an optional value such as `Sustained Hits 2`, `Feel No Pain 5+`, `Melta D6+2`, or `Anti-Vehicle 4+`). |
 | `appliesTo`   | string[] | **Required, non-empty.** Scopes in which the entry can render. One entry may declare multiple scopes (e.g. a `Lethal Hits` keyword that applies both to weapons and to ability-text tooltips). |
 | `displayMode` | string   | Weapons-only. `"explanation"` (default) renders the description as an explanation row below the weapon table. `"tooltip"` renders the description as a hover tooltip on the inline keyword tag and skips the explanation row. Other scopes ignore this field today. |
 | `style`       | object   | Optional. Per-keyword presentation of the inline keyword tag. Modelled as string enums so more options can be added later. `casing`: `"uppercase"` (default) or `"normal"`. `brackets`: `"square"` (default) or `"none"`. `weight`: `"bold"` (default) or `"normal"`. Missing or unknown values fall back to the default, so existing entries keep the original look. |

--- a/docs/custom datasource/keyword-glossary.md
+++ b/docs/custom datasource/keyword-glossary.md
@@ -56,7 +56,7 @@ schema: {
       key: "anti",
       name: "Anti-",
       description: "An unmodified Wound roll of 'x+' against a target with the matching keyword scores a Critical Wound.",
-      matchType: "prefix",
+      matchType: "parameterized",
       appliesTo: ["weapons"],
     },
   ],
@@ -68,7 +68,7 @@ schema: {
 | `key`         | string   | yes      | Stable storage key, unique within the glossary. |
 | `name`        | string   | yes      | Keyword name as it appears on cards. |
 | `description` | string   | yes      | Explanation text rendered by consuming renderers. |
-| `matchType`   | string   | no       | `"exact"` (default, case-insensitive equality) or `"prefix"` (case-insensitive `startsWith`). |
+| `matchType`   | string   | no       | `"exact"` (default, case-insensitive equality), `"prefix"` (case-insensitive `startsWith`), or `"parameterized"` (entry name plus an optional value such as `Sustained Hits 2`, `Feel No Pain 5+`, `Melta D6+2`, or `Anti-Vehicle 4+`). |
 | `appliesTo`   | string[] | yes      | Non-empty array of scopes from `VALID_GLOSSARY_SCOPES`. |
 | `displayMode` | string   | no       | Weapons-only. `"explanation"` (default) renders an explanation row under the profile; `"tooltip"` shows the description on hover over the inline keyword tag and skips the row. Other scopes ignore this field. |
 
@@ -98,7 +98,8 @@ The renderer resolves each keyword tag to at most one glossary entry via `resolv
 1. Filter the glossary down to entries whose `appliesTo` includes the renderer's scope.
 2. `exact` entries compare via case-insensitive equality on the keyword tag.
 3. `prefix` entries match when the keyword tag starts with the entry name (case-insensitive).
-4. When multiple in-scope entries match the same tag, the entry with the **longest `name`** wins. This lets a specific entry like `Power Fist` win over a generic prefix `Power`.
+4. `parameterized` entries match the bare entry name or the entry name plus a value, including save values (`5+`), dice values (`D6`, `D6+2`, `2D6+2`), and text-plus-value suffixes (`Vehicle 4+`).
+5. When multiple in-scope entries match the same tag, the entry with the **longest `name`** wins. This lets a specific entry like `Power Fist` win over a generic prefix `Power`.
 
 Within one renderer section, the same glossary entry is only rendered once even if multiple weapons share the keyword — explanation rows are deduplicated by entry key.
 
@@ -113,7 +114,7 @@ Other base systems (`aos`, `starcraft-tmg`, `blank`) start with an empty glossar
 The glossary editor lives in the Datasource Editor right panel, under the datasource node (above the Factions section). Each row exposes:
 
 - Keyword name input
-- Match type select (`Exact` / `Prefix`)
+- Match type select (`Exact` / `Prefix` / `Parameterized`)
 - Auto-generated storage key (editable for advanced users)
 - **Applies to** multi-select dropdown (one option per scope; new entries default to `weapons` selected)
 - **Display mode** select (`Explanation row` / `Hover tooltip`) — only shown when the entry applies to weapons

--- a/src/Components/DatasourceEditor/cards/shared/__tests__/GlossaryKeywords.test.jsx
+++ b/src/Components/DatasourceEditor/cards/shared/__tests__/GlossaryKeywords.test.jsx
@@ -43,6 +43,14 @@ const glossary = [
     displayMode: "explanation",
   },
   {
+    key: "sustained-hits",
+    name: "Sustained Hits",
+    description: "Extra hits on critical hits.",
+    matchType: "parameterized",
+    appliesTo: ["weapons", "abilities"],
+    displayMode: "tooltip",
+  },
+  {
     key: "rampage",
     name: "Rampage",
     description: "Make a bonus attack.",
@@ -75,7 +83,11 @@ describe("splitKeywordString", () => {
 
 describe("getKeywordExplanations", () => {
   it("returns explanation-mode entries and drops tooltip-mode ones", () => {
-    const entries = getKeywordExplanations(["One Shot", "Lance", "Anti-Infantry 4+"], glossary, "weapons");
+    const entries = getKeywordExplanations(
+      ["One Shot", "Lance", "Anti-Infantry 4+", "Sustained Hits D6+2"],
+      glossary,
+      "weapons",
+    );
     expect(entries.map((e) => e.key)).toEqual(["one-shot", "anti"]);
   });
 
@@ -97,6 +109,14 @@ describe("GlossaryKeywordTags", () => {
     expect(trigger).toBeTruthy();
     expect(trigger.getAttribute("data-tooltip-content")).toMatch(/on the charge/i);
     expect(trigger.querySelector(".ds-kw-tag--has-info")).toBeTruthy();
+  });
+
+  it("renders the full parameterized keyword text on tooltip-mode tags", () => {
+    const { container } = render(<GlossaryKeywordTags keywords={["Sustained Hits D6+2"]} glossary={glossary} />);
+    const trigger = container.querySelector("[data-tooltip-content]");
+    expect(trigger).toBeTruthy();
+    expect(trigger.textContent).toBe("[Sustained Hits D6+2]");
+    expect(trigger.getAttribute("data-tooltip-content")).toMatch(/extra hits/i);
   });
 
   it("leaves explanation-mode entries plain (no tooltip, no has-info)", () => {
@@ -158,6 +178,15 @@ describe("GlossaryText", () => {
     expect(trigger).toBeTruthy();
     expect(trigger.getAttribute("data-tooltip-content")).toMatch(/bonus attack/i);
     expect(trigger.querySelector(".ds-kw-inline")).toBeTruthy();
+  });
+
+  it("wraps the full parameterized match in free text", () => {
+    const { container } = render(
+      <GlossaryText text="This unit has Sustained Hits D6+2 in combat" glossary={glossary} scope="abilities" />,
+    );
+    const trigger = container.querySelector("[data-tooltip-content]");
+    expect(trigger).toBeTruthy();
+    expect(trigger.textContent).toBe("Sustained Hits D6+2");
   });
 
   it("returns the raw string when nothing matches", () => {

--- a/src/Components/DatasourceEditor/cards/units/__tests__/Ds40kUnitWeapons.glossary.test.jsx
+++ b/src/Components/DatasourceEditor/cards/units/__tests__/Ds40kUnitWeapons.glossary.test.jsx
@@ -53,7 +53,14 @@ const glossary = [
     key: "anti",
     name: "Anti-",
     description: "Critical Wounds vs matching keyword.",
-    matchType: "prefix",
+    matchType: "parameterized",
+    appliesTo: ["weapons"],
+  },
+  {
+    key: "sustained-hits",
+    name: "Sustained Hits",
+    description: "Extra hits on critical hits.",
+    matchType: "parameterized",
     appliesTo: ["weapons"],
   },
   {
@@ -137,11 +144,19 @@ describe("Ds40kUnitWeapons glossary explanations", () => {
     expect(screen.queryByText(/Critical Wounds vs matching keyword/i)).toBeNull();
   });
 
-  it("resolves prefix matches for parametrised keywords", () => {
+  it("resolves parameterized matches for parametrised keywords", () => {
     render(
       <Ds40kUnitWeapons unit={unitWith(["Anti-Infantry 4+"])} weaponTypes={weaponTypes} keywordGlossary={glossary} />,
     );
     expect(screen.getByText(/Critical Wounds vs matching keyword/i)).toBeInTheDocument();
+  });
+
+  it("renders the full parameterized inline keyword while resolving the base explanation", () => {
+    const { container } = render(
+      <Ds40kUnitWeapons unit={unitWith(["Sustained Hits D6+2"])} weaponTypes={weaponTypes} keywordGlossary={glossary} />,
+    );
+    expect(container.querySelector(".keyword").textContent).toContain("Sustained Hits D6+2");
+    expect(screen.getByText(/Extra hits on critical hits/i)).toBeInTheDocument();
   });
 
   it("deduplicates explanation rows within a weapon type", () => {

--- a/src/Components/DatasourceEditor/editors/KeywordGlossaryEditor.jsx
+++ b/src/Components/DatasourceEditor/editors/KeywordGlossaryEditor.jsx
@@ -13,11 +13,13 @@ import {
   VALID_GLOSSARY_SCOPES,
 } from "../../../Helpers/customSchema.helpers";
 
-const MATCH_TYPE_TOOLTIP = "Match type — exact matches the full keyword, prefix matches the start";
+const MATCH_TYPE_TOOLTIP =
+  "Match type — exact matches the full keyword, prefix matches the start, parameterized matches the keyword plus a value";
 
 const MATCH_TYPE_OPTIONS = [
   { value: "exact", label: "Exact" },
   { value: "prefix", label: "Prefix" },
+  { value: "parameterized", label: "Parameterized" },
 ];
 
 const DISPLAY_MODE_OPTIONS = [

--- a/src/Components/DatasourceEditor/editors/__tests__/KeywordGlossaryEditor.test.jsx
+++ b/src/Components/DatasourceEditor/editors/__tests__/KeywordGlossaryEditor.test.jsx
@@ -157,9 +157,9 @@ describe("KeywordGlossaryEditor", () => {
     render(<KeywordGlossaryEditor schema={baseSchema()} onChange={onChange} />);
     openSection();
     expandEntry("One Shot");
-    fireEvent.change(screen.getByLabelText("Match type"), { target: { value: "prefix" } });
+    fireEvent.change(screen.getByLabelText("Match type"), { target: { value: "parameterized" } });
     const next = onChange.mock.calls.at(-1)[0];
-    expect(next.keywordGlossary[0].matchType).toBe("prefix");
+    expect(next.keywordGlossary[0].matchType).toBe("parameterized");
   });
 
   it("adds a scope via the appliesTo dropdown", () => {

--- a/src/Components/Glossary/GlossaryList.jsx
+++ b/src/Components/Glossary/GlossaryList.jsx
@@ -27,13 +27,24 @@ const GlossaryDescription = ({ description }) => (
 const GlossaryEntry = ({ entry }) => {
   const [isOpen, setIsOpen] = useState(false);
   const scopes = Array.isArray(entry.appliesTo) ? entry.appliesTo : [];
+  const matchIndicator = entry.matchType === "prefix" ? "…" : entry.matchType === "parameterized" ? " x" : "";
+  const matchTitle =
+    entry.matchType === "prefix"
+      ? "Prefix match"
+      : entry.matchType === "parameterized"
+        ? "Parameterized match"
+        : undefined;
 
   return (
     <div className={`glossary-entry ${isOpen ? "open" : ""}`}>
       <button className="glossary-entry-header" onClick={() => setIsOpen(!isOpen)}>
         <span className="glossary-entry-name">
           {entry.name}
-          {entry.matchType === "prefix" && <span className="glossary-entry-prefix">…</span>}
+          {matchIndicator && (
+            <span className="glossary-entry-prefix" title={matchTitle}>
+              {matchIndicator}
+            </span>
+          )}
         </span>
         <span className="glossary-entry-scopes">
           {scopes.map((scope) => (

--- a/src/Components/Glossary/__tests__/GlossaryList.test.jsx
+++ b/src/Components/Glossary/__tests__/GlossaryList.test.jsx
@@ -15,7 +15,7 @@ const glossary = [
     key: "anti",
     name: "Anti-",
     description: "An unmodified Wound roll of 'x+' scores a Critical Wound.",
-    matchType: "prefix",
+    matchType: "parameterized",
     appliesTo: ["weapons", "abilities"],
   },
 ];
@@ -32,6 +32,11 @@ describe("GlossaryList", () => {
     render(<GlossaryList glossary={glossary} />);
     expect(screen.getAllByText("Weapons").length).toBe(2);
     expect(screen.getByText("Abilities")).toBeTruthy();
+  });
+
+  it("marks parameterized entries in the list", () => {
+    render(<GlossaryList glossary={glossary} />);
+    expect(screen.getByTitle("Parameterized match").textContent).toBe(" x");
   });
 
   it("reveals the description when an entry is expanded", () => {

--- a/src/Helpers/__tests__/keywordGlossary.test.js
+++ b/src/Helpers/__tests__/keywordGlossary.test.js
@@ -31,7 +31,21 @@ const glossary = [
     key: "rapid-fire",
     name: "Rapid Fire",
     description: "Extra attacks at half range.",
-    matchType: "prefix",
+    matchType: "parameterized",
+    appliesTo: ["weapons"],
+  },
+  {
+    key: "sustained-hits",
+    name: "Sustained Hits",
+    description: "Extra hits on critical hits.",
+    matchType: "parameterized",
+    appliesTo: ["weapons"],
+  },
+  {
+    key: "melta",
+    name: "Melta",
+    description: "Extra damage within half range.",
+    matchType: "parameterized",
     appliesTo: ["weapons"],
   },
   {
@@ -66,7 +80,14 @@ describe("VALID_GLOSSARY_SCOPES", () => {
 describe("filterGlossaryByScope", () => {
   it("returns only entries whose appliesTo includes the given scope", () => {
     const filtered = filterGlossaryByScope(glossary, "weapons");
-    expect(filtered.map((e) => e.key)).toEqual(["one-shot", "anti", "rapid-fire", "twin-linked"]);
+    expect(filtered.map((e) => e.key)).toEqual([
+      "one-shot",
+      "anti",
+      "rapid-fire",
+      "sustained-hits",
+      "melta",
+      "twin-linked",
+    ]);
   });
 
   it("returns an entry to multiple scopes when listed", () => {
@@ -104,10 +125,32 @@ describe("resolveKeywordEntry", () => {
     expect(resolveKeywordEntry("  ONE SHOT  ", glossary, "weapons")?.key).toBe("one-shot");
   });
 
-  it("matches prefix entries against parametrised keywords", () => {
+  it("matches parameterized entries with text-plus-save values", () => {
     expect(resolveKeywordEntry("Anti-Infantry 4+", glossary, "weapons")?.key).toBe("anti");
     expect(resolveKeywordEntry("Anti-Psyker 5+", glossary, "weapons")?.key).toBe("anti");
+    expect(resolveKeywordEntry("Anti-Heavy Vehicles 4+", glossary, "weapons")?.key).toBe("anti");
+  });
+
+  it("matches text-only values for hyphenated parameterized entries", () => {
+    expect(resolveKeywordEntry("Anti-Vehicle", glossary, "weapons")?.key).toBe("anti");
+    expect(resolveKeywordEntry("Anti-Heavy Vehicles", glossary, "weapons")?.key).toBe("anti");
+  });
+
+  it("matches parameterized entries with numeric, save, dice, and dice-plus values", () => {
     expect(resolveKeywordEntry("Rapid Fire 2", glossary, "weapons")?.key).toBe("rapid-fire");
+    expect(resolveKeywordEntry("Sustained Hits 2", glossary, "weapons")?.key).toBe("sustained-hits");
+    expect(resolveKeywordEntry("Melta D6", glossary, "weapons")?.key).toBe("melta");
+    expect(resolveKeywordEntry("Melta D6+2", glossary, "weapons")?.key).toBe("melta");
+    expect(resolveKeywordEntry("Melta 2D6+2", glossary, "weapons")?.key).toBe("melta");
+  });
+
+  it("matches a bare parameterized keyword name but not unrelated trailing text", () => {
+    expect(resolveKeywordEntry("Sustained Hits", glossary, "weapons")?.key).toBe("sustained-hits");
+    expect(resolveKeywordEntry("Sustained Hits in melee", glossary, "weapons")).toBeNull();
+  });
+
+  it("does not consume unbounded words before a parameter value", () => {
+    expect(resolveKeywordEntry("Sustained Hits also gives extra Pain 5+", glossary, "weapons")).toBeNull();
   });
 
   it("does not match unrelated keywords", () => {
@@ -159,7 +202,7 @@ describe("findGlossaryMatchesInText", () => {
       key: "feel-no-pain",
       name: "Feel No Pain",
       description: "Roll to ignore a lost wound.",
-      matchType: "exact",
+      matchType: "parameterized",
       appliesTo: ["abilities"],
       displayMode: "tooltip",
     },
@@ -194,6 +237,43 @@ describe("findGlossaryMatchesInText", () => {
     expect(matches).toHaveLength(1);
     expect(matches[0].entry.key).toBe("feel-no-pain");
     expect(matches[0].text).toBe("feel no pain");
+  });
+
+  it("includes parameterized keyword values in the matched tooltip span", () => {
+    const matches = findGlossaryMatchesInText(
+      "This model has Feel No Pain 5+ and Sustained Hits D6+2.",
+      [
+        ...abilityGlossary,
+        {
+          key: "sustained-hits",
+          name: "Sustained Hits",
+          description: "Extra hits.",
+          matchType: "parameterized",
+          appliesTo: ["abilities"],
+          displayMode: "tooltip",
+        },
+      ],
+      "abilities",
+    );
+    expect(matches.map((m) => m.text)).toEqual(["Feel No Pain 5+", "Sustained Hits D6+2"]);
+  });
+
+  it("does not underline long prose as a parameterized keyword value", () => {
+    const matches = findGlossaryMatchesInText(
+      "Sustained Hits also gives extra Pain 5+ models.",
+      [
+        {
+          key: "sustained-hits",
+          name: "Sustained Hits",
+          description: "Extra hits.",
+          matchType: "parameterized",
+          appliesTo: ["abilities"],
+          displayMode: "tooltip",
+        },
+      ],
+      "abilities",
+    );
+    expect(matches.map((m) => m.text)).toEqual(["Sustained Hits"]);
   });
 
   it("returns multiple matches sorted by position", () => {

--- a/src/Helpers/__tests__/keywordGlossaryDefaults.test.js
+++ b/src/Helpers/__tests__/keywordGlossaryDefaults.test.js
@@ -51,7 +51,7 @@ describe("WARHAMMER_40K_10E_KEYWORD_GLOSSARY", () => {
       expect(entry.name.length).toBeGreaterThan(0);
       expect(typeof entry.description).toBe("string");
       expect(entry.description.length).toBeGreaterThan(0);
-      expect(["exact", "prefix"]).toContain(entry.matchType);
+      expect(["exact", "prefix", "parameterized"]).toContain(entry.matchType);
     }
   });
 
@@ -62,12 +62,12 @@ describe("WARHAMMER_40K_10E_KEYWORD_GLOSSARY", () => {
     }
   });
 
-  it("uses prefix matching for parametrised rules", () => {
+  it("uses parameterized matching for parametrised rules", () => {
     const byName = Object.fromEntries(WARHAMMER_40K_10E_KEYWORD_GLOSSARY.map((e) => [e.name, e]));
-    expect(byName["Anti-"].matchType).toBe("prefix");
-    expect(byName["Melta"].matchType).toBe("prefix");
-    expect(byName["Rapid Fire"].matchType).toBe("prefix");
-    expect(byName["Sustained Hits"].matchType).toBe("prefix");
-    expect(byName["Feel No Pain"].matchType).toBe("prefix");
+    expect(byName["Anti-"].matchType).toBe("parameterized");
+    expect(byName["Melta"].matchType).toBe("parameterized");
+    expect(byName["Rapid Fire"].matchType).toBe("parameterized");
+    expect(byName["Sustained Hits"].matchType).toBe("parameterized");
+    expect(byName["Feel No Pain"].matchType).toBe("parameterized");
   });
 });

--- a/src/Helpers/customSchema.helpers.js
+++ b/src/Helpers/customSchema.helpers.js
@@ -12,7 +12,7 @@ import { WARHAMMER_40K_10E_KEYWORD_GLOSSARY } from "./keywordGlossaryDefaults";
 export const VALID_BASE_TYPES = ["unit", "rule", "enhancement", "stratagem"];
 
 // Valid match types for keyword glossary entries
-export const VALID_KEYWORD_MATCH_TYPES = ["exact", "prefix"];
+export const VALID_KEYWORD_MATCH_TYPES = ["exact", "prefix", "parameterized"];
 
 // Valid display modes for weapon-scoped keyword glossary entries.
 // Other scopes don't honour this field today.
@@ -1101,11 +1101,46 @@ export const filterGlossaryByScope = (glossary, scope) => {
   return glossary.filter((entry) => Array.isArray(entry?.appliesTo) && entry.appliesTo.includes(scope));
 };
 
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const PARAMETER_VALUE_PATTERN = String.raw`(?:(?:\d+D\d+|D\d+)(?:\+\d+)?|\d+\+|\d+(?:\+\d+)?)`;
+const PARAMETER_WORD_PATTERN = String.raw`[A-Za-z][A-Za-z-]*`;
+const PARAMETER_TOKEN_PATTERN = String.raw`(?:${PARAMETER_WORD_PATTERN}\s+){0,3}${PARAMETER_VALUE_PATTERN}`;
+const TEXT_ONLY_PARAMETER_PATTERN = String.raw`${PARAMETER_WORD_PATTERN}(?:\s+${PARAMETER_WORD_PATTERN}){0,2}`;
+
+const getMatchType = (entry) => (VALID_KEYWORD_MATCH_TYPES.includes(entry?.matchType) ? entry.matchType : "exact");
+
+const createParameterizedKeywordRegex = (needle) => {
+  const separator = /[\s-]$/.test(needle) ? "" : String.raw`\s+`;
+  const textOnlySuffix = /-$/.test(needle) ? String.raw`|${TEXT_ONLY_PARAMETER_PATTERN}` : "";
+  return new RegExp(
+    String.raw`^${escapeRegExp(needle)}(?:${separator}(?:${PARAMETER_TOKEN_PATTERN}${textOnlySuffix}))?$`,
+    "i",
+  );
+};
+
+const createGlossaryTextRegex = (needle, matchType) => {
+  const escaped = escapeRegExp(needle);
+  if (matchType === "parameterized") {
+    const separator = /[\s-]$/.test(needle) ? "" : String.raw`\s+`;
+    const textOnlySuffix = /-$/.test(needle) ? String.raw`|${TEXT_ONLY_PARAMETER_PATTERN}` : "";
+    // Keep the leading boundary permissive around "-" so entries like "Anti-"
+    // can start inside "Anti-Vehicle", but require a stricter trailing boundary
+    // so values like "5+" are not half-matched inside "5+1".
+    return new RegExp(
+      String.raw`(?<![A-Za-z0-9])${escaped}(?:${separator}(?:${PARAMETER_TOKEN_PATTERN}${textOnlySuffix}))?(?![A-Za-z0-9+-])`,
+      "gi",
+    );
+  }
+  return new RegExp(String.raw`(?<![A-Za-z0-9])${escaped}(?![A-Za-z0-9])`, "gi");
+};
+
 /**
  * Resolves a keyword tag to its glossary entry, if any, within a given scope.
  * Match rules:
- *   - "exact"  → case-insensitive equality
- *   - "prefix" → case-insensitive startsWith match
+ *   - "exact"         → case-insensitive equality
+ *   - "prefix"        → case-insensitive startsWith match
+ *   - "parameterized" → exact entry name, optionally followed by a value
  * When multiple entries match the same keyword, the entry with the longest
  * `name` wins so specific entries (e.g. "Twin-linked") take precedence over
  * shorter prefixes that happen to be substrings.
@@ -1127,8 +1162,13 @@ export const resolveKeywordEntry = (keyword, glossary, scope) => {
     if (!entry?.name || typeof entry.name !== "string") continue;
     const needle = entry.name.toLowerCase().trim();
     if (!needle) continue;
-    const matchType = entry.matchType === "prefix" ? "prefix" : "exact";
-    const matches = matchType === "prefix" ? haystack.startsWith(needle) : haystack === needle;
+    const matchType = getMatchType(entry);
+    const matches =
+      matchType === "prefix"
+        ? haystack.startsWith(needle)
+        : matchType === "parameterized"
+          ? createParameterizedKeywordRegex(needle).test(haystack)
+          : haystack === needle;
     if (matches && (!best || needle.length > best.name.toLowerCase().trim().length)) {
       best = entry;
     }
@@ -1195,8 +1235,7 @@ export const findGlossaryMatchesInText = (text, glossary, scope) => {
   const matches = [];
   for (const entry of sorted) {
     const needle = entry.name.trim();
-    const pattern = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const re = new RegExp(`(?<![A-Za-z0-9])${pattern}(?![A-Za-z0-9])`, "gi");
+    const re = createGlossaryTextRegex(needle, getMatchType(entry));
     let m;
     while ((m = re.exec(text)) !== null) {
       const start = m.index;

--- a/src/Helpers/keywordGlossaryDefaults.js
+++ b/src/Helpers/keywordGlossaryDefaults.js
@@ -8,9 +8,9 @@
  * `schema.keywordGlossary` array; this list is the starter set.
  *
  * Fields:
- *   - matchType: "exact" (case-insensitive equality) or "prefix"
- *     (case-insensitive startsWith), the latter used for parametrised rules
- *     like "Anti-Infantry 4+" or "Melta 2".
+ *   - matchType: "exact" (case-insensitive equality), "prefix"
+ *     (case-insensitive startsWith), or "parameterized" for rules with a
+ *     variable value like "Sustained Hits 2", "Feel No Pain 5+", or "Melta D6+2".
  *   - appliesTo: scopes in which a renderer may use the entry. Today the
  *     seeded entries are weapon-keyword explanations; future scopes
  *     (abilities, unit-keywords, rules, stratagems, enhancements) will
@@ -25,7 +25,7 @@ export const WARHAMMER_40K_10E_KEYWORD_GLOSSARY = [
     key: "anti",
     name: "Anti-",
     description: "An unmodified Wound roll of 'x+' against a target with the matching keyword scores a Critical Wound.",
-    matchType: "prefix",
+    matchType: "parameterized",
     appliesTo: ["weapons"],
   },
   {
@@ -65,7 +65,7 @@ export const WARHAMMER_40K_10E_KEYWORD_GLOSSARY = [
     name: "Feel No Pain",
     description:
       "Each time this model would lose a wound, roll one D6: if the result equals or exceeds 'x', that wound is not lost.",
-    matchType: "prefix",
+    matchType: "parameterized",
     appliesTo: ["weapons"],
   },
   {
@@ -132,7 +132,7 @@ export const WARHAMMER_40K_10E_KEYWORD_GLOSSARY = [
     name: "Melta",
     description:
       "Each time an attack made with this weapon targets a unit within half that weapon's range, that attack's Damage characteristic is increased by the amount denoted by 'x'.",
-    matchType: "prefix",
+    matchType: "parameterized",
     appliesTo: ["weapons"],
   },
   {
@@ -179,14 +179,14 @@ export const WARHAMMER_40K_10E_KEYWORD_GLOSSARY = [
     key: "rapid-fire",
     name: "Rapid Fire",
     description: "Increase the Attacks by 'x' when targeting units within half range.",
-    matchType: "prefix",
+    matchType: "parameterized",
     appliesTo: ["weapons"],
   },
   {
     key: "sustained-hits",
     name: "Sustained Hits",
     description: "Each Critical Hit scores 'x' additional hits on the target.",
-    matchType: "prefix",
+    matchType: "parameterized",
     appliesTo: ["weapons"],
   },
   {

--- a/src/Pages/Help/content/datasource/keyword-glossary.mdx
+++ b/src/Pages/Help/content/datasource/keyword-glossary.mdx
@@ -9,7 +9,7 @@ You'll find the glossary editor in the **right panel** when the datasource itsel
 | Property | Description |
 |----------|-------------|
 | **Name** | The keyword as it appears on cards (e.g. `One Shot`, `Anti-`). |
-| **Match type** | **Exact** matches the whole keyword. **Prefix** matches the start of the keyword — use this for rules with a number suffix, so a single `Anti-` entry covers `Anti-Infantry 4+`, `Anti-Psyker 5+`, and any other variant. |
+| **Match type** | **Exact** matches the whole keyword. **Prefix** matches the start of the keyword. **Parameterized** matches the keyword plus an optional value, so one entry can cover `Sustained Hits 2`, `Feel No Pain 5+`, `Melta D6+2`, or `Anti-Vehicle 4+`. |
 | **Storage key** | Auto-generated from the name. You rarely need to touch this — only edit it if you want a stable id that won't change when you rename the entry. |
 | **Applies to** | Where the description gets used: Weapons, Abilities, Unit keywords, Rules, Stratagems, or Enhancements. New entries default to **Weapons**. One entry can cover several places at once — handy for keywords like *Lethal Hits* that show up both on weapons and inside ability text. |
 | **Display mode** | Weapons only. Picks how the description appears (see below). |
@@ -25,7 +25,7 @@ You'll find the glossary editor in the **right panel** when the datasource itsel
 When a card renders a keyword, it:
 
 1. Looks at every glossary entry whose **Applies to** includes that part of the card.
-2. Picks the entry with the longest matching **Name** (by exact or prefix match).
+2. Picks the entry with the longest matching **Name** (by exact, prefix, or parameterized match).
 3. Renders the description as a row (or a tooltip, for weapons in tooltip mode). If two weapons share a keyword, the row only shows up once.
 
 ### Tips
@@ -33,4 +33,4 @@ When a card renders a keyword, it:
 - Use the **+** in the section header to add an entry. The **⋯** menu has a **Restore defaults** action that replaces the glossary with the 40K 10e seed set.
 - For common rules like *Lethal Hits* and *Sustained Hits*, **Hover tooltip** keeps the card clean.
 - For unique or one-off rules like *Plasma Warhead* or *Hazardous*, **Explanation row** keeps the description on screen at all times.
-- For rules that take a number (`Rapid Fire`, `Melta`, `Anti-…`), use **Prefix** matching so one entry covers every variant.
+- For rules that take a value (`Rapid Fire`, `Melta`, `Sustained Hits`, `Feel No Pain`, `Anti-…`), use **Parameterized** matching so one entry covers every variant.


### PR DESCRIPTION
## Summary
- add a parameterized glossary match type for keywords with values like Sustained Hits 2, Feel No Pain 5+, Melta D6+2, and Anti-Vehicle 4+
- update 40K defaults, editor options, glossary display, and help/docs
- cover resolver, free-text tooltip, and weapon rendering behavior with tests

## Tests
- npx vitest run src/Helpers/__tests__/keywordGlossary.test.js src/Helpers/__tests__/keywordGlossaryDefaults.test.js src/Components/DatasourceEditor/editors/__tests__/KeywordGlossaryEditor.test.jsx src/Components/DatasourceEditor/cards/shared/__tests__/GlossaryKeywords.test.jsx src/Components/DatasourceEditor/cards/units/__tests__/Ds40kUnitWeapons.glossary.test.jsx src/Components/Glossary/__tests__/GlossaryList.test.jsx