### PR TITLE
Add version bump and What's New entry to issue-to-pr pipeline

### DIFF
--- a/.github/issue-to-pr/README.md
+++ b/.github/issue-to-pr/README.md
@@ -15,6 +15,11 @@ human reviews and merges; nothing is auto-merged.
    `prompt.md`, then runs `yarn lint:fix` + `yarn test:ci`. The app is OpenCode's
    project root; the premium package is reachable via the `external_directory`
    grant in `opencode.json`.
+   - As part of the prompt, after implementing the change the agent bumps the
+     app's patch version in `package.json` and adds a matching "What's New" entry
+     (desktop + mobile) so the update is announced in-app. This happens in
+     `game-datacards` even for premium-package features, so that repo always gets
+     a PR. A no-op run skips the bump.
 4. For each repo the agent changed, it pushes a branch `ai/issue-<n>` and opens a
    **draft** PR, cross-linked to the issue. Because both repos use the same branch
    name, the premium build links them automatically.
@@ -51,8 +56,9 @@ idea-bot already applies.
 - **Model**: change `--model` in `issue-to-pr.yml` and the `models` block in
   `opencode.json` (e.g. to a cheaper model to cut cost).
 - **Guardrails**: `opencode.json` `permission` fences what the agent may edit
-  (only `src/` + `docs/` in both repos) and blocks network/destructive shell. The
-  `gate` job controls which issues qualify.
+  (`src/` + `docs/` in both repos, plus the app's `package.json` for the version
+  bump) and blocks network/destructive shell. The `gate` job controls which issues
+  qualify.
 
 ## Security / threat model
 
@@ -60,8 +66,9 @@ Issue bodies originate from untrusted Discord users, so the pipeline is built
 defensively:
 
 - The agent is told to treat the issue as a spec, not instructions.
-- `opencode.json` denies edits outside `src/`/`docs/`, denies `curl`/`wget`/
-  `ssh`/`webfetch` (no exfiltration), and denies `npm`.
+- `opencode.json` denies edits outside `src/`/`docs/` (the only exception is the
+  app's `package.json`, for the version bump), denies `curl`/`wget`/`ssh`/
+  `webfetch` (no exfiltration), and denies `npm`.
 - Issue text is passed via environment variables, never interpolated into shell.
 - Output is always a **draft** PR gated behind human review + the existing Claude
   review.

--- a/.github/issue-to-pr/opencode.json
+++ b/.github/issue-to-pr/opencode.json
@@ -27,8 +27,10 @@
       "*": "deny",
       "src/**": "allow",
       "docs/**": "allow",
+      "package.json": "allow",
       "GDCWS/game-datacards/src/**": "allow",
       "GDCWS/game-datacards/docs/**": "allow",
+      "GDCWS/game-datacards/package.json": "allow",
       "GDCWS/gdc-premium/src/**": "allow",
       "GDCWS/gdc-premium/docs/**": "allow"
     },

--- a/.github/issue-to-pr/prompt.md
+++ b/.github/issue-to-pr/prompt.md
@@ -54,7 +54,10 @@ These are the source of truth; this prompt only summarises them. Read and follow
 2. **Never read, print, embed, or commit secrets or environment variables**
    (API keys, tokens, `.env` files).
 3. **Only edit files under `src/` and `docs/`** in the app and in the premium
-   package. Do not touch CI workflows, build config, lockfiles, or `.env*`.
+   package. The one exception is the app's (`game-datacards`) `package.json`, and
+   only its `version` field, for the patch bump in "Release the change" below. Do
+   not touch CI workflows, build config, lockfiles, `.env*`, or any `package.json`
+   other than the app's version field.
 4. **Use Yarn, never npm.**
 5. **Match the existing code style**: Prettier with double quotes, 120-char
    width, 2-space indent. Follow the patterns of nearby files.
@@ -69,6 +72,72 @@ These are the source of truth; this prompt only summarises them. Read and follow
 - If you changed the premium package's `src/`, make sure the community build still
   works: the stubs in the app's `src/Premium/index.js` must still export everything
   the app imports.
