### PR TITLE
Fix Image Generator crash on factions with unlisted ids

### DIFF
--- a/changes/unreleased/image-generator-faction-crash.json
+++ b/changes/unreleased/image-generator-faction-crash.json
@@ -1,0 +1,5 @@
+{
+  "title": "Image Generator no longer crashes on certain factions",
+  "body": "Selecting factions such as Adeptus Titanicus in the Image Generator no longer throws a \"something went wrong\" error. Each faction's cards are now tracked on demand, so any faction can be generated.",
+  "severity": "info"
+}

--- a/src/Helpers/__tests__/imageGenerator.helpers.test.js
+++ b/src/Helpers/__tests__/imageGenerator.helpers.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { assignBucketRef } from "../imageGenerator.helpers";
+
+describe("assignBucketRef", () => {
+  it("creates a bucket on demand for a previously unseen faction id (e.g. Adeptus Titanicus)", () => {
+    const buckets = {};
+    // "AT" is not pre-seeded; this used to throw
+    // ("can't access property 0, buckets['AT'] is undefined").
+    expect(() => assignBucketRef(buckets, "AT", 0, "node-0")).not.toThrow();
+    expect(buckets.AT).toEqual(["node-0"]);
+  });
+
+  it("assigns nodes at their index and preserves earlier entries", () => {
+    const buckets = {};
+    assignBucketRef(buckets, "SM", 0, "front-0");
+    assignBucketRef(buckets, "SM", 3, "front-3");
+    expect(buckets.SM[0]).toBe("front-0");
+    expect(buckets.SM[3]).toBe("front-3");
+    expect(buckets.SM).toHaveLength(4);
+  });
+
+  it("keeps separate buckets per faction id", () => {
+    const buckets = {};
+    assignBucketRef(buckets, "AT", 0, "at-0");
+    assignBucketRef(buckets, "TAU", 0, "tau-0");
+    expect(buckets.AT).toEqual(["at-0"]);
+    expect(buckets.TAU).toEqual(["tau-0"]);
+  });
+
+  it("stores null on unmount without discarding the bucket", () => {
+    const buckets = { AT: ["at-0"] };
+    assignBucketRef(buckets, "AT", 0, null);
+    expect(buckets.AT[0]).toBeNull();
+  });
+
+  it("is a no-op for a missing bucket object or faction id", () => {
+    expect(() => assignBucketRef(null, "AT", 0, "x")).not.toThrow();
+    const buckets = {};
+    assignBucketRef(buckets, undefined, 0, "x");
+    expect(buckets).toEqual({});
+  });
+});

--- a/src/Helpers/imageGenerator.helpers.js
+++ b/src/Helpers/imageGenerator.helpers.js
@@ -1,18 +1,13 @@
 /**
- * Helpers for the bulk Image Generator page.
+ * Assign a rendered card node into its faction's ref bucket, creating the
+ * bucket on first use. Safe for any faction id, including ones not seen before.
  *
- * The generator keeps one ref bucket per faction, each holding the rendered
- * card DOM nodes so they can be captured to PNG. Faction ids are data-driven
- * (they come from the loaded datasource), so the buckets must NOT be a fixed,
- * hardcoded list: any faction whose id is missing (e.g. Adeptus Titanicus /
- * "AT", or any newly added faction/edition) would otherwise dereference an
- * undefined bucket and crash the page ("can't access property N, ... is
- * undefined").
- */
-
-/**
- * Assign a rendered card node into a faction bucket, creating the bucket on
- * first use. Safe for any faction id, including ones not seen before.
+ * The Image Generator keeps one bucket of card DOM nodes per faction so they
+ * can be captured to PNG. Faction ids are data-driven (they come from the
+ * loaded datasource), so buckets must be created on demand rather than seeded
+ * from a fixed list: a missing id (e.g. Adeptus Titanicus / "AT", or any newly
+ * added faction/edition) would otherwise dereference an undefined bucket and
+ * crash the page ("can't access property N, ... is undefined").
  *
  * @param {Record<string, any[]>} buckets - the ref `.current` object, keyed by faction id
  * @param {string} factionId - the faction the card belongs to

--- a/src/Helpers/imageGenerator.helpers.js
+++ b/src/Helpers/imageGenerator.helpers.js
@@ -1,0 +1,28 @@
+/**
+ * Helpers for the bulk Image Generator page.
+ *
+ * The generator keeps one ref bucket per faction, each holding the rendered
+ * card DOM nodes so they can be captured to PNG. Faction ids are data-driven
+ * (they come from the loaded datasource), so the buckets must NOT be a fixed,
+ * hardcoded list: any faction whose id is missing (e.g. Adeptus Titanicus /
+ * "AT", or any newly added faction/edition) would otherwise dereference an
+ * undefined bucket and crash the page ("can't access property N, ... is
+ * undefined").
+ */
+
+/**
+ * Assign a rendered card node into a faction bucket, creating the bucket on
+ * first use. Safe for any faction id, including ones not seen before.
+ *
+ * @param {Record<string, any[]>} buckets - the ref `.current` object, keyed by faction id
+ * @param {string} factionId - the faction the card belongs to
+ * @param {number} index - the card's index within the faction
+ * @param {any} el - the DOM node (or null on unmount)
+ */
+export const assignBucketRef = (buckets, factionId, index, el) => {
+  if (!buckets || factionId == null) return;
+  if (!buckets[factionId]) {
+    buckets[factionId] = [];
+  }
+  buckets[factionId][index] = el;
+};

