### PR TITLE
Decouple release bookkeeping from issue-to-PR PRs (fix parallel-PR collisions)

### DIFF
--- a/.github/issue-to-pr/README.md
+++ b/.github/issue-to-pr/README.md
@@ -15,20 +15,15 @@ human reviews and merges; nothing is auto-merged.
    `prompt.md`, then runs `yarn lint:fix` + `yarn test:ci`. The app is OpenCode's
    project root; the premium package is reachable via the `external_directory`
    grant in `opencode.json`.
-   - As part of the prompt, after implementing the change the agent bumps the
-     app's `package.json` version and records the release in one of two channels,
-     chosen by the `gate` job from the issue labels and passed to the prompt as a
-     `Release type` line. By default (most fixes) it is a **note**: a patch bump
-     plus one entry appended to `src/data/releaseNotes.json`, which surfaces as a
-     small item in the in-app notification bell — no update modal. When a human
-     adds the **`release:feature`** label, it is a **feature**: a minor bump plus
-     a full "What's New" wizard entry (desktop + mobile). This happens in
-     `game-datacards` even for premium-package changes, so that repo always gets a
-     PR. A no-op run skips the release step.
-   - The prompt has the agent re-run `yarn lint:fix` + `yarn test:ci` *after* the
-     version bump and release edits and fix anything they broke, so those late,
-     post-check edits can't ship a failing tree. The workflow's own lint/test step
-     is a reporting backstop on top of that.
+   - The agent does **not** bump the version or edit `releaseNotes.json`. Instead
+     it writes one release fragment to `changes/unreleased/<issue>.json` (the
+     player-facing note). The version bump and notes are applied automatically
+     **after merge** by `release.yml` (see "Releasing" below). This is what lets
+     several pipeline PRs be open at once without colliding on the version number
+     or the notes file. A no-op run writes no fragment.
+   - The prompt has the agent re-run `yarn lint:fix` + `yarn test:ci` *after*
+     writing the fragment and fix anything that broke. The workflow's own
+     lint/test step is a reporting backstop on top of that.
    - The DeepSeek model runs at maximum reasoning effort (`reasoningEffort: max`
      in `opencode.json`), and after the run the workflow records the run's token
      and cost totals via `opencode stats` — shown in the Actions job summary and
@@ -65,10 +60,30 @@ retry, remove `ai-attempted` and re-add `ai-build`.
 | `ai-build` | Approver opt-in: attempt this issue. |
 | `ai-generated` | Applied to PRs the pipeline opens. |
 | `ai-attempted` | Set automatically; blocks re-runs. |
-| `release:feature` | Approver opt-in: announce this change with the full What's New wizard (minor version bump) instead of the default quiet notification note (patch bump). |
 
 The pipeline relies on the `from-discord` and `enhancement`/`bug` labels the
