### PR TITLE
AI draft: Add card sorting and subcategories in datasource editor (#222)

### DIFF
--- a/docs/custom datasource/datasource-schema-architecture.md
+++ b/docs/custom datasource/datasource-schema-architecture.md
@@ -366,6 +366,7 @@ Sections are optional content blocks rendered below weapons on unit cards. Each 
 | `bannerType`       | string  | Controls the header banner text. Only applies when `baseSystem` is not `"40k-10e"`. |
 | `bannerCustomText` | string  | Custom banner text. Only applies when `bannerType` is `"custom"`.       |
 | `hasAutoResize`    | boolean | Starcraft TMG and 40k-10e only. Exposes a per-card "Auto-resize card" toggle in the Basic Information panel. When the card sets `styling.autoHeight = true`, the rendered card grows beyond its standard 714px frame to fit overflowing content. |
+| `hasSubcategory`   | boolean | Exposes a per-card "Subcategory" text field in the Basic Information panel. When set, cards are grouped under their `subcategory` value (uncategorised cards under "Uncategorized") in the datasource editor card list. Toggled via the card type settings. |
 
 #### Banner type values (AoS / non-40k only)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-datacards",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "The only tool you will ever need for your custom datacards",
   "private": false,
   "homepage": "https://game-datacards.eu",

--- a/src/Components/DatasourceEditor/DatasourceCardEditor.jsx
+++ b/src/Components/DatasourceEditor/DatasourceCardEditor.jsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { Col } from "antd";
-import { Layers } from "lucide-react";
+import { Layers, Tag } from "lucide-react";
 import { resolveCardType } from "../Custom/CustomCardDisplay";
 import {
   CardEditProvider,
@@ -9,7 +9,7 @@ import {
   TemplateSelector,
   usePremiumFeatures,
 } from "../../Premium";
-import { Section } from "./components";
+import { Section, CompactInput } from "./components";
 
 /**
  * Card editor wrapper for the Datasource Editor right panel.
@@ -27,6 +27,14 @@ export const DatasourceCardEditor = ({ card, activeDatasource, onUpdateCard }) =
     (templateId) => {
       if (!onUpdateCard) return;
       onUpdateCard({ ...card, templateId: templateId || undefined });
+    },
+    [card, onUpdateCard],
+  );
+
+  const handleSubcategoryChange = useCallback(
+    (value) => {
+      if (!onUpdateCard) return;
+      onUpdateCard({ ...card, subcategory: value || undefined });
     },
     [card, onUpdateCard],
   );
@@ -59,6 +67,16 @@ export const DatasourceCardEditor = ({ card, activeDatasource, onUpdateCard }) =
       factions={activeDatasource.data || []}
       datasourceSchema={activeDatasource.schema}>
       <div className="props-body">
+        <Section title="Subcategory" icon={Tag} defaultOpen={true}>
+          <CompactInput
+            label="Group"
+            ariaLabel="Card subcategory"
+            value={card.subcategory || ""}
+            onChange={handleSubcategoryChange}
+            type="text"
+            placeholder="e.g. Core, Elite..."
+          />
+        </Section>
         {hasCardDesigner && (
           <Section title="Template" icon={Layers} defaultOpen={true}>
             <TemplateSelector

--- a/src/Components/DatasourceEditor/DatasourceCardEditor.jsx
+++ b/src/Components/DatasourceEditor/DatasourceCardEditor.jsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { Col } from "antd";
-import { Layers, Tag } from "lucide-react";
+import { Layers } from "lucide-react";
 import { resolveCardType } from "../Custom/CustomCardDisplay";
 import {
   CardEditProvider,
@@ -9,7 +9,7 @@ import {
   TemplateSelector,
   usePremiumFeatures,
 } from "../../Premium";
-import { Section, CompactInput } from "./components";
+import { Section } from "./components";
 
 /**
  * Card editor wrapper for the Datasource Editor right panel.
@@ -27,14 +27,6 @@ export const DatasourceCardEditor = ({ card, activeDatasource, onUpdateCard }) =
     (templateId) => {
       if (!onUpdateCard) return;
       onUpdateCard({ ...card, templateId: templateId || undefined });
-    },
-    [card, onUpdateCard],
-  );
-
-  const handleSubcategoryChange = useCallback(
-    (value) => {
-      if (!onUpdateCard) return;
-      onUpdateCard({ ...card, subcategory: value || undefined });
     },
     [card, onUpdateCard],
   );
@@ -67,16 +59,6 @@ export const DatasourceCardEditor = ({ card, activeDatasource, onUpdateCard }) =
       factions={activeDatasource.data || []}
       datasourceSchema={activeDatasource.schema}>
       <div className="props-body">
-        <Section title="Subcategory" icon={Tag} defaultOpen={true}>
-          <CompactInput
-            label="Group"
-            ariaLabel="Card subcategory"
-            value={card.subcategory || ""}
-            onChange={handleSubcategoryChange}
-            type="text"
-            placeholder="e.g. Core, Elite..."
-          />
-        </Section>
         {hasCardDesigner && (
           <Section title="Template" icon={Layers} defaultOpen={true}>
             <TemplateSelector

--- a/src/Components/DatasourceEditor/DatasourceEditor.css
+++ b/src/Components/DatasourceEditor/DatasourceEditor.css
@@ -455,6 +455,23 @@
 
 .designer-card-type-tab {
   flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  border-radius: 6px;
+  background: transparent;
+  transition: all 0.15s ease;
+}
+
+.designer-card-type-tab.active {
+  background: var(--designer-bg-primary);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+/* Tab label button — selects the card type */
+.designer-card-type-tab-select {
+  flex: 1;
+  min-width: 0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -467,18 +484,53 @@
   font-size: 11px;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.15s ease;
+  transition: color 0.15s ease;
   white-space: nowrap;
 }
 
-.designer-card-type-tab:hover {
+.designer-card-type-tab-select span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.designer-card-type-tab:hover .designer-card-type-tab-select,
+.designer-card-type-tab.active .designer-card-type-tab-select {
   color: var(--designer-text-primary);
 }
 
-.designer-card-type-tab.active {
-  background: var(--designer-bg-primary);
-  color: var(--designer-text-primary);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+/* Per-card-type sort toggle — cycles none / A-Z / Z-A */
+.designer-card-type-tab-sort {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  margin-right: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--designer-text-tertiary);
+  cursor: pointer;
+  opacity: 0.6;
+  transition: all 0.15s ease;
+}
+
+.designer-card-type-tab-sort:hover {
+  background: var(--designer-accent-subtle);
+  color: var(--designer-accent);
+  opacity: 1;
+}
+
+.designer-card-type-tab-sort.is-active {
+  color: var(--designer-accent);
+  opacity: 1;
+}
+
+.designer-card-type-tab-sort:focus-visible {
+  outline: 2px solid var(--designer-accent);
+  outline-offset: -1px;
 }
 
 /* Faction switcher — native <select> dropdown, only rendered when the
@@ -557,41 +609,6 @@
   padding: 1px 6px;
   background: var(--designer-bg-secondary);
   border-radius: 8px;
-}
-
-/* Sort select in the Cards panel header */
-.designer-panel-header-actions {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.designer-sort-select {
-  padding: 3px 22px 3px 6px;
-  border: 1px solid var(--designer-border);
-  border-radius: var(--designer-radius-sm);
-  background-color: var(--designer-bg-secondary);
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
-  background-repeat: no-repeat;
-  background-position: right 4px center;
-  color: var(--designer-text-secondary);
-  font-size: 11px;
-  font-weight: 500;
-  cursor: pointer;
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  transition: border-color 0.15s ease;
-}
-
-.designer-sort-select:hover {
-  border-color: var(--designer-accent);
-}
-
-.designer-sort-select:focus-visible {
-  outline: 2px solid var(--designer-accent);
-  outline-offset: -1px;
-  border-color: var(--designer-accent);
 }
 
 /* ===========================================

--- a/src/Components/DatasourceEditor/DatasourceEditor.css
+++ b/src/Components/DatasourceEditor/DatasourceEditor.css
@@ -522,6 +522,78 @@
   padding: 0 8px;
 }
 
+/* Card subcategory group header */
+.designer-card-subcategory {
+  margin-bottom: 4px;
+}
+
+.designer-card-subcategory-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--designer-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  background: var(--designer-bg-tertiary);
+  border-radius: var(--designer-radius-sm);
+  margin: 4px 0;
+}
+
+.designer-card-subcategory-header svg {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  color: var(--designer-text-tertiary);
+}
+
+.designer-card-subcategory-count {
+  margin-left: auto;
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--designer-text-muted);
+  padding: 1px 6px;
+  background: var(--designer-bg-secondary);
+  border-radius: 8px;
+}
+
+/* Sort select in the Cards panel header */
+.designer-panel-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.designer-sort-select {
+  padding: 3px 22px 3px 6px;
+  border: 1px solid var(--designer-border);
+  border-radius: var(--designer-radius-sm);
+  background-color: var(--designer-bg-secondary);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 4px center;
+  color: var(--designer-text-secondary);
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  transition: border-color 0.15s ease;
+}
+
+.designer-sort-select:hover {
+  border-color: var(--designer-accent);
+}
+
+.designer-sort-select:focus-visible {
+  outline: 2px solid var(--designer-accent);
+  outline-offset: -1px;
+  border-color: var(--designer-accent);
+}
+
 /* ===========================================
    EMPTY STATES
    =========================================== */

--- a/src/Components/DatasourceEditor/EditorLeftPanel.jsx
+++ b/src/Components/DatasourceEditor/EditorLeftPanel.jsx
@@ -13,7 +13,19 @@ import {
   Download,
   Upload,
   Tag,
+  ArrowUpDown,
+  ArrowDownAZ,
+  ArrowDownZA,
 } from "lucide-react";
+
+// Sort cycle for a card type's card list: none -> A-Z -> Z-A -> none.
+const SORT_ORDERS = ["default", "asc", "desc"];
+const SORT_META = {
+  default: { Icon: ArrowUpDown, label: "No sorting" },
+  asc: { Icon: ArrowDownAZ, label: "Sorted A to Z" },
+  desc: { Icon: ArrowDownZA, label: "Sorted Z to A" },
+};
+const nextSortOrder = (order) => SORT_ORDERS[(SORT_ORDERS.indexOf(order) + 1) % SORT_ORDERS.length];
 import { DatasourceSyncIcon } from "../../Premium";
 import { ActiveItemToolbar } from "../Shared/ActiveItemToolbar";
 import { getTargetArray } from "../../Helpers/customDatasource.helpers";
@@ -54,7 +66,11 @@ export const EditorLeftPanel = ({
   const [datasourceListOpen, setDatasourceListOpen] = useState(false);
   const [activeCardTypeTab, setActiveCardTypeTab] = useState(null);
   const [activeFactionId, setActiveFactionId] = useState(null);
-  const [sortOrder, setSortOrder] = useState("default");
+  // Sort order is tracked per card type so each tab keeps its own choice.
+  const [sortOrders, setSortOrders] = useState({});
+
+  const cycleSortOrder = (cardTypeKey) =>
+    setSortOrders((prev) => ({ ...prev, [cardTypeKey]: nextSortOrder(prev[cardTypeKey] || "default") }));
 
   if (!activeDatasource && datasources.length === 0) {
     return (
@@ -289,36 +305,31 @@ export const EditorLeftPanel = ({
                 factionId={resolvedFactionId}
               />
             </h3>
-            <div className="designer-panel-header-actions">
-              <select
-                className="designer-sort-select"
-                value={sortOrder}
-                onChange={(e) => setSortOrder(e.target.value)}
-                aria-label="Sort order">
-                <option value="default">Default</option>
-                <option value="asc">A to Z</option>
-                <option value="desc">Z to A</option>
-              </select>
-              <button
-                className="designer-panel-header-action"
-                onClick={() => activeCardType && onAddCard?.(activeCardType, resolvedFactionId)}
-                title={`Add ${activeCardType?.label || "card"}`}>
-                <Plus size={14} />
-              </button>
-            </div>
+            <button
+              className="designer-panel-header-action"
+              onClick={() => activeCardType && onAddCard?.(activeCardType, resolvedFactionId)}
+              title={`Add ${activeCardType?.label || "card"}`}>
+              <Plus size={14} />
+            </button>
           </div>
           <div className="designer-panel-content">
             {factions.length > 1 && (
               <FactionSwitcher factions={factions} activeFactionId={resolvedFactionId} onChange={setActiveFactionId} />
             )}
-            <CardTypeTabBar cardTypes={cardTypes} activeTab={activeCardTypeKey} onTabChange={setActiveCardTypeTab} />
+            <CardTypeTabBar
+              cardTypes={cardTypes}
+              activeTab={activeCardTypeKey}
+              sortOrders={sortOrders}
+              onTabChange={setActiveCardTypeTab}
+              onCycleSort={cycleSortOrder}
+            />
             <CardList
               activeDatasource={activeDatasource}
               cardTypeKey={activeCardTypeKey}
               cardTypes={cardTypes}
               factionId={resolvedFactionId}
               selectedItem={selectedItem}
-              sortOrder={sortOrder}
+              sortOrder={sortOrders[activeCardTypeKey] || "default"}
               onSelectCard={onSelectCard}
               onDeleteCard={onDeleteCard}
             />
@@ -354,19 +365,29 @@ const FactionSwitcher = ({ factions, activeFactionId, onChange }) => (
   </div>
 );
 
-const CardTypeTabBar = ({ cardTypes, activeTab, onTabChange }) => (
+const CardTypeTabBar = ({ cardTypes, activeTab, sortOrders, onTabChange, onCycleSort }) => (
   <div className="designer-card-type-tabs">
     {cardTypes.map((ct) => {
       const Icon = BASETYPE_ICONS[ct.baseType] || BookOpen;
+      const order = sortOrders?.[ct.key] || "default";
+      const { Icon: SortIcon, label: sortLabel } = SORT_META[order];
       return (
-        <button
-          key={ct.key}
-          className={`designer-card-type-tab ${activeTab === ct.key ? "active" : ""}`}
-          onClick={() => onTabChange(ct.key)}
-          title={ct.label}>
-          <Icon size={12} />
-          <span>{ct.label}</span>
-        </button>
+        <div key={ct.key} className={`designer-card-type-tab ${activeTab === ct.key ? "active" : ""}`}>
+          <button className="designer-card-type-tab-select" onClick={() => onTabChange(ct.key)} title={ct.label}>
+            <Icon size={12} />
+            <span>{ct.label}</span>
+          </button>
+          <button
+            className={`designer-card-type-tab-sort ${order !== "default" ? "is-active" : ""}`}
+            onClick={() => {
+              onTabChange(ct.key);
+              onCycleSort(ct.key);
+            }}
+            title={`${ct.label}: ${sortLabel} (click to change)`}
+            aria-label={`Sort ${ct.label} cards: ${sortLabel}`}>
+            <SortIcon size={12} />
+          </button>
+        </div>
       );
     })}
   </div>
@@ -392,33 +413,14 @@ const CardList = ({
   const targetArray = getTargetArray(cardTypeKey);
   const cards = (faction[targetArray] || []).filter((c) => c.cardType === cardTypeKey);
 
+  // Subcategory grouping is opt-in per card type (toggled in the card type settings).
+  const subcategoriesEnabled = !!cardTypeDef.schema?.metadata?.hasSubcategory;
+
   const sortCards = (arr) => {
     if (sortOrder === "asc") return [...arr].sort((a, b) => (a.name || "").localeCompare(b.name || ""));
     if (sortOrder === "desc") return [...arr].sort((a, b) => (b.name || "").localeCompare(a.name || ""));
     return arr;
   };
-
-  // Group cards by subcategory, preserving the original order of groups
-  const groups = [];
-  const subcategoryIndex = new Map();
-  let groupOrder = 0;
-
-  for (const card of cards) {
-    const key = card.subcategory || "";
-    if (!subcategoryIndex.has(key)) {
-      subcategoryIndex.set(key, groupOrder++);
-      groups.push({ label: key || "Uncategorized", key, order: groupOrder, cards: [] });
-    }
-    groups[subcategoryIndex.get(key)].cards.push(card);
-  }
-
-  // Sort groups by their original order, sort cards within each group
-  groups.sort((a, b) => a.order - b.order);
-  for (const group of groups) {
-    group.cards = sortCards(group.cards);
-  }
-
-  const showSubcategoryHeaders = groups.length > 1 || (groups.length === 1 && groups[0].key !== "");
 
   if (cards.length === 0) {
     return (
@@ -430,81 +432,77 @@ const CardList = ({
     );
   }
 
-  if (showSubcategoryHeaders) {
-    return (
-      <div className="designer-card-list">
-        {groups.map((group) => (
-          <div key={group.key || "__uncategorized__"} className="designer-card-subcategory">
-            <div className="designer-card-subcategory-header">
-              <Tag size={12} />
-              <span>{group.label}</span>
-              <span className="designer-card-subcategory-count">{group.cards.length}</span>
-            </div>
-            {group.cards.map((card) => (
-              <div
-                key={card.id}
-                className={`designer-layer-item ${selectedItem?.type === "card" && selectedItem?.data?.id === card.id ? "selected" : ""}`}
-                role="button"
-                tabIndex={0}
-                onClick={() => onSelectCard?.(card)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    onSelectCard?.(card);
-                  }
-                }}>
-                <span className="designer-layer-name">{card.name || "Unnamed"}</span>
-                <span className="designer-layer-actions">
-                  <button
-                    className="designer-layer-action-btn danger"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onDeleteCard?.(card.id, card.cardType);
-                    }}
-                    title="Delete card">
-                    <Trash2 size={14} />
-                  </button>
-                </span>
+  const renderCard = (card) => (
+    <CardItem
+      key={card.id}
+      card={card}
+      selected={selectedItem?.type === "card" && selectedItem?.data?.id === card.id}
+      onSelectCard={onSelectCard}
+      onDeleteCard={onDeleteCard}
+    />
+  );
+
+  if (subcategoriesEnabled) {
+    // Group cards by subcategory, preserving the order in which groups first appear.
+    const groups = [];
+    const subcategoryIndex = new Map();
+    for (const card of cards) {
+      const key = card.subcategory || "";
+      if (!subcategoryIndex.has(key)) {
+        subcategoryIndex.set(key, groups.length);
+        groups.push({ label: key || "Uncategorized", key, cards: [] });
+      }
+      groups[subcategoryIndex.get(key)].cards.push(card);
+    }
+
+    const showSubcategoryHeaders = groups.length > 1 || (groups.length === 1 && groups[0].key !== "");
+
+    if (showSubcategoryHeaders) {
+      return (
+        <div className="designer-card-list">
+          {groups.map((group) => (
+            <div key={group.key || "__uncategorized__"} className="designer-card-subcategory">
+              <div className="designer-card-subcategory-header">
+                <Tag size={12} />
+                <span>{group.label}</span>
+                <span className="designer-card-subcategory-count">{group.cards.length}</span>
               </div>
-            ))}
-          </div>
-        ))}
-      </div>
-    );
+              {sortCards(group.cards).map(renderCard)}
+            </div>
+          ))}
+        </div>
+      );
+    }
   }
 
-  const sorted = sortCards(cards);
-  return (
-    <div className="designer-card-list">
-      {sorted.map((card) => (
-        <div
-          key={card.id}
-          className={`designer-layer-item ${selectedItem?.type === "card" && selectedItem?.data?.id === card.id ? "selected" : ""}`}
-          role="button"
-          tabIndex={0}
-          onClick={() => onSelectCard?.(card)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.preventDefault();
-              onSelectCard?.(card);
-            }
-          }}>
-          <span className="designer-layer-name">{card.name || "Unnamed"}</span>
-          <span className="designer-layer-actions">
-            <button
-              className="designer-layer-action-btn danger"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDeleteCard?.(card.id, card.cardType);
-              }}
-              title="Delete card">
-              <Trash2 size={14} />
-            </button>
-          </span>
-        </div>
-      ))}
-    </div>
-  );
+  return <div className="designer-card-list">{sortCards(cards).map(renderCard)}</div>;
 };
+
+const CardItem = ({ card, selected, onSelectCard, onDeleteCard }) => (
+  <div
+    className={`designer-layer-item ${selected ? "selected" : ""}`}
+    role="button"
+    tabIndex={0}
+    onClick={() => onSelectCard?.(card)}
+    onKeyDown={(e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onSelectCard?.(card);
+      }
+    }}>
+    <span className="designer-layer-name">{card.name || "Unnamed"}</span>
+    <span className="designer-layer-actions">
+      <button
+        className="designer-layer-action-btn danger"
+        onClick={(e) => {
+          e.stopPropagation();
+          onDeleteCard?.(card.id, card.cardType);
+        }}
+        title="Delete card">
+        <Trash2 size={14} />
+      </button>
+    </span>
+  </div>
+);
 
 export { BASETYPE_ICONS, BASETYPE_LABELS };

--- a/src/Components/DatasourceEditor/EditorLeftPanel.jsx
+++ b/src/Components/DatasourceEditor/EditorLeftPanel.jsx
@@ -12,6 +12,7 @@ import {
   ChevronUp,
   Download,
   Upload,
+  Tag,
 } from "lucide-react";
 import { DatasourceSyncIcon } from "../../Premium";
 import { ActiveItemToolbar } from "../Shared/ActiveItemToolbar";
@@ -53,6 +54,7 @@ export const EditorLeftPanel = ({
   const [datasourceListOpen, setDatasourceListOpen] = useState(false);
   const [activeCardTypeTab, setActiveCardTypeTab] = useState(null);
   const [activeFactionId, setActiveFactionId] = useState(null);
+  const [sortOrder, setSortOrder] = useState("default");
 
   if (!activeDatasource && datasources.length === 0) {
     return (
@@ -287,12 +289,23 @@ export const EditorLeftPanel = ({
                 factionId={resolvedFactionId}
               />
             </h3>
-            <button
-              className="designer-panel-header-action"
-              onClick={() => activeCardType && onAddCard?.(activeCardType, resolvedFactionId)}
-              title={`Add ${activeCardType?.label || "card"}`}>
-              <Plus size={14} />
-            </button>
+            <div className="designer-panel-header-actions">
+              <select
+                className="designer-sort-select"
+                value={sortOrder}
+                onChange={(e) => setSortOrder(e.target.value)}
+                aria-label="Sort order">
+                <option value="default">Default</option>
+                <option value="asc">A to Z</option>
+                <option value="desc">Z to A</option>
+              </select>
+              <button
+                className="designer-panel-header-action"
+                onClick={() => activeCardType && onAddCard?.(activeCardType, resolvedFactionId)}
+                title={`Add ${activeCardType?.label || "card"}`}>
+                <Plus size={14} />
+              </button>
+            </div>
           </div>
           <div className="designer-panel-content">
             {factions.length > 1 && (
@@ -305,9 +318,9 @@ export const EditorLeftPanel = ({
               cardTypes={cardTypes}
               factionId={resolvedFactionId}
               selectedItem={selectedItem}
+              sortOrder={sortOrder}
               onSelectCard={onSelectCard}
               onDeleteCard={onDeleteCard}
-              onAddCard={onAddCard}
             />
           </div>
         </>
@@ -365,9 +378,9 @@ const CardList = ({
   cardTypes,
   factionId,
   selectedItem,
+  sortOrder,
   onSelectCard,
   onDeleteCard,
-  onAddCard,
 }) => {
   const cardTypeDef = cardTypes.find((ct) => ct.key === cardTypeKey);
   if (!cardTypeDef) return null;
@@ -379,9 +392,91 @@ const CardList = ({
   const targetArray = getTargetArray(cardTypeKey);
   const cards = (faction[targetArray] || []).filter((c) => c.cardType === cardTypeKey);
 
+  const sortCards = (arr) => {
+    if (sortOrder === "asc") return [...arr].sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+    if (sortOrder === "desc") return [...arr].sort((a, b) => (b.name || "").localeCompare(a.name || ""));
+    return arr;
+  };
+
+  // Group cards by subcategory, preserving the original order of groups
+  const groups = [];
+  const subcategoryIndex = new Map();
+  let groupOrder = 0;
+
+  for (const card of cards) {
+    const key = card.subcategory || "";
+    if (!subcategoryIndex.has(key)) {
+      subcategoryIndex.set(key, groupOrder++);
+      groups.push({ label: key || "Uncategorized", key, order: groupOrder, cards: [] });
+    }
+    groups[subcategoryIndex.get(key)].cards.push(card);
+  }
+
+  // Sort groups by their original order, sort cards within each group
+  groups.sort((a, b) => a.order - b.order);
+  for (const group of groups) {
+    group.cards = sortCards(group.cards);
+  }
+
+  const showSubcategoryHeaders = groups.length > 1 || (groups.length === 1 && groups[0].key !== "");
+
+  if (cards.length === 0) {
+    return (
+      <div className="designer-card-list">
+        <div className="designer-empty-state" style={{ padding: "12px 0" }}>
+          <p style={{ fontSize: 12, opacity: 0.6 }}>No {cardTypeDef.label.toLowerCase()} cards yet</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (showSubcategoryHeaders) {
+    return (
+      <div className="designer-card-list">
+        {groups.map((group) => (
+          <div key={group.key || "__uncategorized__"} className="designer-card-subcategory">
+            <div className="designer-card-subcategory-header">
+              <Tag size={12} />
+              <span>{group.label}</span>
+              <span className="designer-card-subcategory-count">{group.cards.length}</span>
+            </div>
+            {group.cards.map((card) => (
+              <div
+                key={card.id}
+                className={`designer-layer-item ${selectedItem?.type === "card" && selectedItem?.data?.id === card.id ? "selected" : ""}`}
+                role="button"
+                tabIndex={0}
+                onClick={() => onSelectCard?.(card)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onSelectCard?.(card);
+                  }
+                }}>
+                <span className="designer-layer-name">{card.name || "Unnamed"}</span>
+                <span className="designer-layer-actions">
+                  <button
+                    className="designer-layer-action-btn danger"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDeleteCard?.(card.id, card.cardType);
+                    }}
+                    title="Delete card">
+                    <Trash2 size={14} />
+                  </button>
+                </span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const sorted = sortCards(cards);
   return (
     <div className="designer-card-list">
-      {cards.map((card) => (
+      {sorted.map((card) => (
         <div
           key={card.id}
           className={`designer-layer-item ${selectedItem?.type === "card" && selectedItem?.data?.id === card.id ? "selected" : ""}`}
@@ -408,11 +503,6 @@ const CardList = ({
           </span>
         </div>
       ))}
-      {cards.length === 0 && (
-        <div className="designer-empty-state" style={{ padding: "12px 0" }}>
-          <p style={{ fontSize: 12, opacity: 0.6 }}>No {cardTypeDef.label.toLowerCase()} cards yet</p>
-        </div>
-      )}
     </div>
   );
 };

--- a/src/Components/DatasourceEditor/__tests__/EditorLeftPanel.test.jsx
+++ b/src/Components/DatasourceEditor/__tests__/EditorLeftPanel.test.jsx
@@ -22,6 +22,7 @@ vi.mock("lucide-react", () => ({
   Download: (props) => <svg data-testid="icon-download" {...props} />,
   Upload: (props) => <svg data-testid="icon-upload" {...props} />,
   HelpCircle: (props) => <svg data-testid="icon-help" {...props} />,
+  Tag: (props) => <svg data-testid="icon-tag" {...props} />,
 }));
 
 const mockDatasource = {
@@ -35,6 +36,20 @@ const mockDatasource = {
       { key: "battle-rules", label: "Battle Rules", baseType: "rule", schema: {} },
     ],
   },
+  data: [
+    {
+      id: "faction-1",
+      name: "Faction",
+      datasheets: [
+        { id: "card-1", name: "Zeta Unit", cardType: "infantry" },
+        { id: "card-2", name: "Alpha Unit", cardType: "infantry" },
+        { id: "card-3", name: "Beta Unit", cardType: "infantry", subcategory: "Core" },
+        { id: "card-4", name: "Gamma Unit", cardType: "infantry", subcategory: "Core" },
+        { id: "card-5", name: "Delta Unit", cardType: "infantry", subcategory: "Elite" },
+      ],
+      rules: [{ id: "card-6", name: "Test Rule", cardType: "battle-rules" }],
+    },
+  ],
 };
 
 const mockDatasources = [mockDatasource, { id: "ds-2", name: "Other DS", version: "2.0.0", schema: { cardTypes: [] } }];
@@ -309,6 +324,89 @@ describe("EditorLeftPanel", () => {
       const treeItems = screen.getAllByText("Test Datasource");
       const treeItem = treeItems[treeItems.length - 1].closest(".designer-layer-item");
       expect(treeItem).toHaveClass("selected");
+    });
+
+    describe("sorting", () => {
+      it("renders sort select in the Cards header", () => {
+        render(<EditorLeftPanel datasources={mockDatasources} activeDatasource={mockDatasource} />);
+        expect(screen.getByLabelText("Sort order")).toBeInTheDocument();
+        expect(screen.getByText("A to Z")).toBeInTheDocument();
+        expect(screen.getByText("Z to A")).toBeInTheDocument();
+      });
+
+      it("sorts cards A-Z when asc selected", async () => {
+        const user = userEvent.setup();
+        render(<EditorLeftPanel datasources={mockDatasources} activeDatasource={mockDatasource} />);
+
+        const sortSelect = screen.getByLabelText("Sort order");
+        await user.selectOptions(sortSelect, "asc");
+
+        // Cards are sorted within subcategory groups: uncategorized (Alpha, Zeta), Core (Beta, Gamma), Elite (Delta)
+        const cardNames = screen
+          .getAllByText(/Unit/)
+          .filter((el) => el.closest(".designer-card-list"))
+          .map((el) => el.textContent);
+        expect(cardNames).toEqual(["Alpha Unit", "Zeta Unit", "Beta Unit", "Gamma Unit", "Delta Unit"]);
+      });
+
+      it("sorts cards Z-A when desc selected", async () => {
+        const user = userEvent.setup();
+        render(<EditorLeftPanel datasources={mockDatasources} activeDatasource={mockDatasource} />);
+
+        const sortSelect = screen.getByLabelText("Sort order");
+        await user.selectOptions(sortSelect, "desc");
+
+        // Cards sorted Z-A within subcategory groups: uncategorized (Zeta, Alpha), Core (Gamma, Beta), Elite (Delta)
+        const cardNames = screen
+          .getAllByText(/Unit/)
+          .filter((el) => el.closest(".designer-card-list"))
+          .map((el) => el.textContent);
+        expect(cardNames).toEqual(["Zeta Unit", "Alpha Unit", "Gamma Unit", "Beta Unit", "Delta Unit"]);
+      });
+    });
+
+    describe("subcategories", () => {
+      it("renders subcategory headers when cards have subcategories set", () => {
+        render(<EditorLeftPanel datasources={mockDatasources} activeDatasource={mockDatasource} />);
+        expect(screen.getByText("Core")).toBeInTheDocument();
+        expect(screen.getByText("Elite")).toBeInTheDocument();
+        expect(screen.getByText("Uncategorized")).toBeInTheDocument();
+      });
+
+      it("does not render subcategory headers when no cards have subcategories", () => {
+        const dsWithoutSubcategories = {
+          ...mockDatasource,
+          data: [
+            {
+              id: "faction-1",
+              name: "Faction",
+              datasheets: [
+                { id: "card-1", name: "Unit A", cardType: "infantry" },
+                { id: "card-2", name: "Unit B", cardType: "infantry" },
+              ],
+              rules: [],
+            },
+          ],
+        };
+        render(<EditorLeftPanel datasources={mockDatasources} activeDatasource={dsWithoutSubcategories} />);
+        expect(screen.queryByText("Uncategorized")).not.toBeInTheDocument();
+        expect(screen.getByText("Unit A")).toBeInTheDocument();
+        expect(screen.getByText("Unit B")).toBeInTheDocument();
+      });
+
+      it("shows subcategory counts", () => {
+        render(<EditorLeftPanel datasources={mockDatasources} activeDatasource={mockDatasource} />);
+        // Core has 2 cards (Beta Unit, Gamma Unit), Elite has 1 (Delta Unit), Uncategorized has 2 (Zeta, Alpha)
+        const subcategoryHeaders = document.querySelectorAll(".designer-card-subcategory-header");
+        expect(subcategoryHeaders.length).toBe(3);
+      });
+
+      it("displays card names within subcategory groups", () => {
+        render(<EditorLeftPanel datasources={mockDatasources} activeDatasource={mockDatasource} />);
+        // Cards should be grouped: uncategorized first (Zeta, Alpha), then Core (Beta, Gamma), then Elite (Delta)
+        const cardItems = document.querySelectorAll(".designer-card-list .designer-card-subcategory");
+        expect(cardItems.length).toBe(3);
+      });
     });
   });
 });

--- a/src/Components/DatasourceEditor/__tests__/EditorLeftPanel.test.jsx
+++ b/src/Components/DatasourceEditor/__tests__/EditorLeftPanel.test.jsx
@@ -23,6 +23,9 @@ vi.mock("lucide-react", () => ({
   Upload: (props) => <svg data-testid="icon-upload" {...props} />,
   HelpCircle: (props) => <svg data-testid="icon-help" {...props} />,
   Tag: (props) => <svg data-testid="icon-tag" {...props} />,
+  ArrowUpDown: (props) => <svg data-testid="icon-sort-none" {...props} />,
+  ArrowDownAZ: (props) => <svg data-testid="icon-sort-asc" {...props} />,
+  ArrowDownZA: (props) => <svg data-testid="icon-sort-desc" {...props} />,
 }));
 
 const mockDatasource = {
@@ -32,7 +35,7 @@ const mockDatasource = {
   schema: {
     baseSystem: "40k-10e",
     cardTypes: [
-      { key: "infantry", label: "Infantry", baseType: "unit", schema: {} },
+      { key: "infantry", label: "Infantry", baseType: "unit", schema: { metadata: { hasSubcategory: true } } },
       { key: "battle-rules", label: "Battle Rules", baseType: "rule", schema: {} },
     ],
   },
@@ -327,41 +330,70 @@ describe("EditorLeftPanel", () => {
     });
 
     describe("sorting", () => {
-      it("renders sort select in the Cards header", () => {
+      const cardListNames = () =>
+        screen
+          .getAllByText(/Unit/)
+          .filter((el) => el.closest(".designer-card-list"))
+          .map((el) => el.textContent);
+
+      it("renders a per-card-type sort toggle in the tab bar", () => {
         render(<EditorLeftPanel datasources={mockDatasources} activeDatasource={mockDatasource} />);
-        expect(screen.getByLabelText("Sort order")).toBeInTheDocument();
-        expect(screen.getByText("A to Z")).toBeInTheDocument();
-        expect(screen.getByText("Z to A")).toBeInTheDocument();
+        // One sort toggle per card type tab (Infantry + Battle Rules)
+        expect(screen.getByRole("button", { name: /Sort Infantry cards/ })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /Sort Battle Rules cards/ })).toBeInTheDocument();
       });
 
-      it("sorts cards A-Z when asc selected", async () => {
+      it("starts with no sorting (original order)", () => {
+        render(<EditorLeftPanel datasources={mockDatasources} activeDatasource={mockDatasource} />);
+        const toggle = screen.getByRole("button", { name: /Sort Infantry cards/ });
+        expect(toggle).toHaveAccessibleName(/No sorting/);
+        // Original order within subcategory groups: uncategorized (Zeta, Alpha), Core (Beta, Gamma), Elite (Delta)
+        expect(cardListNames()).toEqual(["Zeta Unit", "Alpha Unit", "Beta Unit", "Gamma Unit", "Delta Unit"]);
+      });
+
+      it("sorts cards A-Z after one click on the toggle", async () => {
         const user = userEvent.setup();
         render(<EditorLeftPanel datasources={mockDatasources} activeDatasource={mockDatasource} />);
 
-        const sortSelect = screen.getByLabelText("Sort order");
-        await user.selectOptions(sortSelect, "asc");
+        await user.click(screen.getByRole("button", { name: /Sort Infantry cards/ }));
 
         // Cards are sorted within subcategory groups: uncategorized (Alpha, Zeta), Core (Beta, Gamma), Elite (Delta)
-        const cardNames = screen
-          .getAllByText(/Unit/)
-          .filter((el) => el.closest(".designer-card-list"))
-          .map((el) => el.textContent);
-        expect(cardNames).toEqual(["Alpha Unit", "Zeta Unit", "Beta Unit", "Gamma Unit", "Delta Unit"]);
+        expect(cardListNames()).toEqual(["Alpha Unit", "Zeta Unit", "Beta Unit", "Gamma Unit", "Delta Unit"]);
+        expect(screen.getByRole("button", { name: /Sort Infantry cards/ })).toHaveAccessibleName(/A to Z/);
       });
 
-      it("sorts cards Z-A when desc selected", async () => {
+      it("sorts cards Z-A after two clicks on the toggle", async () => {
         const user = userEvent.setup();
         render(<EditorLeftPanel datasources={mockDatasources} activeDatasource={mockDatasource} />);
 
-        const sortSelect = screen.getByLabelText("Sort order");
-        await user.selectOptions(sortSelect, "desc");
+        const toggle = screen.getByRole("button", { name: /Sort Infantry cards/ });
+        await user.click(toggle);
+        await user.click(screen.getByRole("button", { name: /Sort Infantry cards/ }));
 
         // Cards sorted Z-A within subcategory groups: uncategorized (Zeta, Alpha), Core (Gamma, Beta), Elite (Delta)
-        const cardNames = screen
-          .getAllByText(/Unit/)
-          .filter((el) => el.closest(".designer-card-list"))
-          .map((el) => el.textContent);
-        expect(cardNames).toEqual(["Zeta Unit", "Alpha Unit", "Gamma Unit", "Beta Unit", "Delta Unit"]);
+        expect(cardListNames()).toEqual(["Zeta Unit", "Alpha Unit", "Gamma Unit", "Beta Unit", "Delta Unit"]);
+        expect(screen.getByRole("button", { name: /Sort Infantry cards/ })).toHaveAccessibleName(/Z to A/);
+      });
+
+      it("cycles back to no sorting after three clicks", async () => {
+        const user = userEvent.setup();
+        render(<EditorLeftPanel datasources={mockDatasources} activeDatasource={mockDatasource} />);
+
+        for (let i = 0; i < 3; i++) {
+          await user.click(screen.getByRole("button", { name: /Sort Infantry cards/ }));
+        }
+        expect(screen.getByRole("button", { name: /Sort Infantry cards/ })).toHaveAccessibleName(/No sorting/);
+        expect(cardListNames()).toEqual(["Zeta Unit", "Alpha Unit", "Beta Unit", "Gamma Unit", "Delta Unit"]);
+      });
+
+      it("keeps sort order independent per card type", async () => {
+        const user = userEvent.setup();
+        render(<EditorLeftPanel datasources={mockDatasources} activeDatasource={mockDatasource} />);
+
+        // Sort Infantry A-Z, then switch to Battle Rules: it should still be unsorted.
+        await user.click(screen.getByRole("button", { name: /Sort Infantry cards/ }));
+        expect(screen.getByRole("button", { name: /Sort Battle Rules cards/ })).toHaveAccessibleName(/No sorting/);
+        expect(screen.getByRole("button", { name: /Sort Infantry cards/ })).toHaveAccessibleName(/A to Z/);
       });
     });
 
@@ -392,6 +424,29 @@ describe("EditorLeftPanel", () => {
         expect(screen.queryByText("Uncategorized")).not.toBeInTheDocument();
         expect(screen.getByText("Unit A")).toBeInTheDocument();
         expect(screen.getByText("Unit B")).toBeInTheDocument();
+      });
+
+      it("does not group cards when the card type has subcategory disabled", () => {
+        const dsSubcategoryDisabled = {
+          ...mockDatasource,
+          schema: {
+            ...mockDatasource.schema,
+            cardTypes: [
+              // hasSubcategory omitted -> grouping disabled
+              { key: "infantry", label: "Infantry", baseType: "unit", schema: {} },
+              { key: "battle-rules", label: "Battle Rules", baseType: "rule", schema: {} },
+            ],
+          },
+        };
+        render(<EditorLeftPanel datasources={mockDatasources} activeDatasource={dsSubcategoryDisabled} />);
+        // Cards still have subcategory values, but no headers are shown
+        expect(screen.queryByText("Core")).not.toBeInTheDocument();
+        expect(screen.queryByText("Elite")).not.toBeInTheDocument();
+        expect(screen.queryByText("Uncategorized")).not.toBeInTheDocument();
+        expect(document.querySelectorAll(".designer-card-subcategory-header").length).toBe(0);
+        // All cards render flat
+        expect(screen.getByText("Beta Unit")).toBeInTheDocument();
+        expect(screen.getByText("Delta Unit")).toBeInTheDocument();
       });
 
       it("shows subcategory counts", () => {

--- a/src/Components/DatasourceEditor/editors/CardTypeSettingsEditor.jsx
+++ b/src/Components/DatasourceEditor/editors/CardTypeSettingsEditor.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Tag } from "lucide-react";
-import { IconTag, IconResize } from "@tabler/icons-react";
+import { IconTag, IconResize, IconCategory } from "@tabler/icons-react";
 import { Section, CompactInput } from "../components";
 import { TemplateSelector, usePremiumFeatures } from "../../../Premium";
 
@@ -31,6 +31,7 @@ export const CardTypeSettingsEditor = ({
 
   const metadata = cardType.schema?.metadata;
   const showAutoResize = !!metadata && AUTO_RESIZE_SYSTEMS.includes(baseSystem) && typeof onUpdateSchema === "function";
+  const showSubcategory = !!metadata && typeof onUpdateSchema === "function";
 
   return (
     <Section title="Card Type" icon={Tag} defaultOpen={true}>
@@ -54,6 +55,16 @@ export const CardTypeSettingsEditor = ({
           type="toggle"
           value={!!metadata.hasAutoResize}
           onChange={(val) => onUpdateSchema({ ...cardType.schema, metadata: { ...metadata, hasAutoResize: val } })}
+        />
+      )}
+      {showSubcategory && (
+        <CompactInput
+          label={<IconCategory size={10} stroke={1.5} />}
+          ariaLabel="Subcategory"
+          tooltip="Add a per-card Subcategory field (shown in Basic Information) and group cards by it in the card list"
+          type="toggle"
+          value={!!metadata.hasSubcategory}
+          onChange={(val) => onUpdateSchema({ ...cardType.schema, metadata: { ...metadata, hasSubcategory: val } })}
         />
       )}
       {hasCardDesigner && (

--- a/src/Components/DatasourceEditor/editors/__tests__/CardTypeSettingsEditor.test.jsx
+++ b/src/Components/DatasourceEditor/editors/__tests__/CardTypeSettingsEditor.test.jsx
@@ -167,6 +167,53 @@ describe("CardTypeSettingsEditor", () => {
     });
   });
 
+  describe("subcategory toggle", () => {
+    const unitWithMetadata = { ...mockCardType, schema: { metadata: {} } };
+
+    it("shows the subcategory toggle for card types with metadata, regardless of base system", () => {
+      render(
+        <CardTypeSettingsEditor
+          cardType={unitWithMetadata}
+          activeDatasource={mockDatasource}
+          onUpdateCardType={vi.fn()}
+          onUpdateSchema={vi.fn()}
+          baseSystem="aos"
+        />,
+      );
+      expect(screen.getByLabelText("Subcategory")).toBeInTheDocument();
+    });
+
+    it("hides the subcategory toggle when the schema has no metadata", () => {
+      render(
+        <CardTypeSettingsEditor
+          cardType={mockCardType}
+          activeDatasource={mockDatasource}
+          onUpdateCardType={vi.fn()}
+          onUpdateSchema={vi.fn()}
+          baseSystem="40k-10e"
+        />,
+      );
+      expect(screen.queryByLabelText("Subcategory")).not.toBeInTheDocument();
+    });
+
+    it("updates schema.metadata.hasSubcategory on toggle", () => {
+      const onUpdateSchema = vi.fn();
+      render(
+        <CardTypeSettingsEditor
+          cardType={unitWithMetadata}
+          activeDatasource={mockDatasource}
+          onUpdateCardType={vi.fn()}
+          onUpdateSchema={onUpdateSchema}
+          baseSystem="40k-10e"
+        />,
+      );
+      fireEvent.click(screen.getByLabelText("Subcategory"));
+      expect(onUpdateSchema).toHaveBeenCalledWith(
+        expect.objectContaining({ metadata: expect.objectContaining({ hasSubcategory: true }) }),
+      );
+    });
+  });
+
   afterEach(() => {
     mockPremiumFeatures.hasCardDesigner = false;
   });

--- a/src/Components/WhatsNewWizard/versions/__tests__/registry.test.js
+++ b/src/Components/WhatsNewWizard/versions/__tests__/registry.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { compare } from "compare-versions";
 import {
   VERSION_REGISTRY,
   getVersionConfig,
@@ -16,12 +17,12 @@ describe("WhatsNewWizard version registry", () => {
   it("is sorted in ascending version order", () => {
     const versions = VERSION_REGISTRY.map((v) => v.version);
     for (let i = 1; i < versions.length; i++) {
-      expect(versions[i] > versions[i - 1]).toBe(true);
+      expect(compare(versions[i], versions[i - 1], ">")).toBe(true);
     }
   });
 
-  it("has v3.9.0 as the latest version", () => {
-    expect(getLatestWizardVersion()).toBe("3.9.0");
+  it("has v3.10.0 as the latest version", () => {
+    expect(getLatestWizardVersion()).toBe("3.10.0");
   });
 
   it("returns v3.2.2 config via getVersionConfig", () => {

--- a/src/Components/WhatsNewWizard/versions/__tests__/v3100.test.js
+++ b/src/Components/WhatsNewWizard/versions/__tests__/v3100.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { VERSION_CONFIG } from "../v3.10.0";
+
+describe("Desktop WhatsNewWizard v3.10.0 config", () => {
+  it("has version 3.10.0", () => {
+    expect(VERSION_CONFIG.version).toBe("3.10.0");
+  });
+
+  it("has the correct release name", () => {
+    expect(VERSION_CONFIG.releaseName).toBe("Subcategories & Sorting");
+  });
+
+  it("has at least 1 step", () => {
+    expect(VERSION_CONFIG.steps.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("has unique keys for all steps", () => {
+    const keys = VERSION_CONFIG.steps.map((s) => s.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("has title and component on every step", () => {
+    VERSION_CONFIG.steps.forEach((step) => {
+      expect(step.title).toBeTruthy();
+      expect(step.component).toBeTruthy();
+    });
+  });
+
+  it("marks the last step as thankYou", () => {
+    expect(VERSION_CONFIG.steps[VERSION_CONFIG.steps.length - 1].isThankYou).toBe(true);
+  });
+});

--- a/src/Components/WhatsNewWizard/versions/index.js
+++ b/src/Components/WhatsNewWizard/versions/index.js
@@ -19,6 +19,7 @@ import v371Config from "./v3.7.1";
 import v372Config from "./v3.7.2";
 import v380Config from "./v3.8.0";
 import v390Config from "./v3.9.0";
+import v3100Config from "./v3.10.0";
 
 /**
  * Registry of all version wizard configurations
@@ -50,6 +51,7 @@ export const VERSION_REGISTRY = [
   v372Config,
   v380Config,
   v390Config,
+  v3100Config,
 ]
   .filter((config) => config && config.version)
   .sort((a, b) => compareVersions(a.version, b.version));

--- a/src/Components/WhatsNewWizard/versions/v3.10.0/StepPatchNotes.jsx
+++ b/src/Components/WhatsNewWizard/versions/v3.10.0/StepPatchNotes.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { FolderTree } from "lucide-react";
+
+export const StepPatchNotes = () => (
+  <div className="wnw-step-subscription">
+    <div className="wnw-feature-header">
+      <div className="wnw-feature-icon">
+        <FolderTree size={28} />
+      </div>
+      <div>
+        <h2 className="wnw-feature-title">Subcategories &amp; Sorting</h2>
+      </div>
+    </div>
+    <p className="wnw-feature-description">
+      The Datasource Editor can now group a card type&apos;s cards into subcategories and sort each card type on its
+      own. Turn on subcategories in the card type settings, set each card&apos;s group from the Basic Information panel,
+      and use the sort toggle on a card type to order its list A&ndash;Z or Z&ndash;A.
+    </p>
+  </div>
+);
+
+export default StepPatchNotes;

--- a/src/Components/WhatsNewWizard/versions/v3.10.0/index.js
+++ b/src/Components/WhatsNewWizard/versions/v3.10.0/index.js
@@ -1,0 +1,18 @@
+import { FolderTree } from "lucide-react";
+import { StepPatchNotes } from "./StepPatchNotes";
+
+export const VERSION_CONFIG = {
+  version: "3.10.0",
+  releaseName: "Subcategories & Sorting",
+  steps: [
+    {
+      key: "3.10.0-patch-notes",
+      title: "What's New",
+      icon: FolderTree,
+      component: StepPatchNotes,
+      isThankYou: true,
+    },
+  ],
+};
+
+export default VERSION_CONFIG;


### PR DESCRIPTION
Automated draft for ronplanken/game-datacards#222.

Refs #222

Generated by the issue-to-pr pipeline. This is a draft and requires human review
before merge. A matching branch `ai/issue-222` may also exist in ronplanken/gdc-premium
and is linked at premium-build time.

Checks: tests passed