### PR TITLE
Fix issue-to-PR pr-summary.md write being auto-rejected

### DIFF
--- a/.github/issue-to-pr/README.md
+++ b/.github/issue-to-pr/README.md
@@ -35,9 +35,10 @@ human reviews and merges; nothing is auto-merged.
    the `gate` job; because both repos use the same name, the premium build links
    them automatically.
    - The PR body is built by `create-prs.sh` from the agent's own plain-language
-     summary (written to `pr-summary.md`, outside both repos so it is never
-     committed), the actual `git diff --stat` of the change, the issue link
-     (`Closes #<n>` on the app PR), the lint/test status, and the OpenCode usage.
+     summary (written to `pr-summary.md` in the app repo, which `create-prs.sh`
+     deletes before committing so it never lands in the PR), the actual
+     `git diff --stat` of the change, the issue link (`Closes #<n>` on the app
+     PR), the lint/test status, and the OpenCode usage.
 5. The PRs are opened with a PAT, so `ci.yml` and `claude-review.yml` run on them
    automatically. The bot also comments the result back on the issue.
 

--- a/.github/issue-to-pr/create-prs.sh
+++ b/.github/issue-to-pr/create-prs.sh
@@ -9,9 +9,9 @@ set -euo pipefail
 # two at build time. Both repos must use the same branch name.
 #
 # The PR body is assembled from the agent's own plain-language summary
-# (pr-summary.md, written outside both repos so it is never committed), the
-# actual git diffstat of the change, the issue link, the lint/test status, and
-# the OpenCode token/cost usage for the run.
+# (pr-summary.md, written in the app repo and deleted here before committing so
+# it never lands in the PR), the actual git diffstat of the change, the issue
+# link, the lint/test status, and the OpenCode token/cost usage for the run.
 #
 # Required env:
 #   GITHUB_WORKSPACE  parent dir containing game-datacards/ and gdc-premium/
@@ -23,7 +23,7 @@ set -euo pipefail
 #   PREMIUM_REPO      owner/repo, e.g. ronplanken/gdc-premium
 #   CHECKS            human-readable lint/test status line
 # Optional:
-#   SUMMARY_FILE      path to the agent's PR summary (default: $GITHUB_WORKSPACE/pr-summary.md)
+#   SUMMARY_FILE      path to the agent's PR summary (default: $GITHUB_WORKSPACE/game-datacards/pr-summary.md)
 #   USAGE_FILE        path to the OpenCode usage stats text
 #   PREMIUM_BASE      base branch for the premium PR (default: main)
 #   BOT_NAME, BOT_EMAIL
@@ -32,12 +32,16 @@ BRANCH="${BRANCH:?BRANCH must be set by the workflow}"
 PREMIUM_BASE="${PREMIUM_BASE:-main}"
 BOT_NAME="${BOT_NAME:-gdc-issue-bot}"
 BOT_EMAIL="${BOT_EMAIL:-issue-bot@users.noreply.github.com}"
-SUMMARY_FILE="${SUMMARY_FILE:-${GITHUB_WORKSPACE}/pr-summary.md}"
+SUMMARY_FILE="${SUMMARY_FILE:-${GITHUB_WORKSPACE}/game-datacards/pr-summary.md}"
 
 # Read the agent summary and usage stats if present; both degrade gracefully.
+# The summary lives inside the app repo (so the agent can write it without an
+# external-directory grant), so delete it after reading or `git add -A` below
+# would commit it into the PR.
 SUMMARY=""
 if [ -s "$SUMMARY_FILE" ]; then
   SUMMARY="$(cat "$SUMMARY_FILE")"
+  rm -f "$SUMMARY_FILE"
 fi
 USAGE=""
 if [ -n "${USAGE_FILE:-}" ] && [ -s "$USAGE_FILE" ]; then

