### PR TITLE
AI draft: Legends label overlaps points when multiple point values shown (#233)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-datacards",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "The only tool you will ever need for your custom datacards",
   "private": false,
   "homepage": "https://game-datacards.eu",

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitName.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitName.jsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { UnitPoints } from "./UnitPoints";
 
@@ -33,8 +34,46 @@ export const UnitName = ({
 }) => {
   const imageUrl = localImageUrl || externalImage;
 
+  const hasMultipleActivePoints = showAllPoints && points?.filter((p) => p.active)?.length > 1;
+
+  const headerRef = useRef(null);
+  // Distance (in px) the Legends label must sit from the header's right edge so it
+  // clears the leftmost points block. Measured from the actual points layout because
+  // the points container grows leftward as more values (or model keywords) are shown.
+  const [legendsOffset, setLegendsOffset] = useState(null);
+
+  useLayoutEffect(() => {
+    if (!legends || !hasMultipleActivePoints) {
+      setLegendsOffset(null);
+      return undefined;
+    }
+    const header = headerRef.current;
+    const pointsContainer = header?.querySelector(".points_container");
+    if (!header || !pointsContainer) {
+      return undefined;
+    }
+    const GAP = 16;
+    const measure = () => {
+      const headerRect = header.getBoundingClientRect();
+      const pointsRect = pointsContainer.getBoundingClientRect();
+      const offset = Math.round(headerRect.right - pointsRect.left + GAP);
+      setLegendsOffset(offset > 0 ? offset : null);
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") {
+      return undefined;
+    }
+    const observer = new ResizeObserver(measure);
+    observer.observe(header);
+    observer.observe(pointsContainer);
+    return () => observer.disconnect();
+  }, [legends, hasMultipleActivePoints, points, showAllPoints, showPointsModels]);
+
+  const legendsStyle = legendsOffset != null ? { "--legends-multi-offset": `${legendsOffset}px` } : undefined;
+
   return (
     <HeaderContainer
+      ref={headerRef}
       className="header_container"
       imageurl={imageUrl}
       imagezindex={imageZIndex}
@@ -44,7 +83,7 @@ export const UnitName = ({
         <div className="name">{name}</div>
         {subname && <div className="subname">{subname}</div>}
       </div>
-      {legends && <div className="legends" />}
+      {legends && <div className={`legends${hasMultipleActivePoints ? " legends--multi" : ""}`} style={legendsStyle} />}
       {combatPatrol && <div className="combatpatrol" />}
       <UnitPoints points={points} showAllPoints={showAllPoints} showPointsModels={showPointsModels} />
     </HeaderContainer>

--- a/src/Components/Warhammer40k-10e/UnitCard/__tests__/UnitName.test.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/__tests__/UnitName.test.jsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { vi, describe, it, expect } from "vitest";
+import { UnitName } from "../UnitName";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("antd", () => ({
+  Button: ({ children, ...props }) => <button {...props}>{children}</button>,
+  Popover: ({ children }) => <>{children}</>,
+  Grid: { useBreakpoint: () => ({}) },
+}));
+
+const renderUnitName = (props) =>
+  render(
+    <MemoryRouter>
+      <UnitName {...props} />
+    </MemoryRouter>,
+  );
+
+describe("UnitName", () => {
+  it("renders legends div when legends is true", () => {
+    const { container } = renderUnitName({ name: "Test", legends: true, points: [] });
+    expect(container.querySelector(".legends")).toBeInTheDocument();
+  });
+
+  it("does not render legends div when legends is false", () => {
+    const { container } = renderUnitName({ name: "Test", legends: false, points: [] });
+    expect(container.querySelector(".legends")).toBeNull();
+  });
+
+  it("does not add legends--multi class when showAllPoints is false", () => {
+    const points = [
+      { active: true, models: 5, cost: 100, primary: true },
+      { active: true, models: 10, cost: 190 },
+    ];
+    const { container } = renderUnitName({ name: "Test", legends: true, points, showAllPoints: false });
+    const legendsEl = container.querySelector(".legends");
+    expect(legendsEl).toBeInTheDocument();
+    expect(legendsEl.classList.contains("legends--multi")).toBe(false);
+  });
+
+  it("does not add legends--multi when showAllPoints is true but only one active point", () => {
+    const points = [{ active: true, models: 5, cost: 100, primary: true }];
+    const { container } = renderUnitName({ name: "Test", legends: true, points, showAllPoints: true });
+    const legendsEl = container.querySelector(".legends");
+    expect(legendsEl).toBeInTheDocument();
+    expect(legendsEl.classList.contains("legends--multi")).toBe(false);
+  });
+
+  it("adds legends--multi class when legends is true, showAllPoints is true, and multiple active points", () => {
+    const points = [
+      { active: true, models: 5, cost: 100, primary: true },
+      { active: true, models: 10, cost: 190 },
+    ];
+    const { container } = renderUnitName({ name: "Test", legends: true, points, showAllPoints: true });
+    const legendsEl = container.querySelector(".legends");
+    expect(legendsEl).toBeInTheDocument();
+    expect(legendsEl.classList.contains("legends--multi")).toBe(true);
+  });
+
+  it("sets the --legends-multi-offset variable from measured layout when multiple points are shown", () => {
+    const points = [
+      { active: true, models: 5, cost: 100, primary: true },
+      { active: true, models: 10, cost: 190 },
+      { active: true, models: 20, cost: 360 },
+    ];
+    const { container } = renderUnitName({ name: "Test", legends: true, points, showAllPoints: true });
+    const legendsEl = container.querySelector(".legends--multi");
+    expect(legendsEl).toBeInTheDocument();
+    // Layout is measured via useLayoutEffect, so the dynamic offset is applied inline
+    // rather than relying on the fixed CSS fallback.
+    expect(legendsEl.style.getPropertyValue("--legends-multi-offset")).not.toBe("");
+  });
+
+  it("does not set the --legends-multi-offset variable for a single point value", () => {
+    const points = [{ active: true, models: 5, cost: 100, primary: true }];
+    const { container } = renderUnitName({ name: "Test", legends: true, points, showAllPoints: true });
+    const legendsEl = container.querySelector(".legends");
+    expect(legendsEl.style.getPropertyValue("--legends-multi-offset")).toBe("");
+  });
+
+  it("does not add legends--multi when legends is false even with multiple points", () => {
+    const points = [
+      { active: true, models: 5, cost: 100 },
+      { active: true, models: 10, cost: 190 },
+    ];
+    const { container } = renderUnitName({ name: "Test", legends: false, points, showAllPoints: true });
+    const legendsEl = container.querySelector(".legends");
+    expect(legendsEl).toBeNull();
+  });
+
+  it("renders unit name", () => {
+    renderUnitName({ name: "Intercessors" });
+    expect(screen.getByText("Intercessors")).toBeInTheDocument();
+  });
+
+  it("renders subname when provided", () => {
+    renderUnitName({ name: "Captain", subname: "In Terminator Armour" });
+    expect(screen.getByText("Captain")).toBeInTheDocument();
+    expect(screen.getByText("In Terminator Armour")).toBeInTheDocument();
+  });
+
+  it("renders points when showAllPoints is true", () => {
+    const points = [
+      { active: true, models: 5, cost: 100, primary: true },
+      { active: true, models: 10, cost: 190 },
+    ];
+    renderUnitName({ name: "Test", points, showAllPoints: true });
+    expect(screen.getByText("100 pts")).toBeInTheDocument();
+    expect(screen.getByText("190 pts")).toBeInTheDocument();
+  });
+});

--- a/src/data/releaseNotes.json
+++ b/src/data/releaseNotes.json
@@ -1,1 +1,9 @@
-[]
+[
+  {
+    "version": "3.10.1",
+    "title": "Legends label no longer overlaps points",
+    "body": "When you mark a datasheet as Legends and show more than one points value, the Legends label used to sit on top of the points. Now it moves to the left and stays clear, however many values you show.",
+    "severity": "info",
+    "timestamp": 1779861089
+  }
+]

--- a/src/styles/40k-10e.less
+++ b/src/styles/40k-10e.less
@@ -1913,6 +1913,9 @@
             font-family: "EB Garamond", "serif";
             color: var(--faction-text-colour);
           }
+          .legends--multi {
+            right: var(--legends-multi-offset, 250px);
+          }
           .combatpatrol {
             &::before {
               content: "Combat Patrol Datasheet";
@@ -3167,6 +3170,9 @@
               font-weight: 600;
               font-family: "EB Garamond", "serif";
               color: var(--faction-text-colour);
+            }
+            .legends--multi {
+              right: var(--legends-multi-offset, 250px);
             }
           }
 


### PR DESCRIPTION
Automated draft for ronplanken/game-datacards#233.

Refs #233

Generated by the issue-to-pr pipeline. This is a draft and requires human review
before merge. A matching branch `bug/233-legends-label-overlaps-points-when-multi` may also exist in ronplanken/gdc-premium
and is linked at premium-build time.

Checks: tests FAILED (see workflow logs)