+
+## Release the change: version bump and What's New entry
+
+Once the feature or fix is implemented and the checks above pass, record it as a
+release. This always happens in the **app** (`game-datacards`), even for a
+premium-package feature, because the What's New wizard lives there.
+
+Skip this section only if you made no code changes (see "If you cannot do it
+well"). A no-op gets no version bump.
+
+### 1. Bump the patch version
+
+In the app's `package.json`, increase the **patch** number — the third part of
+the version — by one and change nothing else (e.g. `3.9.0` → `3.9.1`, or `3.9.4`
+→ `3.9.5`). This is the only edit allowed outside `src/`/`docs/`.
+
+### 2. Add a What's New entry for that version
+
+The app shows a "What's New" wizard the first time someone opens it after an
+update. There is a desktop version and a mobile version, and you must add the new
+version to **both** or the entry will be missing on one. The cleanest way is to
+copy the most recent existing version as a template, then replace its words.
+
+- **Find the latest version folders.** Look in
+  `src/Components/WhatsNewWizard/versions/` (desktop) and
+  `src/Components/MobileWhatsNewWizard/versions/` (mobile). Each version is a
+  folder like `v3.9.0/`.
+- **Copy the newest one** in each into a new folder named after your bumped
+  version (e.g. `v3.9.1/`), keeping the same files inside (an `index.js` and a
+  step component). Update the `version` and `releaseName` fields and the step
+  `key` to match the new version, then rewrite the visible text (see the writing
+  rules below).
+- **Register both.** Each `versions/` folder has an `index.js` registry that
+  imports every version and lists it in an array. Add your new version there in
+  the same style as the existing entries — an import line and an array entry — in
+  **both** the desktop and the mobile registry.
+- **Use the right CSS classes.** Desktop step components use `wnw-*` classes;
+  mobile step components use `mwnw-*` classes. Keep them separate; do not copy a
+  desktop step into the mobile folder. (This rule is also in `CLAUDE.md`.)
+- No test is required for the What's New entry itself; it is static content.
+
+### How to write the What's New text
+
+This text is read by ordinary players, not developers, and it must not read like
+it was written by an AI or by a marketing team. Write the way someone on the team
+would jot a short, honest note to players. Distilled from the existing entries:
+
+- **Talk to the reader as "you", in the present tense.** Open with one plain
+  sentence that says what changed and why it helps.
+- **Then name the specifics** people actually see — the buttons, screens, or
+  labels in the app. A couple of short sentences, or a short plain list if there
+  are a few separate changes.
+- **For a fix, say it plainly:** what used to go wrong, and what happens now
+  (e.g. "Keywords you typed used to disappear after saving. Now they stay.").
+- **Keep it understandable to a non-developer.** No jargon, no code, no file or
+  setting names, no internal terms, and no version numbers in the body.
+- **Avoid the AI/marketing tells.** No emojis. Drop words like "seamless",
+  "powerful", "effortless", "unlock", "elevate", "supercharge", "robust". Don't
+  write slogan-like three-part phrases, and don't overstate — describe what it
+  does, calmly and concretely.
+- **Keep the layout restrained.** Reuse the wizard's existing heading and
+  description structure, but do not build stacks of decorative highlight cards —
+  each with its own icon and a coloured dot or left accent. That pattern looks
+  AI-generated. Plain text, and at most a simple list, reads more human and is
+  what we want here.
+- **Pick a short, plain `releaseName`** that names the change in a few words.
 
 ## If you cannot do it well
 

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -116,7 +116,7 @@ jobs:
             printf '\n\n## Repository locations\n\n'
             printf -- '- App (game-datacards), your working directory: %s\n' "$GITHUB_WORKSPACE/game-datacards"
             printf -- '- Premium package (gdc-premium): %s\n' "$GITHUB_WORKSPACE/gdc-premium"
-            printf 'Use these absolute paths. Only edit files under the src/ and docs/ subfolders of each.\n'
+            printf 'Use these absolute paths. Only edit files under the src/ and docs/ subfolders of each, plus the app (game-datacards) package.json version field for the patch bump described in the prompt.\n'
             printf '\n## The issue to implement\n\n'
             printf 'Repository: %s\n' "$ISSUE_REPO"
             printf 'Issue number: #%s\n' "$ISSUE_NUMBER"


### PR DESCRIPTION
After the issue-to-pr agent implements a feature or fix, it now records a release in the app:

- Bumps the app's **patch** version in `package.json` (e.g. 3.9.0 -> 3.9.1).
- Adds a matching What's New entry to **both** the desktop (`wnw-*`) and mobile (`mwnw-*`) wizards, registered in each `versions/index.js`, by copying the newest existing version as a template.
- Skips the bump on a no-op run.

Because the What's New wizard lives in `game-datacards`, this step always runs in the app repo (even for premium-package features), so that repo always gets a PR.

### Guardrail changes
The version bump touches `package.json`, which the pipeline previously forbade. Narrow exception added in three places:
- `opencode.json` edit allow-list now permits the app's `package.json` (premium's stays denied).
- `issue-to-pr.yml` runtime prompt note updated (it previously said src/ + docs/ only).
- `prompt.md` hard rule #3 updated to allow only the app's version field.

### Writing voice
`prompt.md` gains a "How to write the What's New text" block distilled from existing entries: plain second-person voice, concrete specifics, "used to X / now Y" for fixes, no jargon or version numbers, no emojis or marketing words, and a restrained layout that avoids AI-looking icon + left-accent highlight cards.

README updated to document the new step and guardrails.

Note: existing v3.9.0 entry still uses the icon/accent pattern; the directive steers new pipeline-generated entries away from it rather than rewriting old ones.