### PR TITLE
Allow issue-to-pr pipeline to build bug issues

### DIFF
--- a/.github/issue-to-pr/README.md
+++ b/.github/issue-to-pr/README.md
@@ -1,13 +1,13 @@
 # Issue to PR pipeline
 
-Turns an approved Discord-sourced feature issue into a draft pull request,
+Turns an approved Discord-sourced feature or bug issue into a draft pull request,
 implemented by an [OpenCode](https://opencode.ai) agent (1M-context model). A
 human reviews and merges; nothing is auto-merged.
 
 ## How it works
 
-1. The idea-to-issue Discord bot files a feature issue here with the
-   `from-discord` + `enhancement` labels.
+1. The idea-to-issue Discord bot files a feature or bug issue here with the
+   `from-discord` + `enhancement` (or `bug`) labels.
 2. An approver adds the **`ai-build`** label when they want the bot to attempt it.
 3. `issue-to-pr.yml` runs: it checks out **both** `game-datacards` and
    `gdc-premium` as sibling directories (matching the `vite.config.js` /
@@ -41,8 +41,8 @@ retry, remove `ai-attempted` and re-add `ai-build`.
 | `ai-generated` | Applied to PRs the pipeline opens. |
 | `ai-attempted` | Set automatically; blocks re-runs. |
 
-The pipeline relies on the `from-discord` and `enhancement` labels the idea-bot
-already applies.
+The pipeline relies on the `from-discord` and `enhancement`/`bug` labels the
+idea-bot already applies.
 
 ## Tuning
 

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -1,8 +1,8 @@
 name: Issue to PR
 
 # Opt-in pipeline: when an approver adds the `ai-build` label to a from-discord
-# enhancement issue, an OpenCode agent implements it and opens a draft PR in each
-# repo it changed. See .github/issue-to-pr/README.md.
+# enhancement or bug issue, an OpenCode agent implements it and opens a draft PR
+# in each repo it changed. See .github/issue-to-pr/README.md.
 
 on:
   issues:
@@ -17,8 +17,8 @@ jobs:
   # Fire only when an approver adds `ai-build`, then re-read the issue's CURRENT
   # labels to confirm eligibility. Reading the supporting labels from the
   # triggering event is unreliable: when several labels are applied together, the
-  # `ai-build` event's payload may not yet include `from-discord`/`enhancement`
-  # (they can arrive in a later event), which would wrongly skip the run.
+  # `ai-build` event's payload may not yet include `from-discord`/`enhancement`/
+  # `bug` (they can arrive in a later event), which would wrongly skip the run.
   gate:
     name: Check eligibility
     if: github.event.label.name == 'ai-build'
@@ -37,13 +37,13 @@ jobs:
             --repo "${{ github.repository }}" --json labels --jq '[.labels[].name]')"
           echo "Current labels: $labels"
           if echo "$labels" | grep -q '"from-discord"' \
-             && echo "$labels" | grep -q '"enhancement"' \
+             && { echo "$labels" | grep -q '"enhancement"' || echo "$labels" | grep -q '"bug"'; } \
              && ! echo "$labels" | grep -q '"ai-attempted"'; then
             echo "eligible=true" >> "$GITHUB_OUTPUT"
             echo "Eligible: proceeding to implementation."
           else
             echo "eligible=false" >> "$GITHUB_OUTPUT"
-            echo "Not eligible: needs from-discord + enhancement and must not be ai-attempted."
+            echo "Not eligible: needs from-discord + (enhancement or bug) and must not be ai-attempted."
           fi
 
   implement:


### PR DESCRIPTION
Extends the issue-to-pr pipeline gate to also handle bug reports.

- The gate now fires for from-discord issues labeled **enhancement OR bug** (previously enhancement only) when an approver adds the ai-build label. from-discord and not-ai-attempted are still required.
- README updated to match.

Note: the prior PR for this branch (#226) is already merged into main, so this PR contains only the gate change (2 files).