### PR TITLE
Name issue-to-pr branches by type and issue title

### DIFF
--- a/.github/issue-to-pr/README.md
+++ b/.github/issue-to-pr/README.md
@@ -20,9 +20,12 @@ human reviews and merges; nothing is auto-merged.
      (desktop + mobile) so the update is announced in-app. This happens in
      `game-datacards` even for premium-package features, so that repo always gets
      a PR. A no-op run skips the bump.
-4. For each repo the agent changed, it pushes a branch `ai/issue-<n>` and opens a
-   **draft** PR, cross-linked to the issue. Because both repos use the same branch
-   name, the premium build links them automatically.
+4. For each repo the agent changed, it pushes a branch named for the issue type
+   and number — `feature/<n>-<slug>` for an enhancement, `bug/<n>-<slug>` for a
+   bug (the `<slug>` is a short, sanitised form of the issue title) — and opens a
+   **draft** PR, cross-linked to the issue. The branch name is computed once in
+   the `gate` job; because both repos use the same name, the premium build links
+   them automatically.
 5. The PRs are opened with a PAT, so `ci.yml` and `claude-review.yml` run on them
    automatically. The bot also comments the result back on the issue.
 

--- a/.github/issue-to-pr/create-prs.sh
+++ b/.github/issue-to-pr/create-prs.sh
@@ -3,12 +3,15 @@ set -euo pipefail
 
 # Opens a draft PR in each repo (game-datacards, gdc-premium) that the agent
 # changed, cross-links them to the originating issue, and comments on the issue
-# with the result. Pushes a branch named ai/issue-<n> in each changed repo so the
-# existing scripts/build-premium.sh branch-matching links the two at build time.
+# with the result. Pushes the branch named in $BRANCH (e.g.
+# feature/<n>-<slug> or bug/<n>-<slug>, set by the workflow's gate job) in each
+# changed repo so the existing scripts/build-premium.sh branch-matching links the
+# two at build time. Both repos must use the same branch name.
 #
 # Required env:
 #   GITHUB_WORKSPACE  parent dir containing game-datacards/ and gdc-premium/
 #   GH_TOKEN          PAT with contents + pull-requests + issues write on both repos
+#   BRANCH            working branch name, same in both repos
 #   ISSUE_NUMBER      issue number in game-datacards
 #   ISSUE_TITLE       issue title
 #   GAME_REPO         owner/repo, e.g. ronplanken/game-datacards
@@ -18,7 +21,7 @@ set -euo pipefail
 #   PREMIUM_BASE      base branch for the premium PR (default: main)
 #   BOT_NAME, BOT_EMAIL
 
-BRANCH="ai/issue-${ISSUE_NUMBER}"
+BRANCH="${BRANCH:?BRANCH must be set by the workflow}"
 PREMIUM_BASE="${PREMIUM_BASE:-main}"
 BOT_NAME="${BOT_NAME:-gdc-issue-bot}"
 BOT_EMAIL="${BOT_EMAIL:-issue-bot@users.noreply.github.com}"

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -27,13 +27,16 @@ jobs:
       issues: read
     outputs:
       eligible: ${{ steps.check.outputs.eligible }}
+      branch: ${{ steps.check.outputs.branch }}
     steps:
       - name: Read current labels
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          labels="$(gh issue view "${{ github.event.issue.number }}" \
+          labels="$(gh issue view "$ISSUE_NUMBER" \
             --repo "${{ github.repository }}" --json labels --jq '[.labels[].name]')"
           echo "Current labels: $labels"
           if echo "$labels" | grep -q '"from-discord"' \
@@ -41,6 +44,32 @@ jobs:
              && ! echo "$labels" | grep -q '"ai-attempted"'; then
             echo "eligible=true" >> "$GITHUB_OUTPUT"
             echo "Eligible: proceeding to implementation."
+
+            # Branch type from labels: enhancement -> feature, otherwise bug.
+            if echo "$labels" | grep -q '"enhancement"'; then
+              type="feature"
+            else
+              type="bug"
+            fi
+
+            # Short, git-safe slug from the issue title. The title is untrusted, so
+            # it is read from the environment as data (never interpolated into the
+            # script) and reduced to lowercase a-z0-9 plus single hyphens, max 40
+            # chars. Result is e.g. feature/123-add-keyword-glossary.
+            slug="$(printf '%s' "$ISSUE_TITLE" \
+              | tr '[:upper:]' '[:lower:]' \
+              | tr -c 'a-z0-9' '-' \
+              | sed -E 's/-+/-/g; s/^-//; s/-$//' \
+              | cut -c1-40 \
+              | sed -E 's/-$//')"
+
+            if [ -n "$slug" ]; then
+              branch="${type}/${ISSUE_NUMBER}-${slug}"
+            else
+              branch="${type}/${ISSUE_NUMBER}"
+            fi
+            echo "branch=$branch" >> "$GITHUB_OUTPUT"
+            echo "Branch: $branch"
           else
             echo "eligible=false" >> "$GITHUB_OUTPUT"
             echo "Not eligible: needs from-discord + (enhancement or bug) and must not be ai-attempted."
@@ -94,8 +123,9 @@ jobs:
         run: npm install -g opencode-ai@1.15.10
 
       - name: Create working branches
+        env:
+          BRANCH: ${{ needs.gate.outputs.branch }}
         run: |
-          BRANCH="ai/issue-${{ github.event.issue.number }}"
           git -C game-datacards checkout -b "$BRANCH"
           git -C gdc-premium checkout -b "$BRANCH"
 
@@ -163,4 +193,5 @@ jobs:
           GAME_REPO: ${{ github.repository }}
           PREMIUM_REPO: ronplanken/gdc-premium
           CHECKS: ${{ steps.checks.outputs.result }}
+          BRANCH: ${{ needs.gate.outputs.branch }}
         run: bash game-datacards/.github/issue-to-pr/create-prs.sh


### PR DESCRIPTION
Follow-up to #229. Replaces the fixed `ai/issue-<n>` branch name the pipeline used with a descriptive, type-aware name:

- `feature/<n>-<slug>` when the issue is an enhancement
- `bug/<n>-<slug>` when the issue is a bug

### How
- The `gate` job now computes the branch name once and exposes it as a job output. Type comes from the issue's `enhancement`/`bug` labels (enhancement wins if both are present); `<slug>` is a lowercase, hyphenated, 40-char-max form of the issue title.
- The title is untrusted, so the slug is built from an env var as data (never interpolated into the shell) and reduced to `[a-z0-9-]`, which is also git-ref-safe.
- The implement job's checkout step and `create-prs.sh` both consume the gate output, so both repos use the identical branch name (required by `scripts/build-premium.sh` branch matching). `create-prs.sh` now requires `BRANCH` from the workflow instead of building it itself.
- README updated.

Examples: `feature/123-add-keyword-glossary`, `bug/88-cards-don-t-save-after-edit`.