--- a/src/Pages/ImageGenerator.jsx
+++ b/src/Pages/ImageGenerator.jsx
@@ -13,103 +13,18 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 import JSZip from "jszip";
 import { useSettingsStorage } from "../Hooks/useSettingsStorage";
 import { buildUniqueFilenames } from "../Helpers/export.helpers";
+import { assignBucketRef } from "../Helpers/imageGenerator.helpers";
 
 const { useBreakpoint } = Grid;
 const { Option } = Select;
 export const ImageGenerator = () => {
-  const cardsFrontRef = useRef({
-    AS: [],
-    AC: [],
-    AdM: [],
-    AE: [],
-    AoI: [],
-    AM: [],
-    CHBT: [],
-    CHBA: [],
-    CSM: [],
-    CD: [],
-    QT: [],
-    CHDA: [],
-    DG: [],
-    LGEC: [],
-    CHDW: [],
-    DRU: [],
-    GK: [],
-    GSC: [],
-    QI: [],
-    NEC: [],
-    ORK: [],
-    SM: [],
-    CHSW: [],
-    TAU: [],
-    TS: [],
-    TYR: [],
-    UN: [],
-    LoV: [],
-    WE: [],
-  });
-  const cardsBackRef = useRef({
-    AS: [],
-    AC: [],
-    AdM: [],
-    AE: [],
-    AoI: [],
-    AM: [],
-    CHBT: [],
-    CHBA: [],
-    CSM: [],
-    CD: [],
-    QT: [],
-    CHDA: [],
-    DG: [],
-    LGEC: [],
-    CHDW: [],
-    DRU: [],
-    GK: [],
-    GSC: [],
-    QI: [],
-    NEC: [],
-    ORK: [],
-    SM: [],
-    CHSW: [],
-    TAU: [],
-    TS: [],
-    TYR: [],
-    UN: [],
-    LoV: [],
-    WE: [],
-  });
-  const cardsStratagems = useRef({
-    AS: [],
-    AC: [],
-    AdM: [],
-    AE: [],
-    AoI: [],
-    AM: [],
-    CHBT: [],
-    CHBA: [],
-    CSM: [],
-    CD: [],
-    QT: [],
-    CHDA: [],
-    DG: [],
-    LGEC: [],
-    CHDW: [],
-    DRU: [],
-    GK: [],
-    GSC: [],
-    QI: [],
-    NEC: [],
-    ORK: [],
-    SM: [],
-    CHSW: [],
-    TAU: [],
-    TS: [],
-    TYR: [],
-    UN: [],
-    LoV: [],
-    WE: [],
-  });
+  // Ref buckets are keyed by faction id and created on demand (see
+  // assignBucketRef). They must not be a hardcoded faction list: faction ids
+  // are data-driven, so any missing id (e.g. Adeptus Titanicus / "AT") would
+  // otherwise crash the page when its ref callback fires.
+  const cardsFrontRef = useRef({});
+  const cardsBackRef = useRef({});
+  const cardsStratagems = useRef({});
   const basicStratagems = useRef([]);
   const overlayRef = useRef(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -295,7 +210,7 @@ export const ImageGenerator = () => {
                               "--banner-colour": faction?.colours?.banner,
                               "--header-colour": faction?.colours?.header,
                             }}
-                            key={faction.id}>
+                            key={`${faction.id}-${card.name}-${index}`}>
                             <Col
                               key={`${card.name}-${index}`}
                               className={`data-${card?.source ? card?.source : "40k"}`}>
@@ -304,7 +219,7 @@ export const ImageGenerator = () => {
                                   key={`${card.name}-${index}`}
                                   className={`data-${card?.source ? card?.source : "40k"}`}>
                                   <div
-                                    ref={(el) => (cardsFrontRef.current[faction.id][index] = el)}
+                                    ref={(el) => assignBucketRef(cardsFrontRef.current, faction.id, index, el)}
                                     style={{
                                       "--banner-colour": faction?.colours?.banner,
                                       "--header-colour": faction?.colours?.header,
@@ -314,7 +229,7 @@ export const ImageGenerator = () => {
                                     )}
                                   </div>
                                   <div
-                                    ref={(el) => (cardsBackRef.current[faction.id][index] = el)}
+                                    ref={(el) => assignBucketRef(cardsBackRef.current, faction.id, index, el)}
                                     style={{
                                       "--banner-colour": faction?.colours?.banner,
                                       "--header-colour": faction?.colours?.header,
@@ -338,7 +253,7 @@ export const ImageGenerator = () => {
                                 key={`${card.name}-${index}`}
                                 className={`data-${card?.source ? card?.source : "40k"}`}>
                                 <div
-                                  ref={(el) => (cardsStratagems.current[faction.id][index] = el)}
+                                  ref={(el) => assignBucketRef(cardsStratagems.current, faction.id, index, el)}
                                   style={{
                                     "--banner-colour": faction?.colours?.banner,
                                     "--header-colour": faction?.colours?.header,


### PR DESCRIPTION
## Proposed Changes

The Image Generator (`/image-generator`) seeded its per-faction card ref buckets from a **hardcoded list of faction ids** (`AS, AC, AdM, …`). When a user selected a faction whose id was not in that list — e.g. **Adeptus Titanicus** (id `"AT"`) — the ref callback dereferenced an undefined bucket (`cardsFrontRef.current["AT"][index] = el`) and crashed the whole page with:

> Sorry, something went wrong. can't access property 3, t.current[y.id] is undefined

This affected any faction id missing from the hardcoded lists, not just Adeptus Titanicus.

Changes:
- Add `assignBucketRef` (`src/Helpers/imageGenerator.helpers.js`), which creates each faction bucket on demand, and use it for the front / back / stratagem ref callbacks.
- Drop the three hardcoded faction-id lists (`useRef({})` instead), so the generator works for every faction the datasource provides.
- Fix a duplicated React `key` on the datasheet wrapper (`key={faction.id}` was repeated for every card of a faction).
- Add unit tests for the helper, including the previously-crashing "unseen faction id" case.

Note: full 11th edition support in the Image Generator (edition selector + rendering `40k-11e` cards) is intentionally **not** in this PR — it depends on the 11e renderset from PR #253 and is tracked separately.

Ships a `changes/unreleased/` fragment so the post-merge release job records the patch note.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (`yarn lint` clean)
- [x] New and existing tests pass locally with my changes (`assignBucketRef` suite: 5/5; JS build transforms all modules — the only build error is an unrelated proxy-blocked Google Fonts `@import` in `aos.less`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1FcYwxkX2Epp7tqzWdW4j)_