-idea-bot already applies.
+idea-bot already applies. Pipeline PRs always ship as a **patch** (a quiet
+notification note); the full What's New wizard is reserved for feature releases a
+human cuts by hand.
+
+## Releasing
+
+The pipeline keeps release bookkeeping out of the feature PR so parallel PRs
+never conflict on it. Releasing happens after merge instead:
+
+- Each PR carries a fragment in `changes/unreleased/` (see `changes/README.md`).
+- When a PR merges to `main`, `release.yml` consumes the fragment(s): it bumps
+  the **patch** version in `package.json`, appends the note to
+  `src/data/releaseNotes.json`, deletes the fragment, commits, and tags
+  `v<x.y.z>`. Back-to-back merges queue (a `release` concurrency group) so each
+  gets a sequential version.
+- That version-bump commit is the **only** thing that changes `package.json`.
+  Cloudflare Pages is configured with a **build watch path** of `package.json`,
+  so production deploys only on release commits — routine merges that carry no
+  fragment never deploy.
+- **Feature releases** (the full What's New wizard + a minor bump) are cut
+  manually by a human; the pipeline never produces them. Old patch notes stay in
+  `releaseNotes.json`, so nothing is lost.
 
 ## Tuning
 

--- a/.github/issue-to-pr/opencode.json
+++ b/.github/issue-to-pr/opencode.json
@@ -31,10 +31,10 @@
       "*": "deny",
       "src/**": "allow",
       "docs/**": "allow",
-      "package.json": "allow",
+      "changes/unreleased/**": "allow",
       "GDCWS/game-datacards/src/**": "allow",
       "GDCWS/game-datacards/docs/**": "allow",
-      "GDCWS/game-datacards/package.json": "allow",
+      "GDCWS/game-datacards/changes/unreleased/**": "allow",
       "GDCWS/gdc-premium/src/**": "allow",
       "GDCWS/gdc-premium/docs/**": "allow",
       "GDCWS/pr-summary.md": "allow"

--- a/.github/issue-to-pr/prompt.md
+++ b/.github/issue-to-pr/prompt.md
@@ -54,11 +54,12 @@ These are the source of truth; this prompt only summarises them. Read and follow
 2. **Never read, print, embed, or commit secrets or environment variables**
    (API keys, tokens, `.env` files).
 3. **Only edit files under `src/` and `docs/`** in the app and in the premium
-   package. There are two exceptions: the app's (`game-datacards`) `package.json`
-   `version` field, for the patch bump in "Release the change" below; and the PR
-   summary file at the path given under "Repository locations", for "Write the PR
-   summary" below. Do not touch CI workflows, build config, lockfiles, `.env*`, or
-   any `package.json` other than the app's version field.
+   package. There are two exceptions, both at the paths given under "Repository
+   locations": the release fragment file, for "Record the change" below; and the
+   PR summary file, for "Write the PR summary" below. Do NOT bump the version or
+   touch `package.json`, `src/data/releaseNotes.json`, the What's New wizard,
+   CI workflows, build config, lockfiles, or `.env*`. Versioning and release
+   notes are handled automatically after your PR merges.
 4. **Use Yarn, never npm.**
 5. **Match the existing code style**: Prettier with double quotes, 120-char
    width, 2-space indent. Follow the patterns of nearby files.
@@ -74,99 +75,52 @@ These are the source of truth; this prompt only summarises them. Read and follow
   works: the stubs in the app's `src/Premium/index.js` must still export everything
   the app imports.
 
-## Release the change
+## Record the change (release note)
 
-Once the feature or fix is implemented and the checks above pass, record it as a
-release. This always happens in the **app** (`game-datacards`), even for a
-premium-package change, because both release channels live there.
+Once the feature or fix is implemented and the checks above pass, leave a short
+release note so the change is announced after it ships. You do **not** bump the
+version, edit `package.json`, edit `src/data/releaseNotes.json`, or touch the
+What's New wizard — all of that happens automatically once your PR merges. You
+only write one small fragment file describing the change.
 
-Skip this section only if you made no code changes (see "If you cannot do it
-well"). A no-op gets no release.
+Skip this only if you made no code changes (see "If you cannot do it well"). A
+no-op gets no fragment.
 
-There are two release channels. The **"Release type"** line in "The issue to
-implement" below tells you which one to use:
-
-- **`note`** (the default, used for most fixes and small changes) — add a short
-  entry to the notification feed. Users see a small note in the in-app
-  notification bell. Do **not** add a What's New wizard entry.
-- **`feature`** — a human decided this change is notable enough to interrupt with
-  the full-screen What's New wizard. Add a What's New entry as well.
-
-Choosing the channel is not your call: follow the "Release type" line exactly. If
-that line is missing, treat it as `note`.
-
-### 1. Bump the version
-
-In the app's `package.json`, change only the `version` field. This is the only
-edit allowed outside `src/`/`docs/`.
-
-- For **`note`**, bump the **patch** number — the third part — by one (e.g.
-  `3.9.0` → `3.9.1`, or `3.9.4` → `3.9.5`).
-- For **`feature`**, bump the **minor** number — the second part — by one and
-  reset the patch to `0` (e.g. `3.9.4` → `3.10.0`).
-
-### 2a. Release type `note`: add a notification entry
-
-Append one object to the JSON array in `src/data/releaseNotes.json`, keeping the
-existing entries. Use this shape:
+Write a single JSON object to the **release fragment file** whose absolute path is
+given under "Repository locations" (it lives at `changes/unreleased/<issue>.json`
+inside the app). Use this shape:
 
 ```json
 {
-  "version": "3.9.1",
   "title": "Keywords stay after saving",
   "body": "Keywords you typed used to disappear after saving. Now they stay.",
-  "severity": "info",
-  "timestamp": 1716800000
+  "severity": "info"
 }
 ```
 
-- `version` must match the version you just bumped to.
-- `timestamp` is the current Unix time in **seconds** (the output of `date +%s`),
-  not milliseconds. A note only shows as new for seven days, so it must be
-  roughly now.
+- `title` and `body` are the player-facing note — write them with the rules in
+  "How to write the release text" below.
 - `severity` is optional — one of `info`, `success`, `warning`, `error`. Use
   `info` for an ordinary fix.
-- Write `title` and `body` with the rules in "How to write the release text"
-  below. No What's New folders, no registry edits, and no test — it is static
-  content.
+- Do **not** add a `version` or `timestamp`. The automatic post-merge release
+  assigns the next patch version and the current time. Each issue gets its own
+  fragment file (named after the issue number), so two open PRs never collide.
 
-### 2b. Release type `feature`: add a What's New entry for that version
-
-The app shows a "What's New" wizard the first time someone opens it after an
-update. There is a desktop version and a mobile version, and you must add the new
-version to **both** or the entry will be missing on one. The cleanest way is to
-copy the most recent existing version as a template, then replace its words.
-
-- **Find the latest version folders.** Look in
-  `src/Components/WhatsNewWizard/versions/` (desktop) and
-  `src/Components/MobileWhatsNewWizard/versions/` (mobile). Each version is a
-  folder like `v3.9.0/`.
-- **Copy the newest one** in each into a new folder named after your bumped
-  version (e.g. `v3.9.1/`), keeping the same files inside (an `index.js` and a
-  step component). Update the `version` and `releaseName` fields and the step
-  `key` to match the new version, then rewrite the visible text (see the writing
-  rules below).
-- **Register both.** Each `versions/` folder has an `index.js` registry that
-  imports every version and lists it in an array. Add your new version there in
-  the same style as the existing entries — an import line and an array entry — in
-  **both** the desktop and the mobile registry.
-- **Use the right CSS classes.** Desktop step components use `wnw-*` classes;
-  mobile step components use `mwnw-*` classes. Keep them separate; do not copy a
-  desktop step into the mobile folder. (This rule is also in `CLAUDE.md`.)
-- No test is required for the What's New entry itself; it is static content.
+This note appears as a small item in the in-app notification bell. The full-screen
+What's New wizard is reserved for notable feature releases that a human cuts
+manually — it is not part of this task.
 
 ### How to write the release text
 
-This applies to both a notification entry and a What's New entry. The text is read
-by ordinary players, not developers, and it must not read like it was written by
-an AI or by a marketing team. Write the way someone on the team would jot a short,
-honest note to players. Distilled from the existing entries:
+The `title` and `body` are read by ordinary players, not developers, and must not
+read like they were written by an AI or a marketing team. Write the way someone on
+the team would jot a short, honest note to players. Distilled from the existing
+entries:
 
 - **Talk to the reader as "you", in the present tense.** Open with one plain
   sentence that says what changed and why it helps.
 - **Then name the specifics** people actually see — the buttons, screens, or
-  labels in the app. A couple of short sentences, or a short plain list if there
-  are a few separate changes.
+  labels in the app. A couple of short sentences at most.
 - **For a fix, say it plainly:** what used to go wrong, and what happens now
   (e.g. "Keywords you typed used to disappear after saving. Now they stay.").
 - **Keep it understandable to a non-developer.** No jargon, no code, no file or
@@ -175,25 +129,17 @@ honest note to players. Distilled from the existing entries:
   "powerful", "effortless", "unlock", "elevate", "supercharge", "robust". Don't
   write slogan-like three-part phrases, and don't overstate — describe what it
   does, calmly and concretely.
-- **Keep the layout restrained.** Reuse the wizard's existing heading and
-  description structure, but do not build stacks of decorative highlight cards —
-  each with its own icon and a coloured dot or left accent. That pattern looks
-  AI-generated. Plain text, and at most a simple list, reads more human and is
-  what we want here.
-- **Pick a short, plain `releaseName`** that names the change in a few words.
 
 ## Final check before you finish
 
-The version bump and the release entry (a notification entry, or a What's New
-entry plus registry edits) land *after* the checks in "Definition of done"
-already ran, so they can break lint or tests on their own (malformed
-`releaseNotes.json`, a new step component with a lint error, a registry snapshot
-test that now sees an extra version, and so on). Do not finish on a stale check.
+The release fragment is static JSON, but writing it (and any last edits) lands
+*after* the checks in "Definition of done" already ran. Do not finish on a stale
+check: the fragment must be valid JSON, and nothing you touched last should have
+broken lint or tests.
 
-As your last action, after the release edits are in place, run `yarn lint:fix`,
-`yarn prettier:fix`, and `yarn test:ci` once more inside the app
-(`game-datacards`) directory, and resolve anything that broke. Only end your run
-once these pass on the full working tree, release changes included.
+As your last action, run `yarn lint:fix`, `yarn prettier:fix`, and `yarn test:ci`
+once more inside the app (`game-datacards`) directory, and resolve anything that
+broke. Only end your run once these pass on the full working tree.
 
 ## Write the PR summary
 

--- a/.github/scripts/apply-release-fragment.mjs
+++ b/.github/scripts/apply-release-fragment.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// Applies one issue-to-PR release fragment to the working tree:
+//   1. bumps the PATCH version in package.json (preserving its exact formatting)
+//   2. appends a notification entry to src/data/releaseNotes.json
+//
+// Invoked once per fragment by .github/workflows/release.yml. The feature PR no
+// longer does any of this; deferring it to a post-merge run on main is what lets
+// parallel PRs avoid colliding on the version number and the notes file.
+//
+// Usage: node .github/scripts/apply-release-fragment.mjs <path/to/fragment.json>
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const fragmentPath = process.argv[2];
+if (!fragmentPath) {
+  console.error("usage: apply-release-fragment.mjs <fragment.json>");
+  process.exit(1);
+}
+
+const PKG_PATH = "package.json";
+const NOTES_PATH = "src/data/releaseNotes.json";
+const ALLOWED_SEVERITY = new Set(["info", "success", "warning", "error"]);
+
+const fragment = JSON.parse(readFileSync(fragmentPath, "utf8"));
+if (!fragment.title || !fragment.body) {
+  console.error(`fragment ${fragmentPath} must have a "title" and a "body"`);
+  process.exit(1);
+}
+
+// Bump the patch version with a targeted replace so package.json keeps its exact
+// formatting (rewriting the parsed object risks reformatting that trips CI).
+const pkgRaw = readFileSync(PKG_PATH, "utf8");
+const match = pkgRaw.match(/("version":\s*")(\d+)\.(\d+)\.(\d+)(")/);
+if (!match) {
+  console.error(`could not find an x.y.z version field in ${PKG_PATH}`);
+  process.exit(1);
+}
+const [major, minor, patch] = [match[2], match[3], match[4]].map((n) => parseInt(n, 10));
+const version = `${major}.${minor}.${patch + 1}`;
+writeFileSync(PKG_PATH, pkgRaw.replace(match[0], `${match[1]}${version}${match[5]}`));
+
+// Append the notification entry. The post-merge run owns version + timestamp;
+// the fragment only supplies the player-facing text and optional severity.
+const entry = {
+  version,
+  title: String(fragment.title),
+  body: String(fragment.body),
+  severity: ALLOWED_SEVERITY.has(fragment.severity) ? fragment.severity : "info",
+  timestamp: Math.floor(Date.now() / 1000),
+};
+
+let notes = [];
+try {
+  const parsed = JSON.parse(readFileSync(NOTES_PATH, "utf8"));
+  if (Array.isArray(parsed)) notes = parsed;
+} catch {
+  notes = [];
+}
+notes.push(entry);
+writeFileSync(NOTES_PATH, `${JSON.stringify(notes, null, 2)}\n`);
+
+console.log(`Released v${version}: ${entry.title}`);

--- a/.github/scripts/apply-release-fragment.mjs
+++ b/.github/scripts/apply-release-fragment.mjs
@@ -22,8 +22,8 @@ const NOTES_PATH = "src/data/releaseNotes.json";
 const ALLOWED_SEVERITY = new Set(["info", "success", "warning", "error"]);
 
 const fragment = JSON.parse(readFileSync(fragmentPath, "utf8"));
-if (!fragment.title || !fragment.body) {
-  console.error(`fragment ${fragmentPath} must have a "title" and a "body"`);
+if (!fragment.title || !fragment.body || !String(fragment.title).trim() || !String(fragment.body).trim()) {
+  console.error(`fragment ${fragmentPath} must have a non-empty "title" and "body"`);
   process.exit(1);
 }
 

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -28,7 +28,6 @@ jobs:
     outputs:
       eligible: ${{ steps.check.outputs.eligible }}
       branch: ${{ steps.check.outputs.branch }}
-      release_kind: ${{ steps.check.outputs.release_kind }}
     steps:
       - name: Read current labels
         id: check
@@ -71,17 +70,6 @@ jobs:
             fi
             echo "branch=$branch" >> "$GITHUB_OUTPUT"
             echo "Branch: $branch"
-
-            # Release channel. Default is a quiet notification entry; the full
-            # What's New wizard is opt-in via an explicit `release:feature` label
-            # a human adds, so routine fixes never trigger an update modal.
-            if echo "$labels" | grep -q '"release:feature"'; then
-              release_kind="feature"
-            else
-              release_kind="note"
-            fi
-            echo "release_kind=$release_kind" >> "$GITHUB_OUTPUT"
-            echo "Release type: $release_kind"
           else
             echo "eligible=false" >> "$GITHUB_OUTPUT"
             echo "Not eligible: needs from-discord + (enhancement or bug) and must not be ai-attempted."
@@ -158,7 +146,6 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_REPO: ${{ github.repository }}
-          RELEASE_KIND: ${{ needs.gate.outputs.release_kind }}
         run: |
           PROMPT_FILE="$RUNNER_TEMP/prompt.txt"
           {
@@ -167,11 +154,11 @@ jobs:
             printf -- '- App (game-datacards), your working directory: %s\n' "$GITHUB_WORKSPACE/game-datacards"
             printf -- '- Premium package (gdc-premium): %s\n' "$GITHUB_WORKSPACE/gdc-premium"
             printf -- '- PR summary file (write your summary here as your final step): %s\n' "$GITHUB_WORKSPACE/pr-summary.md"
-            printf 'Use these absolute paths. Only edit files under the src/ and docs/ subfolders of each, plus the app (game-datacards) package.json version field for the patch bump described in the prompt, plus the PR summary file above (see "Write the PR summary").\n'
+            printf -- '- Release fragment file (write the release note here): %s\n' "$GITHUB_WORKSPACE/game-datacards/changes/unreleased/${ISSUE_NUMBER}.json"
+            printf 'Use these absolute paths. Only edit files under the src/ and docs/ subfolders of each, plus the release fragment and PR summary files above (see "Record the change" and "Write the PR summary"). Do NOT edit package.json or any other release bookkeeping; the version bump and release notes happen automatically after merge.\n'
             printf '\n## The issue to implement\n\n'
             printf 'Repository: %s\n' "$ISSUE_REPO"
             printf 'Issue number: #%s\n' "$ISSUE_NUMBER"
-            printf 'Release type: %s\n' "${RELEASE_KIND:-note}"
             printf 'Title: %s\n\n' "$ISSUE_TITLE"
             printf 'Body:\n'
             printf '%s\n' "$ISSUE_BODY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+# Issue-to-PR patches land on main carrying a release fragment in
+# changes/unreleased/. This job runs the release that the feature PR no longer
+# does: it assigns the next PATCH version ON main (so parallel PRs never collide
+# on the number), records the note in src/data/releaseNotes.json, deletes the
+# fragment, commits, and tags. The version bump is the only change to
+# package.json, which is what the Cloudflare Pages "build watch path" keys on to
+# deploy production — so routine merges that carry no fragment never deploy.
+#
+# Feature releases (the full What's New wizard + minor bump) are cut by a human,
+# not here.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "changes/unreleased/**"
+
+# One release at a time. Back-to-back merges queue, so each picks up the version
+# the previous one just committed and bumps from there.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release pending fragments
+    runs-on: ubuntu-latest
+    # The release commit below also touches changes/unreleased (it deletes the
+    # consumed fragment), which would re-fire this workflow; skip those so there
+    # is no loop. The fragment-presence guard in the step is a second backstop.
+    if: ${{ !startsWith(github.event.head_commit.message, 'Release v') }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GH_PAT }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Apply fragments, commit, and tag
+        run: |
+          shopt -s nullglob
+          frags=(changes/unreleased/*.json)
+          if [ "${#frags[@]}" -eq 0 ]; then
+            echo "No release fragments; nothing to release."
+            exit 0
+          fi
+
+          git config user.name "gdc-release-bot"
+          git config user.email "release-bot@users.noreply.github.com"
+
+          # Apply in a stable order; each fragment bumps the patch and appends its
+          # note, so several merged at once get sequential versions.
+          mapfile -t sorted < <(printf '%s\n' "${frags[@]}" | sort)
+          for frag in "${sorted[@]}"; do
+            node .github/scripts/apply-release-fragment.mjs "$frag"
+            git rm -q "$frag"
+          done
+
+          version="$(node -p "require('./package.json').version")"
+          git add -A
+          git commit -m "Release v${version}"
+          git push origin HEAD:main
+          git tag "v${version}"
+          git push origin "v${version}"
+          echo "Released v${version}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,18 +58,38 @@ jobs:
           git config user.name "gdc-release-bot"
           git config user.email "release-bot@users.noreply.github.com"
 
-          # Apply in a stable order; each fragment bumps the patch and appends its
-          # note, so several merged at once get sequential versions.
+          # Apply in a stable order. Each fragment is its own commit so every
+          # version gets a distinct commit (and, below, its own tag) even when
+          # several merge before this job fires; they still go out in one push,
+          # so Cloudflare builds once.
           mapfile -t sorted < <(printf '%s\n' "${frags[@]}" | sort)
+          versions=()
           for frag in "${sorted[@]}"; do
             node .github/scripts/apply-release-fragment.mjs "$frag"
-            git rm -q "$frag"
+            rm -f "$frag"
+            version="$(node -p "require('./package.json').version")"
+            git add -A
+            git commit -q -m "Release v${version}"
+            versions+=("$version")
           done
 
-          version="$(node -p "require('./package.json').version")"
-          git add -A
-          git commit -m "Release v${version}"
-          git push origin HEAD:main
-          git tag "v${version}"
-          git push origin "v${version}"
-          echo "Released v${version}"
+          # Land the release commit(s) on main. The release concurrency group
+          # serialises release runs against each other, but not against a manual
+          # push or a non-fragment merge that lands between our checkout and push,
+          # so rebase and retry on a non-fast-forward rejection.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              break
+            fi
+            echo "push rejected (attempt ${attempt}); rebasing on origin/main"
+            git pull --rebase origin main
+          done
+
+          # Tag each version at its commit, after the push, so a rebase above can
+          # never leave a tag pointing at an orphaned (pre-rebase) commit.
+          for version in "${versions[@]}"; do
+            commit="$(git rev-list --max-count=1 --grep="^Release v${version}$" HEAD)"
+            git tag "v${version}" "$commit"
+          done
+          git push origin --tags
+          echo "Released: ${versions[*]}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ For detailed documentation on card data formats, import features, components, an
 - **All new features require unit tests.** Write tests using Vitest before or alongside implementation.
 - **Use Chrome DevTools MCP to validate UI work.** Take snapshots and screenshots to verify visual changes render correctly in the browser.
 - **WhatsNew wizard mobile steps must use `mwnw-*` CSS classes.** Desktop wizard uses `wnw-*` classes, mobile uses `mwnw-*`. When adding a new version step to `MobileWhatsNewWizard/versions/`, use an existing mobile step (e.g., v3.7.0 `StepMobileEditor.jsx`) as the template, not the desktop counterpart.
-- **Two release channels: notification notes (default) vs the What's New wizard.** Routine fixes ship as a quiet entry appended to `src/data/releaseNotes.json` (shown in the notification bell, patch version bump) and add NO wizard entry. Only notable features get a full What's New wizard entry (minor version bump). See `docs/release-notifications.md`; the issue-to-PR pipeline routes by the `release:feature` label.
+- **Two release channels: notification notes (default) vs the What's New wizard.** Routine fixes ship as a quiet entry in `src/data/releaseNotes.json` (shown in the notification bell, patch version bump) and add NO wizard entry. Only notable features get a full What's New wizard entry (minor version bump). See `docs/release-notifications.md`. Issue-to-PR PRs do NOT bump the version or edit `releaseNotes.json` themselves: they drop a fragment in `changes/unreleased/`, and `.github/workflows/release.yml` applies the patch bump + note after merge. Feature/wizard releases are cut manually by a human.
 
 ## Before Making Changes
 
@@ -283,9 +283,11 @@ Feature flags (set in `.env`, all default to `true` if omitted):
 ## CI/CD Pipeline
 
 - **GitHub Actions**: Runs lint on all branches, tests on pull requests only (Node.js 20)
+- **Release** (`.github/workflows/release.yml`): on merge to `main`, consumes any `changes/unreleased/` fragment, bumps the patch version, appends the release note, and tags. This is the only thing that changes `package.json`.
 - **Cloudflare Pages**: Automatically builds and deploys all branches
   - Preview URLs generated for each branch
   - Production deployment on `main` branch
+  - **Production builds are gated by a build watch path of `package.json`** so only release commits (the post-merge version bump) deploy — routine merges that carry no release fragment do not. Set this under Cloudflare Pages → Settings → Builds & deployments → Build watch paths.
 
 ## Cloudflare Pages Configuration
 

--- a/changes/README.md
+++ b/changes/README.md
@@ -1,0 +1,30 @@
+# Release fragments
+
+Each pull request that should ship a release note drops one JSON file in
+`changes/unreleased/`, named after its issue number (e.g. `231.json`):
+
+```json
+{
+  "title": "Keywords stay after saving",
+  "body": "Keywords you typed used to disappear after saving. Now they stay.",
+  "severity": "info"
+}
+```
+
+- `title`, `body` — the player-facing note (no version numbers, no jargon).
+- `severity` — optional; one of `info`, `success`, `warning`, `error`.
+- No `version` or `timestamp` — the release workflow assigns those.
+
+Why one file per issue: two open PRs never edit the same file, so they cannot
+conflict on the version bump or on `src/data/releaseNotes.json` the way they did
+when each PR bumped the version itself.
+
+When a PR merges to `main`, `.github/workflows/release.yml` consumes its
+fragment: it bumps the **patch** version in `package.json`, appends the note to
+`src/data/releaseNotes.json` (the in-app notification bell), deletes the
+fragment, commits, and tags `v<x.y.z>`. That version-bump commit is the only
+thing that changes `package.json`, which is what the Cloudflare Pages build
+watch path uses to deploy production.
+
+Notable **feature** releases — the full-screen What's New wizard plus a minor
+version bump — are cut by a human, not by this pipeline.

--- a/docs/release-notifications.md
+++ b/docs/release-notifications.md
@@ -15,6 +15,9 @@ file_locations:
   settings: src/Hooks/useSettingsStorage.jsx
   pipeline_prompt: .github/issue-to-pr/prompt.md
   pipeline_workflow: .github/workflows/issue-to-pr.yml
+  fragments: changes/unreleased/
+  release_workflow: .github/workflows/release.yml
+  release_script: .github/scripts/apply-release-fragment.mjs
 ---
 
 # Release Notifications and What's New Channels
@@ -28,15 +31,15 @@ that the steady stream of small fixes does not bury users under update modals.
 - [Release notes feed](#release-notes-feed)
 - [Read state and unread badge](#read-state-and-unread-badge)
 - [Where notes render](#where-notes-render)
-- [How the pipeline chooses a channel](#how-the-pipeline-chooses-a-channel)
+- [How the pipeline releases](#how-the-pipeline-releases)
 - [Authoring a release note](#authoring-a-release-note)
 
 ## The two channels
 
-| Channel | For | Version bump | Where it shows |
-|---------|-----|--------------|----------------|
-| **Release note** (default) | Fixes and small changes | Patch (`3.9.0` -> `3.9.1`) | A small item in the notification bell |
-| **What's New** (opt-in) | Notable features | Minor (`3.9.4` -> `3.10.0`) | The full-screen What's New wizard |
+| Channel | For | Who/when | Version bump | Where it shows |
+|---------|-----|----------|--------------|----------------|
+| **Release note** | Fixes and small changes (all issue-to-PR PRs) | Pipeline, automatically after merge | Patch (`3.9.0` -> `3.9.1`) | A small item in the notification bell |
+| **What's New** | Notable features | A human, cut manually | Minor (`3.9.4` -> `3.10.0`) | The full-screen What's New wizard |
 
 The What's New wizard is unchanged: it is still triggered purely by entries in the
 desktop/mobile `VERSION_REGISTRY` (see `src/Components/WhatsNewWizard/`). A patch
@@ -89,19 +92,30 @@ newest first, and pick the right unread cursor by each item's `source`:
 - Mobile sheet: `src/Components/Viewer/MobileNotifications.jsx`
 - Mobile badge count: `src/Components/Viewer/MobileMenu.jsx`
 
-## How the pipeline chooses a channel
+## How the pipeline releases
 
-The issue-to-PR pipeline routes by an explicit, human-applied label:
+Issue-to-PR PRs always use the **release-note** channel, and the version bump and
+feed entry are applied **after merge**, not in the PR. This keeps release
+bookkeeping out of the feature branch, so several pipeline PRs can be open at once
+without colliding on the version number or on `releaseNotes.json`.
 
-- No `release:feature` label (the default) -> **note**: patch bump + one
-  `releaseNotes.json` entry, no wizard.
-- `release:feature` label present -> **feature**: minor bump + a What's New entry
-  (desktop + mobile).
+1. The agent writes one **fragment** to `changes/unreleased/<issue>.json` — just
+   `title`, `body`, and optional `severity` (no version, no timestamp). One file
+   per issue means two PRs never edit the same file. See `changes/README.md`.
+2. On merge to `main`, `.github/workflows/release.yml` runs (serialized via a
+   `release` concurrency group). For each pending fragment it calls
+   `.github/scripts/apply-release-fragment.mjs`, which bumps the **patch** version
+   in `package.json` and appends the entry to `src/data/releaseNotes.json` with
+   the assigned version and current timestamp. It then deletes the fragment,
+   commits `Release v<x.y.z>`, and tags.
+3. That commit is the only thing that changes `package.json`. Cloudflare Pages is
+   set with a **build watch path** of `package.json`, so production deploys on
+   release commits only — a merge that carries no fragment does not deploy.
 
-The `gate` job in `.github/workflows/issue-to-pr.yml` derives a `release_kind`
-output (`note` or `feature`) from the labels and passes it to the agent prompt as a
-`Release type` line. The agent follows `.github/issue-to-pr/prompt.md` ("Release
-the change").
+The full-screen **What's New** wizard is not produced by the pipeline. It is still
+triggered purely by `VERSION_REGISTRY` entries, and a human adds those (with a
+minor bump) when cutting a notable feature release. Patch notes are never lost —
+they remain in `releaseNotes.json` and the bell.
 
 ## Authoring a release note
 

--- a/src/Helpers/__tests__/releaseFragments.test.js
+++ b/src/Helpers/__tests__/releaseFragments.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Issue-to-PR PRs drop a release fragment in changes/unreleased/<issue>.json;
+// the post-merge Release workflow consumes it (bump version + append a
+// notification entry). A malformed fragment would break that release, so this
+// test validates every fragment on the branch. On main the directory is
+// normally empty (fragments are deleted on release), so the per-file checks
+// simply do not run.
+const FRAGMENT_DIR = resolve(process.cwd(), "changes/unreleased");
+const ALLOWED_SEVERITY = ["info", "success", "warning", "error"];
+
+const fragmentFiles = existsSync(FRAGMENT_DIR)
+  ? readdirSync(FRAGMENT_DIR).filter((file) => file.endsWith(".json"))
+  : [];
+
+describe("release fragments (changes/unreleased)", () => {
+  it("has the fragments directory", () => {
+    expect(existsSync(FRAGMENT_DIR)).toBe(true);
+  });
+
+  it.each(fragmentFiles)("%s is a valid release fragment", (file) => {
+    const raw = readFileSync(resolve(FRAGMENT_DIR, file), "utf8");
+
+    let parsed;
+    expect(() => {
+      parsed = JSON.parse(raw);
+    }, `${file} must be valid JSON`).not.toThrow();
+
+    expect(typeof parsed.title, `${file} needs a string "title"`).toBe("string");
+    expect(parsed.title.trim().length).toBeGreaterThan(0);
+    expect(typeof parsed.body, `${file} needs a string "body"`).toBe("string");
+    expect(parsed.body.trim().length).toBeGreaterThan(0);
+
+    if (parsed.severity !== undefined) {
+      expect(ALLOWED_SEVERITY, `${file} severity must be one of ${ALLOWED_SEVERITY.join(", ")}`).toContain(
+        parsed.severity,
+      );
+    }
+
+    // version and timestamp are assigned by the release workflow, not the PR.
+    expect(parsed.version, `${file} must not set "version"`).toBeUndefined();
+    expect(parsed.timestamp, `${file} must not set "timestamp"`).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

Pipeline PRs each bumped `package.json` to the same next version and appended to the same `src/data/releaseNotes.json`, so multiple open PRs collided (and all claimed the same version). Confirmed against the 3 open AI PRs — all bump to `3.10.1` and all add the first `releaseNotes.json` entry.

## Fix: move release bookkeeping off the feature branch

| Before | After |
|---|---|
| Each PR bumps version + edits `releaseNotes.json` | Each PR writes `changes/unreleased/<issue>.json` (unique per issue) |
| Version chosen against stale `main` (collides) | Version assigned **on `main`** after merge (sequential) |
| Collisions between open PRs | No shared-file edits → no collisions |

- **`prompt.md` / `opencode.json` / `issue-to-pr.yml`**: the agent no longer touches `package.json`, `releaseNotes.json`, or the What's New wizard; it writes a release fragment. The gate no longer computes a release channel (pipeline is patch-only).
- **`release.yml`** (new): on push to `main`, fragment-gated and serialized. Bumps the patch version via `.github/scripts/apply-release-fragment.mjs`, appends the note, deletes the fragment, commits `Release v<x.y.z>`, tags. Skips its own release commit (no loop).
- **Cloudflare**: the version-bump commit is the only thing that changes `package.json`. Set a **build watch path of `package.json`** in the Cloudflare dashboard so production deploys only on release commits. (Dashboard step — documented in CLAUDE.md.)
- **Feature/What's New releases** stay manual (minor bump + wizard); old patch notes are never lost.

## Tested locally
- `apply-release-fragment.mjs`: sequential patch bumps (`3.10.0`→`.1`→`.2`), `package.json` formatting preserved, unique-versioned notes.
- New `releaseFragments.test.js` guard: passes empty, fails a malformed fragment.
- `yarn lint` clean; Helpers tests pass.

## Follow-up (sequencing)
After this merges, the 3 open pipeline PRs (#230, #235, #236) should be converted to the fragment format (strip their version/`releaseNotes.json` edits, add a fragment) so they merge cleanly and auto-release. Happy to do that once this lands.