### PR TITLE
Allow agent edits: use relative paths for in-project edit rules

### DIFF
--- a/.github/issue-to-pr/README.md
+++ b/.github/issue-to-pr/README.md
@@ -76,6 +76,9 @@ review gate is the backstop. Use a dedicated, rotatable key for this pipeline.
   "Run OpenCode" step substitutes the real absolute path (via `sed`) before
   running, so the permission globs and the `external_directory` grant resolve
   correctly. Edit the placeholders, not hardcoded `/home/runner/...` paths.
+- OpenCode matches **in-project** `edit` rules against paths relative to the app
+  root (`src/**`, `docs/**`); only the **external** (`gdc-premium`) rules use
+  absolute paths. Don't make the app's edit rules absolute or they won't match.
 - OpenCode auto-installs the `@ai-sdk/openai-compatible` provider package named in
   `opencode.json` (confirmed working in CI).
 - If the model rejects the request over `max_tokens`, lower `limit.output` in

--- a/.github/issue-to-pr/opencode.json
+++ b/.github/issue-to-pr/opencode.json
@@ -25,6 +25,8 @@
     },
     "edit": {
       "*": "deny",
+      "src/**": "allow",
+      "docs/**": "allow",
       "GDCWS/game-datacards/src/**": "allow",
       "GDCWS/game-datacards/docs/**": "allow",
       "GDCWS/gdc-premium/src/**": "allow",


### PR DESCRIPTION
## Problem
On the first full run, the OpenCode agent loaded context and started implementing, but every `Edit` to an app file (e.g. `src/Components/DatasourceEditor/EditorLeftPanel.jsx`) was rejected, so it produced no changes.

Cause: OpenCode matches **in-project** `edit` permission rules against the path **relative to the project root** (`src/Components/...`), but the app's allow-rules were written as **absolute** paths. They never matched, so the `edit: deny *` fallback won. (OpenCode's docs use relative globs for in-project edits and absolute only for `external_directory`.)

## Fix
Add relative `src/**` and `docs/**` allow-rules for the app (kept the absolute ones as a backstop). The premium package stays on absolute paths because it is external to the app root.

After merge: remove `ai-attempted` and re-add `ai-build` on a from-discord enhancement issue to retry.