--- a/.github/issue-to-pr/opencode.json
+++ b/.github/issue-to-pr/opencode.json
@@ -24,20 +24,20 @@
   },
   "permission": {
     "external_directory": {
-      "GDCWS/gdc-premium/**": "allow",
-      "GDCWS/pr-summary.md": "allow"
+      "GDCWS/gdc-premium/**": "allow"
     },
     "edit": {
       "*": "deny",
       "src/**": "allow",
       "docs/**": "allow",
       "changes/unreleased/**": "allow",
+      "pr-summary.md": "allow",
       "GDCWS/game-datacards/src/**": "allow",
       "GDCWS/game-datacards/docs/**": "allow",
       "GDCWS/game-datacards/changes/unreleased/**": "allow",
+      "GDCWS/game-datacards/pr-summary.md": "allow",
       "GDCWS/gdc-premium/src/**": "allow",
-      "GDCWS/gdc-premium/docs/**": "allow",
-      "GDCWS/pr-summary.md": "allow"
+      "GDCWS/gdc-premium/docs/**": "allow"
     },
     "bash": {
       "*": "allow",

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -153,7 +153,7 @@ jobs:
             printf '\n\n## Repository locations\n\n'
             printf -- '- App (game-datacards), your working directory: %s\n' "$GITHUB_WORKSPACE/game-datacards"
             printf -- '- Premium package (gdc-premium): %s\n' "$GITHUB_WORKSPACE/gdc-premium"
-            printf -- '- PR summary file (write your summary here as your final step): %s\n' "$GITHUB_WORKSPACE/pr-summary.md"
+            printf -- '- PR summary file (write your summary here as your final step): %s\n' "$GITHUB_WORKSPACE/game-datacards/pr-summary.md"
             printf -- '- Release fragment file (write the release note here): %s\n' "$GITHUB_WORKSPACE/game-datacards/changes/unreleased/${ISSUE_NUMBER}.json"
             printf 'Use these absolute paths. Only edit files under the src/ and docs/ subfolders of each, plus the release fragment and PR summary files above (see "Record the change" and "Write the PR summary"). Do NOT edit package.json or any other release bookkeeping; the version bump and release notes happen automatically after merge.\n'
             printf '\n## The issue to implement\n\n'
@@ -230,7 +230,8 @@ jobs:
           PREMIUM_REPO: ronplanken/gdc-premium
           CHECKS: ${{ steps.checks.outputs.result }}
           BRANCH: ${{ needs.gate.outputs.branch }}
-          # pr-summary.md is written by the agent; usage.txt by the step above.
-          SUMMARY_FILE: ${{ github.workspace }}/pr-summary.md
+          # pr-summary.md is written by the agent inside the app repo; usage.txt
+          # by the step above. create-prs.sh deletes the summary before committing.
+          SUMMARY_FILE: ${{ github.workspace }}/game-datacards/pr-summary.md
           USAGE_FILE: ${{ env.USAGE_FILE }}
         run: bash game-datacards/.github/issue-to-pr/create-prs.sh


### PR DESCRIPTION
## Bug

Pipeline runs failed to write the PR summary:

```
! permission requested: external_directory (/home/runner/work/game-datacards/game-datacards/*); auto-rejecting
✗ Write /home/runner/work/game-datacards/game-datacards/pr-summary.md failed
```

## Cause

`GITHUB_WORKSPACE` is `/home/runner/work/game-datacards/game-datacards`, and the app is checked out **into** `$GITHUB_WORKSPACE/game-datacards` (the agent's `--dir`). So `$GITHUB_WORKSPACE/pr-summary.md` sat in the **parent** of the project root — an `external_directory` write, which opencode auto-rejects (a file-specific allow doesn't satisfy its directory-level request). The release fragment never hit this because it's written *inside* the project root.

## Fix

Write `pr-summary.md` inside the app repo (`$GITHUB_WORKSPACE/game-datacards/pr-summary.md`), governed by an in-project `edit` rule like the fragment and `src/**`:

- `issue-to-pr.yml`: prompt path + `SUMMARY_FILE` env now point inside the app repo.
- `opencode.json`: `pr-summary.md` moved from `external_directory` to in-project `edit` (`pr-summary.md` + the absolute `GDCWS/game-datacards/pr-summary.md`); removed the external entry.
- `create-prs.sh`: reads the summary then `rm -f`s it before `git add -A`, so it never lands in the PR. Docs updated.

No app code changes.