### PR TITLE
Fix custom datasource crash on mobile list importer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,7 @@ Two-mode wizard (`src/Components/DatasourceWizard/`) for creating datasources ("
 ### Datasource Validation Limits
 
 - Max 200 char names, 50 char versions
-- Max 10 factions, 2000 total cards
+- Max 25 factions, 2000 total cards
 - Schema export/import via JSON
 
 ## Card Designer (Premium)

--- a/docs/custom-datasource-format.md
+++ b/docs/custom-datasource-format.md
@@ -61,7 +61,7 @@ For schema definitions, see [datasource-schema-architecture.md](custom%20datasou
 | `author`      | string | No       | Author name |
 | `lastUpdated` | string | No       | ISO 8601 timestamp |
 | `schema`      | object | No       | Schema definition (see [Schema Object](#schema-object)) |
-| `data`        | array  | Yes      | Array of faction objects (1 to 10 factions) |
+| `data`        | array  | Yes      | Array of faction objects (1 to 25 factions) |
 
 ## Faction Object
 

--- a/src/Helpers/__tests__/customDatasource.helpers.test.js
+++ b/src/Helpers/__tests__/customDatasource.helpers.test.js
@@ -100,7 +100,7 @@ describe("validateCustomDatasource", () => {
   });
 
   it("returns invalid when too many factions", () => {
-    const factions = Array.from({ length: 11 }, (_, i) => ({
+    const factions = Array.from({ length: 26 }, (_, i) => ({
       id: `f-${i}`,
       name: `Faction ${i}`,
       colours: { header: "#000", banner: "#111" },

--- a/src/Helpers/__tests__/functions.test.js
+++ b/src/Helpers/__tests__/functions.test.js
@@ -679,7 +679,7 @@ describe("customDatasource.helpers", () => {
     });
 
     it("should reject too many factions", () => {
-      const manyFactions = Array(11)
+      const manyFactions = Array(26)
         .fill(null)
         .map((_, i) => ({
           id: `faction-${i}`,

--- a/src/Helpers/customDatasource.helpers.js
+++ b/src/Helpers/customDatasource.helpers.js
@@ -7,7 +7,7 @@ export const VALID_DISPLAY_FORMATS = ["40k-10e", "40k", "basic", "necromunda", "
 // Validation limits for security
 const MAX_NAME_LENGTH = 200;
 const MAX_VERSION_LENGTH = 50;
-const MAX_FACTION_COUNT = 10;
+const MAX_FACTION_COUNT = 25;
 const MAX_CARD_COUNT = 2000;
 const MAX_STRING_FIELD_LENGTH = 10000;
 

--- a/src/Helpers/listforgeImport.helpers.js
+++ b/src/Helpers/listforgeImport.helpers.js
@@ -353,8 +353,11 @@ export const buildCoreAbilitySet = (factions) => {
     if (!Array.isArray(faction.datasheets)) continue;
     for (const sheet of faction.datasheets) {
       if (Array.isArray(sheet.abilities?.core)) {
-        for (const name of sheet.abilities.core) {
-          coreNames.add(name.toLowerCase());
+        for (const entry of sheet.abilities.core) {
+          // Built-in 40K datasources store core abilities as bare strings;
+          // custom datasources store them as `{ name, showAbility, ... }`.
+          const name = typeof entry === "string" ? entry : entry?.name;
+          if (typeof name === "string") coreNames.add(name.toLowerCase());
         }
       }
     }


### PR DESCRIPTION
## Summary

- `buildCoreAbilitySet` crashed with `s.toLowerCase is not a function` whenever a custom datasource was selected on mobile. Built-in 40K data stores core abilities as bare strings, but custom datasources store them as `{ name, showAbility, ... }` objects. Extract `name` from the object and skip non-string entries.
- Raise `MAX_FACTION_COUNT` from 10 to 25 so larger custom datasources (e.g. the 12-faction Monster Hunter datasource reported in the bug) can be imported. Tests + docs updated.

## Test plan
- [x] `yarn test:ci` for `listforgeImport.helpers`, `customDatasource.helpers`, and `functions` (460 tests pass)
- [x] `yarn lint`
- [ ] Manually load a 12-faction custom datasource on mobile and confirm faction selection no longer crashes