### PR TITLE
Add 11e wargear abilities, wargear points, and points restrictions

### DIFF
--- a/changes/unreleased/11e-wargear-editor-and-points.json
+++ b/changes/unreleased/11e-wargear-editor-and-points.json
@@ -1,5 +1,5 @@
 {
   "title": "Edit wargear and special abilities, and pay for wargear in lists",
-  "body": "The card editor now has Wargear abilities and Special abilities panels for 11th edition units, so abilities like Terminator Storm Shield or Chapter Master of the Raven Guard can be edited or hidden instead of only showing up on the card. In the list builder, units that charge points for wargear (such as a Redemptor Dreadnought's macro plasma incinerator) now let you pick those options and count them towards your list total.",
+  "body": "The card editor now has Wargear abilities and Special abilities panels for 11th edition units, so abilities like Terminator Storm Shield or Chapter Master of the Raven Guard can be edited or hidden instead of only showing up on the card. In the list builder, units that charge points for wargear (such as a Redemptor Dreadnought's macro plasma incinerator) now let you pick those options and count them towards your list total. Those wargear choices also appear on the back of the card, each with its points cost, instead of the card simply saying \"None\", and you can add, edit and price them yourself in the Wargear Options panel. Points that only apply to one faction or detachment — 5 Assault Intercessors cost more in a Blood Angels army — now say so on the card, and can be set per size in the Points panel.",
   "severity": "info"
 }

--- a/changes/unreleased/11e-wargear-editor-and-points.json
+++ b/changes/unreleased/11e-wargear-editor-and-points.json
@@ -1,0 +1,5 @@
+{
+  "title": "Edit wargear and special abilities, and pay for wargear in lists",
+  "body": "The card editor now has Wargear abilities and Special abilities panels for 11th edition units, so abilities like Terminator Storm Shield or Chapter Master of the Raven Guard can be edited or hidden instead of only showing up on the card. In the list builder, units that charge points for wargear (such as a Redemptor Dreadnought's macro plasma incinerator) now let you pick those options and count them towards your list total.",
+  "severity": "info"
+}

--- a/changes/unreleased/weapon-keywords-string-crash.json
+++ b/changes/unreleased/weapon-keywords-string-crash.json
@@ -1,0 +1,5 @@
+{
+  "title": "Weapons tab no longer breaks after adding a weapon keyword",
+  "body": "Adding a weapon keyword could leave a card in a state where the weapons tab refused to open, even after a refresh. Affected cards now open again and the stray keyword can simply be deleted.",
+  "severity": "error"
+}

--- a/docs/warhammer-40k-11e-format.md
+++ b/docs/warhammer-40k-11e-format.md
@@ -51,6 +51,7 @@ detachments, rules).
 - [Rich-text markup](#rich-text-markup)
 - [Keyword glossary (tooltips)](#keyword-glossary-tooltips)
 - [Points, unit sizes and roster surcharge](#points-unit-sizes-and-roster-surcharge)
+- [Wargear options](#wargear-options)
 - [Rule cards](#rule-cards)
 - [Faction colours and symbols](#faction-colours-and-symbols)
 - [Scope and limitations](#scope-and-limitations)
@@ -192,8 +193,9 @@ add `nameLoc`/`descriptionLoc` language maps:
 
 ## Points, unit sizes and roster surcharge
 
-Each datasheet's `points` is an array of size tiers — `{ cost, models, keyword, detachment }`
-— plus (11e-only) an optional `additionalCost: { cost, afterSelections }`.
+Each datasheet's `points` is an array of size tiers —
+`{ cost, models, keyword, faction, detachment }` — plus (11e-only) an optional
+`additionalCost: { cost, afterSelections }`.
 
 - **Unit size (base cost):** in a list, a card's base cost is the chosen tier
   (`card.unitSize`, picked via the desktop unit config modal or the mobile
@@ -212,10 +214,41 @@ Each datasheet's `points` is an array of size tiers — `{ cost, models, keyword
   datasheet identity (`id` + `source`). It backs the tree category badge, the list
   overview total (which shows the surcharge on its own line) and the text export,
   so all three agree. 10e lists are unaffected (they carry no `additionalCost`).
+- **Restricted tiers (`faction` / `detachment`):** a tier can be priced for one
+  faction keyword or one detachment, never both — 5 Assault Intercessors are 75,
+  but 80 in a Blood Angels army. Both are language-keyed, and `null` means
+  unrestricted. `getPointsTierRestriction` / `getPointsTierRestrictionLabel`
+  resolve them; how a list narrows its tiers is covered in
+  [40k-11e list building](40k-11e-list-building.md).
 - **Where it is shown:** the card's points popover / all-points row
-  (`UnitCard/UnitPoints.jsx`), the size pickers (desktop config modal, mobile
-  add/edit sheets) as a note under the tier options, and the card editor
-  (`UnitCardEditor/UnitPoints.jsx`), which can also edit the surcharge.
+  (`UnitCard/UnitPoints.jsx`) — which names a tier's restriction next to it, as
+  a sub-label in the popover table and in parentheses on the chips — the size
+  pickers (desktop config modal, mobile add/edit sheets) as a note under the
+  tier options, and the card editor (`UnitCardEditor/UnitPoints.jsx`), which can
+  also edit the surcharge and each tier's faction or detachment.
+
+## Wargear options
+
+11e datasheets carry their wargear twice:
+
+- `wargear` — an array of language-keyed sentences, which in the 11e data dump
+  is usually just `"None"`.
+- `wargearOptions` — the structured groups the datasheet really offers:
+  `{ instruction, options: [{ name, cost }] }`, with `instruction` and `name`
+  language-keyed and `cost` a string (mostly `"0"`).
+
+The data repeats an identical group once per model in the unit, so
+`getWargearOptionGroups(card)` (`listPoints.helpers.js`) collapses groups that
+are identical in instruction and in options-at-prices. `getPaidWargearOptions`
+builds on it for the list builder, keeping only the options that cost points.
+
+`UnitCard/UnitWargear.jsx` renders both, sentences first, and appends
+`(+N pts)` to an option that costs points. A lone `"None"` is dropped, so a
+datasheet with real options is never described as having none; when neither
+half has anything to say the section disappears. `showWargear === false` hides
+it outright. `UnitCardEditor/UnitWargearOptions.jsx` edits both halves in the
+one "Wargear Options" panel, and keeps costs as strings — the shape the
+datasource uses and the points helpers coerce.
 
 ## Rule cards
 

--- a/src/Components/AgeOfSigmar/WarscrollCardEditor/WarscrollWeapon.jsx
+++ b/src/Components/AgeOfSigmar/WarscrollCardEditor/WarscrollWeapon.jsx
@@ -2,6 +2,7 @@ import { Trash2 } from "lucide-react";
 import { Button, Card, Input, Popconfirm, Space, Switch, Typography } from "antd";
 import React, { useState, useEffect } from "react";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
+import { normalizeKeywords } from "../../../Helpers/weaponProfile.helpers";
 
 export function WarscrollWeapon({ weapon, index, type }) {
   const { activeCard, updateActiveCard } = useCardStorage();
@@ -30,12 +31,16 @@ export function WarscrollWeapon({ weapon, index, type }) {
     });
   };
 
-  const keywordsArray = weapon.abilities?.length ? weapon.abilities : weapon.keywords?.length ? weapon.keywords : [];
-  const [keywordsText, setKeywordsText] = useState(keywordsArray.join(", "));
+  // Saved cards can carry a plain string in either field (see normalizeKeywords).
+  const resolveKeywords = () => {
+    const abilities = normalizeKeywords(weapon.abilities);
+    return abilities.length ? abilities : normalizeKeywords(weapon.keywords);
+  };
+  const [keywordsText, setKeywordsText] = useState(resolveKeywords().join(", "));
 
   useEffect(() => {
-    const arr = weapon.abilities?.length ? weapon.abilities : weapon.keywords?.length ? weapon.keywords : [];
-    setKeywordsText(arr.join(", "));
+    const abilities = normalizeKeywords(weapon.abilities);
+    setKeywordsText((abilities.length ? abilities : normalizeKeywords(weapon.keywords)).join(", "));
   }, [weapon.abilities, weapon.keywords]);
 
   return (

--- a/src/Components/Custom/CustomCardWeapons.jsx
+++ b/src/Components/Custom/CustomCardWeapons.jsx
@@ -1,4 +1,5 @@
 import { WeaponTypeIcon } from "../Icons/WeaponTypeIcon";
+import { normalizeKeywords } from "../../Helpers/weaponProfile.helpers";
 
 /**
  * Renders a single weapon's profiles with schema-defined columns.
@@ -14,28 +15,32 @@ const CustomWeaponProfiles = ({ weapon, columns, hasKeywords, columnTemplate }) 
     <>
       {weapon.profiles
         ?.filter((profile) => profile.active !== false)
-        ?.map((profile, index, profiles) => (
-          <div
-            className={`weapon${profiles.length > 1 ? " multi-line" : ""}`}
-            key={`weapon-profile-${index}`}
-            data-name={profile.name}>
-            <div className="line" style={{ gridTemplateColumns: columnTemplate }}>
-              <div className="value" style={{ display: "flex", flexWrap: "wrap" }}>
-                <span>{profile.name}</span>
-                {hasKeywords && profile.keywords?.length > 0 && (
-                  <span style={{ paddingLeft: "4px" }}>
-                    [<span className="weapon-keywords">{profile.keywords.join(", ")}</span>]
-                  </span>
-                )}
-              </div>
-              {columns.map((col) => (
-                <div className="value center" key={col.key}>
-                  {profile[col.key] || "-"}
+        ?.map((profile, index, profiles) => {
+          // Saved cards can carry a string here (see normalizeKeywords).
+          const keywords = normalizeKeywords(profile.keywords);
+          return (
+            <div
+              className={`weapon${profiles.length > 1 ? " multi-line" : ""}`}
+              key={`weapon-profile-${index}`}
+              data-name={profile.name}>
+              <div className="line" style={{ gridTemplateColumns: columnTemplate }}>
+                <div className="value" style={{ display: "flex", flexWrap: "wrap" }}>
+                  <span>{profile.name}</span>
+                  {hasKeywords && keywords.length > 0 && (
+                    <span style={{ paddingLeft: "4px" }}>
+                      [<span className="weapon-keywords">{keywords.join(", ")}</span>]
+                    </span>
+                  )}
                 </div>
-              ))}
+                {columns.map((col) => (
+                  <div className="value center" key={col.key}>
+                    {profile[col.key] || "-"}
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       {weapon?.abilities?.length > 0 && (
         <div className="special">
           {weapon.abilities

--- a/src/Components/DatasourceEditor/DatasourceEditor.css
+++ b/src/Components/DatasourceEditor/DatasourceEditor.css
@@ -1386,6 +1386,15 @@ select.props-compact-field {
   border-radius: var(--designer-radius-sm);
 }
 
+/* Inline validation hint under a properties-panel field (e.g. a weapon column
+   key that collides with a reserved weapon profile field). */
+.props-field-error {
+  margin: 2px 0 6px;
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--designer-danger, #d4380d);
+}
+
 .props-field-item {
   display: flex;
   align-items: flex-start;

--- a/src/Components/DatasourceEditor/cards/units/Ds40kUnitWeapons.jsx
+++ b/src/Components/DatasourceEditor/cards/units/Ds40kUnitWeapons.jsx
@@ -12,6 +12,7 @@ import {
   resolveKeywordEntry,
   resolveKeywordStyle,
 } from "../../../../Helpers/customSchema.helpers";
+import { normalizeKeywords } from "../../../../Helpers/weaponProfile.helpers";
 
 /**
  * Inline weapon keyword tag renderer that consults the datasource glossary
@@ -90,7 +91,7 @@ const Ds40kWeaponType = ({ weaponTypeDef, weapons, glossary }) => {
     weapons.forEach((weapon) => {
       weapon.profiles?.forEach((profile) => {
         if (profile.active === false) return;
-        profile.keywords?.forEach((kw) => allKeywords.push(kw));
+        normalizeKeywords(profile.keywords).forEach((kw) => allKeywords.push(kw));
       });
     });
     // `displayMode: "tooltip"` entries are rendered as hover tooltips on the
@@ -160,40 +161,44 @@ const Ds40kWeaponProfiles = ({ weapon, columns, glossary }) => {
     <>
       {weapon.profiles
         ?.filter((profile) => profile.active !== false)
-        ?.map((profile, index, profiles) => (
-          <div
-            className={`weapon${profiles.length > 1 ? " multi-line" : ""}`}
-            key={`weapon-profile-${index}`}
-            data-name={profile.name}>
-            <div className="line">
-              <div className="value" style={{ display: "flex", flexWrap: "wrap" }}>
-                <span>{profile.name}</span>
-                {profile.keywords?.length > 0 && (
-                  <span style={{ paddingLeft: "4px" }}>
-                    {Array.isArray(glossary) && glossary.length > 0 ? (
-                      <Ds40kWeaponKeywords keywords={profile.keywords} glossary={glossary} />
-                    ) : (
-                      <UnitWeaponKeywords keywords={profile.keywords} />
-                    )}
-                  </span>
-                )}
+        ?.map((profile, index, profiles) => {
+          // Saved cards can carry a string here (see normalizeKeywords).
+          const keywords = normalizeKeywords(profile.keywords);
+          return (
+            <div
+              className={`weapon${profiles.length > 1 ? " multi-line" : ""}`}
+              key={`weapon-profile-${index}`}
+              data-name={profile.name}>
+              <div className="line">
+                <div className="value" style={{ display: "flex", flexWrap: "wrap" }}>
+                  <span>{profile.name}</span>
+                  {keywords.length > 0 && (
+                    <span style={{ paddingLeft: "4px" }}>
+                      {Array.isArray(glossary) && glossary.length > 0 ? (
+                        <Ds40kWeaponKeywords keywords={keywords} glossary={glossary} />
+                      ) : (
+                        <UnitWeaponKeywords keywords={keywords} />
+                      )}
+                    </span>
+                  )}
+                </div>
+                {columns.map((col) => {
+                  const displayValue =
+                    col.type === "boolean"
+                      ? profile[col.key]
+                        ? col.onValue || "Yes"
+                        : col.offValue || "No"
+                      : profile[col.key] || "-";
+                  return (
+                    <div className="value center" key={col.key}>
+                      {displayValue}
+                    </div>
+                  );
+                })}
               </div>
-              {columns.map((col) => {
-                const displayValue =
-                  col.type === "boolean"
-                    ? profile[col.key]
-                      ? col.onValue || "Yes"
-                      : col.offValue || "No"
-                    : profile[col.key] || "-";
-                return (
-                  <div className="value center" key={col.key}>
-                    {displayValue}
-                  </div>
-                );
-              })}
             </div>
-          </div>
-        ))}
+          );
+        })}
     </>
   );
 };

--- a/src/Components/DatasourceEditor/cards/warscroll/DsAosWeapons.jsx
+++ b/src/Components/DatasourceEditor/cards/warscroll/DsAosWeapons.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { GlossaryExplanationRows, GlossaryKeywordTags, getKeywordExplanations } from "../shared/GlossaryKeywords";
+import { normalizeKeywords } from "../../../../Helpers/weaponProfile.helpers";
 
 /**
  * Resolves display value for a weapon column, handling booleans.
@@ -79,7 +80,7 @@ export const DsAosWeapons = ({ weapons, weaponTypeDef, grandAlliance, maxColumns
   // Renders a weapon profile's keyword tags — glossary-styled when a glossary
   // is present, otherwise the plain badge treatment.
   const renderKeywords = (keywords) => {
-    if (!keywords?.length) return null;
+    if (!keywords.length) return null;
     if (hasGlossary) {
       return <GlossaryKeywordTags keywords={keywords} glossary={glossary} scope="weapons" />;
     }
@@ -101,7 +102,11 @@ export const DsAosWeapons = ({ weapons, weaponTypeDef, grandAlliance, maxColumns
       weapon.profiles
         .filter((p) => p.active !== false)
         .forEach((profile) => {
-          rows.push({ ...profile, keywords: profile.keywords || weapon.keywords });
+          // Saved cards can carry a string here (see normalizeKeywords), so the
+          // row's keywords are normalised once and every consumer below reads
+          // the array form.
+          const keywords = normalizeKeywords(profile.keywords);
+          rows.push({ ...profile, keywords: keywords.length ? keywords : normalizeKeywords(weapon.keywords) });
         });
     }
   });
@@ -111,7 +116,7 @@ export const DsAosWeapons = ({ weapons, weaponTypeDef, grandAlliance, maxColumns
   // Glossary explanation rows for every keyword across this weapon section.
   const explanationEntries = hasGlossary
     ? getKeywordExplanations(
-        rows.flatMap((profile) => profile.keywords || []),
+        rows.flatMap((profile) => profile.keywords),
         glossary,
         "weapons",
       )
@@ -135,7 +140,7 @@ export const DsAosWeapons = ({ weapons, weaponTypeDef, grandAlliance, maxColumns
               ))}
             </div>
             <RowFields profile={profile} rowCols={rowCols} altBg={false} />
-            {profile.keywords?.length > 0 && (
+            {profile.keywords.length > 0 && (
               <div className="weapon-card-abilities">{renderKeywords(profile.keywords)}</div>
             )}
           </div>
@@ -170,7 +175,7 @@ export const DsAosWeapons = ({ weapons, weaponTypeDef, grandAlliance, maxColumns
           <div className={`weapon-row ${index % 2 === 1 ? "alt-bg" : ""}`}>
             <span className="w-name">
               {profile.name}
-              {profile.keywords?.length > 0 && (
+              {profile.keywords.length > 0 && (
                 <div className="weapon-abilities-list">{renderKeywords(profile.keywords)}</div>
               )}
             </span>

--- a/src/Components/DatasourceEditor/components/ImportSchemaDialog.jsx
+++ b/src/Components/DatasourceEditor/components/ImportSchemaDialog.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Upload, FileText, AlertCircle, CheckCircle2 } from "lucide-react";
-import { validateSchema } from "../../../Helpers/customSchema.helpers";
+import { validateSchema, stripReservedWeaponColumns } from "../../../Helpers/customSchema.helpers";
 
 /**
  * Dialog for importing a datasource schema from a JSON file.
@@ -60,6 +60,9 @@ export const ImportSchemaDialog = ({ open, onImport, onCancel }) => {
         }
 
         if (data.schema) {
+          // Weapon columns keyed after a reserved profile field corrupt card
+          // data as soon as they are edited, so drop them on import.
+          data.schema = stripReservedWeaponColumns(data.schema);
           const schemaResult = validateSchema(data.schema);
           if (!schemaResult.valid) {
             validationErrors.push(...schemaResult.errors);

--- a/src/Components/DatasourceEditor/components/__tests__/ImportSchemaDialog.test.jsx
+++ b/src/Components/DatasourceEditor/components/__tests__/ImportSchemaDialog.test.jsx
@@ -16,6 +16,7 @@ vi.mock("../../../../Helpers/customSchema.helpers", () => ({
     }
     return { valid: true, errors: [] };
   }),
+  stripReservedWeaponColumns: vi.fn((schema) => schema),
 }));
 
 const validSchemaJson = JSON.stringify({

--- a/src/Components/DatasourceEditor/editors/WeaponsSchemaEditor.jsx
+++ b/src/Components/DatasourceEditor/editors/WeaponsSchemaEditor.jsx
@@ -96,7 +96,9 @@ export const WeaponsSchemaEditor = ({ schema, onChange, baseSystem }) => {
   };
 
   // Column operations for the active weapon type
-  const updateColumn = (typeIndex, colIndex, key, value) => {
+  // `colId` is the column's stable `_id`: the hint has to follow the column
+  // itself, since moving or removing a column shifts every index above it.
+  const updateColumn = (typeIndex, colIndex, key, value, colId) => {
     const columns = types[typeIndex].columns || [];
     // A column keyed after a reserved profile field (e.g. `keywords`) would make
     // the card editors render a plain text input over that field and overwrite
@@ -104,12 +106,11 @@ export const WeaponsSchemaEditor = ({ schema, onChange, baseSystem }) => {
     // explain why instead of applying it.
     if (key === "key") {
       const rejected = isReservedWeaponProfileKey(value);
-      const slot = `${typeIndex}:${colIndex}`;
       setReservedKeyColumns((prev) => {
-        if (!!prev[slot] === rejected) return prev;
+        if (!!prev[colId] === rejected) return prev;
         const next = { ...prev };
-        if (rejected) next[slot] = true;
-        else delete next[slot];
+        if (rejected) next[colId] = true;
+        else delete next[colId];
         return next;
       });
       if (rejected) return;
@@ -366,9 +367,9 @@ export const WeaponsSchemaEditor = ({ schema, onChange, baseSystem }) => {
                   tooltip="Key"
                   type="text"
                   value={col.key}
-                  onChange={(val) => updateColumn(activeTab, colIndex, "key", val)}
+                  onChange={(val) => updateColumn(activeTab, colIndex, "key", val, col._id)}
                 />
-                {reservedKeyColumns[`${activeTab}:${colIndex}`] && (
+                {reservedKeyColumns[col._id] && (
                   <div className="props-field-error" role="alert">
                     {RESERVED_KEY_HINT}
                   </div>

--- a/src/Components/DatasourceEditor/editors/WeaponsSchemaEditor.jsx
+++ b/src/Components/DatasourceEditor/editors/WeaponsSchemaEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { nanoid } from "nanoid";
 import { Swords, Plus, X, Trash2, ChevronUp, ChevronDown } from "lucide-react";
 import {
@@ -19,6 +19,9 @@ import {
 import { Section, CompactInput, CollapsibleFieldItem } from "../components";
 import { Tooltip } from "../../Tooltip/Tooltip";
 import { ensureIds } from "./editorUtils";
+import { RESERVED_WEAPON_PROFILE_KEYS, isReservedWeaponProfileKey } from "../../../Helpers/weaponProfile.helpers";
+
+const RESERVED_KEY_HINT = `Reserved key — pick another. The weapon profile owns: ${RESERVED_WEAPON_PROFILE_KEYS.join(", ")}.`;
 
 const COLUMN_TYPES = [
   { value: "string", label: "Text" },
@@ -49,8 +52,14 @@ export const WeaponsSchemaEditor = ({ schema, onChange, baseSystem }) => {
   const weaponTypes = schema?.weaponTypes;
   if (!weaponTypes) return null;
 
-  const types = ensureIds(weaponTypes.types);
+  // Memoised so the generated `_id`s stay stable while this component
+  // re-renders on its own state — otherwise every keystroke would hand the
+  // collapsible column rows a fresh React key and snap them shut.
+  const types = useMemo(() => ensureIds(weaponTypes.types), [weaponTypes.types]);
   const [activeTab, setActiveTab] = useState(0);
+  // "<typeIndex>:<colIndex>" of columns whose last key edit was rejected for
+  // colliding with a reserved profile field, so the hint shows under that input.
+  const [reservedKeyColumns, setReservedKeyColumns] = useState({});
   const abilityCategoryOptions = (schema?.abilities?.categories || []).map((c) => ({ value: c.key, label: c.label }));
   const showPhaseFields = baseSystem === "starcraft-tmg";
 
@@ -89,6 +98,22 @@ export const WeaponsSchemaEditor = ({ schema, onChange, baseSystem }) => {
   // Column operations for the active weapon type
   const updateColumn = (typeIndex, colIndex, key, value) => {
     const columns = types[typeIndex].columns || [];
+    // A column keyed after a reserved profile field (e.g. `keywords`) would make
+    // the card editors render a plain text input over that field and overwrite
+    // its real value with a string, corrupting saved cards. Reject the edit and
+    // explain why instead of applying it.
+    if (key === "key") {
+      const rejected = isReservedWeaponProfileKey(value);
+      const slot = `${typeIndex}:${colIndex}`;
+      setReservedKeyColumns((prev) => {
+        if (!!prev[slot] === rejected) return prev;
+        const next = { ...prev };
+        if (rejected) next[slot] = true;
+        else delete next[slot];
+        return next;
+      });
+      if (rejected) return;
+    }
     const updatedCols = columns.map((c, i) => (i === colIndex ? { ...c, [key]: value } : c));
     updateType(typeIndex, { columns: updatedCols });
   };
@@ -121,7 +146,8 @@ export const WeaponsSchemaEditor = ({ schema, onChange, baseSystem }) => {
   };
 
   const rawActiveType = types[activeTab];
-  const activeType = rawActiveType ? { ...rawActiveType, columns: ensureIds(rawActiveType.columns) } : undefined;
+  const activeColumns = useMemo(() => ensureIds(rawActiveType?.columns), [rawActiveType?.columns]);
+  const activeType = rawActiveType ? { ...rawActiveType, columns: activeColumns } : undefined;
 
   return (
     <Section title="Weapon Types" icon={Swords} defaultOpen={true}>
@@ -342,6 +368,11 @@ export const WeaponsSchemaEditor = ({ schema, onChange, baseSystem }) => {
                   value={col.key}
                   onChange={(val) => updateColumn(activeTab, colIndex, "key", val)}
                 />
+                {reservedKeyColumns[`${activeTab}:${colIndex}`] && (
+                  <div className="props-field-error" role="alert">
+                    {RESERVED_KEY_HINT}
+                  </div>
+                )}
                 <CompactInput
                   label={<IconTag size={10} stroke={1.5} />}
                   ariaLabel="Label"

--- a/src/Components/DatasourceEditor/editors/__tests__/WeaponsSchemaEditor.test.jsx
+++ b/src/Components/DatasourceEditor/editors/__tests__/WeaponsSchemaEditor.test.jsx
@@ -433,4 +433,53 @@ describe("WeaponsSchemaEditor", () => {
     expect(screen.queryByLabelText("Display label")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Visual style")).not.toBeInTheDocument();
   });
+
+  // A column keyed after a reserved weapon profile field makes the card editors
+  // render a plain text input over that field, so the first keystroke replaces
+  // e.g. the keywords array with a string and the card can no longer render.
+  describe("reserved column keys", () => {
+    it("rejects a column key that collides with a reserved profile field", () => {
+      const onChange = vi.fn();
+      render(<WeaponsSchemaEditor schema={mockSchema} onChange={onChange} />);
+      expandColumn("Range");
+      fireEvent.change(screen.getByDisplayValue("range"), { target: { value: "keywords" } });
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getByRole("alert")).toHaveTextContent(/reserved key/i);
+    });
+
+    it("rejects reserved keys case-insensitively", () => {
+      const onChange = vi.fn();
+      render(<WeaponsSchemaEditor schema={mockSchema} onChange={onChange} />);
+      expandColumn("Range");
+      const keyInput = screen.getByDisplayValue("range");
+      ["Keywords", "NAME", "active", "upgrade"].forEach((reserved) => {
+        fireEvent.change(keyInput, { target: { value: reserved } });
+      });
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("clears the hint and applies the value once the key is no longer reserved", () => {
+      const onChange = vi.fn();
+      render(<WeaponsSchemaEditor schema={mockSchema} onChange={onChange} />);
+      expandColumn("Range");
+      const keyInput = screen.getByDisplayValue("range");
+      fireEvent.change(keyInput, { target: { value: "keywords" } });
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      fireEvent.change(keyInput, { target: { value: "keyword_note" } });
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          weaponTypes: expect.objectContaining({
+            types: expect.arrayContaining([
+              expect.objectContaining({
+                key: "ranged",
+                columns: expect.arrayContaining([expect.objectContaining({ key: "keyword_note" })]),
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+  });
 });

--- a/src/Components/DatasourceEditor/editors/__tests__/WeaponsSchemaEditor.test.jsx
+++ b/src/Components/DatasourceEditor/editors/__tests__/WeaponsSchemaEditor.test.jsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { WeaponsSchemaEditor } from "../WeaponsSchemaEditor";
 
@@ -480,6 +481,26 @@ describe("WeaponsSchemaEditor", () => {
           }),
         }),
       );
+    });
+
+    // The hint belongs to a column, not to a position: moving a column shifts
+    // every index above it, so a position-keyed hint would resurface under an
+    // unrelated column.
+    it("does not leave the hint behind on another column after a reorder", () => {
+      const ControlledEditor = () => {
+        const [schema, setSchema] = useState(mockSchema);
+        return <WeaponsSchemaEditor schema={schema} onChange={setSchema} />;
+      };
+      render(<ControlledEditor />);
+
+      expandColumn("Range");
+      fireEvent.change(screen.getByDisplayValue("range"), { target: { value: "keywords" } });
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Range moves to second place, so "A" now sits where Range was.
+      fireEvent.click(screen.getByLabelText("Move Range down"));
+      expandColumn("A");
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/Components/TreeView/TreeItem.jsx
+++ b/src/Components/TreeView/TreeItem.jsx
@@ -64,6 +64,7 @@ export function TreeItem({
       name: `${card.name} Copy`,
       unitSize: undefined,
       selectedEnhancement: undefined,
+      selectedWargear: undefined,
       isWarlord: undefined,
       isCustom: true,
       uuid: uuidv4(),

--- a/src/Components/TreeView/UnitConfigModal.css
+++ b/src/Components/TreeView/UnitConfigModal.css
@@ -523,6 +523,86 @@
 }
 
 /* ===========================================
+   WARGEAR OPTIONS (11e, paid options only)
+   =========================================== */
+
+/* Same card as an enhancement row, but a stepper instead of a radio: several
+   models in a unit can each take the same paid option. */
+.ucm-wargear-option {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  background: var(--glass-bg);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid var(--glass-border-subtle);
+  border-radius: 10px;
+  transition: all var(--transition-base);
+  user-select: none;
+}
+
+.ucm-wargear-option.selected {
+  background: var(--accent-light);
+  border-color: rgba(22, 119, 255, 0.2);
+}
+
+.ucm-wargear-option.selected .ucm-enhancement-name,
+.ucm-wargear-option.selected .ucm-enhancement-cost {
+  color: var(--accent-primary);
+  font-weight: 600;
+}
+
+.ucm-wargear-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.ucm-wargear-stepper {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.ucm-wargear-step {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  background: var(--bg-elevated);
+  border: 1px solid var(--glass-border-subtle);
+  border-radius: 8px;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.ucm-wargear-step:hover:not(:disabled) {
+  border-color: var(--accent-secondary);
+  color: var(--accent-primary);
+}
+
+.ucm-wargear-step:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.ucm-wargear-quantity {
+  min-width: 20px;
+  text-align: center;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ===========================================
    SUBMIT BUTTON
    =========================================== */
 

--- a/src/Components/TreeView/UnitConfigModal.jsx
+++ b/src/Components/TreeView/UnitConfigModal.jsx
@@ -1,14 +1,18 @@
 import React, { useEffect, useMemo, useState } from "react";
 import ReactDOM from "react-dom";
-import { X, Crown, ChevronDown } from "lucide-react";
+import { X, Crown, ChevronDown, Minus, Plus } from "lucide-react";
 import classNames from "classnames";
 import { Toggle } from "../SettingsModal/Toggle";
 import { getDetachmentName } from "../../Helpers/faction.helpers";
 import {
   filterPointsTiersForArmy,
+  getPaidWargearOptions,
   getPointsTierRestrictionLabel,
   getSelectablePointsTiers,
+  getWargearQuantity,
+  getWargearQuantityMax,
   isSamePointsTier,
+  setWargearQuantity,
 } from "../../Helpers/listPoints.helpers";
 import {
   cardHasKeyword,
@@ -45,6 +49,9 @@ export const UnitConfigModal = ({ isOpen, onClose, card, category, onSave }) => 
     [category?.detachments, category?.cards, listFaction?.name],
   );
   const availableTiers = useMemo(() => filterPointsTiersForArmy(getSelectablePointsTiers(card), army), [card, army]);
+  // Only the wargear this datasheet actually charges for; free swaps are noise
+  // here. Empty for every non-11e card, which hides the section entirely.
+  const paidWargear = useMemo(() => getPaidWargearOptions(card), [card]);
 
   const [selectedUnitSize, setSelectedUnitSize] = useState(undefined);
   const [isWarlord, setIsWarlord] = useState(false);
@@ -52,6 +59,7 @@ export const UnitConfigModal = ({ isOpen, onClose, card, category, onSave }) => 
   const [selectedDetachment, setSelectedDetachment] = useState(undefined);
   const [detachmentOpen, setDetachmentOpen] = useState(false);
   const [selectedAttachment, setSelectedAttachment] = useState(undefined);
+  const [selectedWargear, setSelectedWargear] = useState([]);
 
   // Reset the card's own selections when the modal opens for a (different) card.
   // Keyed on the card's uuid rather than the object so an unrelated re-render
@@ -61,6 +69,7 @@ export const UnitConfigModal = ({ isOpen, onClose, card, category, onSave }) => 
       setIsWarlord(card?.isWarlord || false);
       setSelectedEnhancement(card?.selectedEnhancement);
       setSelectedAttachment(card?.attachedTo);
+      setSelectedWargear(Array.isArray(card?.selectedWargear) ? card.selectedWargear : []);
       setDetachmentOpen(false);
 
       if (card.unitSize) {
@@ -153,8 +162,18 @@ export const UnitConfigModal = ({ isOpen, onClose, card, category, onSave }) => 
     });
   };
 
+  const changeWargearQuantity = (option, quantity) =>
+    setSelectedWargear((current) => setWargearQuantity(current, option, quantity));
+
   const handleSubmit = () => {
-    onSave({ ...card, unitSize: selectedUnitSize, selectedEnhancement, isWarlord, attachedTo: selectedAttachment });
+    onSave({
+      ...card,
+      unitSize: selectedUnitSize,
+      selectedEnhancement,
+      isWarlord,
+      attachedTo: selectedAttachment,
+      selectedWargear,
+    });
   };
 
   // Regular enhancements are once per army; Upgrades may be taken up to three
@@ -279,6 +298,49 @@ export const UnitConfigModal = ({ isOpen, onClose, card, category, onSave }) => 
                       <div className="ucm-enhancement-text">
                         <span className="ucm-enhancement-name">{enhancement.name}</span>
                         <span className="ucm-enhancement-cost">{enhancement.cost} pts</span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Wargear that costs points (11e) */}
+          {paidWargear.length > 0 && (
+            <div>
+              <div className="ucm-section-label">Wargear</div>
+              <div className="ucm-enhancement-list">
+                {paidWargear.map((option) => {
+                  const name = localize(option.name, settings.language);
+                  const quantity = getWargearQuantity(selectedWargear, option);
+                  const max = getWargearQuantityMax(selectedUnitSize);
+                  return (
+                    <div
+                      key={`${localize(option.name)}-${option.cost}`}
+                      className={classNames("ucm-wargear-option", { selected: quantity > 0 })}>
+                      <div className="ucm-wargear-text">
+                        <span className="ucm-enhancement-name">{name}</span>
+                        <span className="ucm-enhancement-cost">+{option.cost} pts each</span>
+                      </div>
+                      <div className="ucm-wargear-stepper">
+                        <button
+                          className="ucm-wargear-step"
+                          type="button"
+                          aria-label={`Remove one ${name}`}
+                          disabled={quantity <= 0}
+                          onClick={() => changeWargearQuantity(option, quantity - 1)}>
+                          <Minus size={14} />
+                        </button>
+                        <span className="ucm-wargear-quantity">{quantity}</span>
+                        <button
+                          className="ucm-wargear-step"
+                          type="button"
+                          aria-label={`Add one ${name}`}
+                          disabled={quantity >= max}
+                          onClick={() => changeWargearQuantity(option, quantity + 1)}>
+                          <Plus size={14} />
+                        </button>
                       </div>
                     </div>
                   );

--- a/src/Components/TreeView/UnitConfigModal.jsx
+++ b/src/Components/TreeView/UnitConfigModal.jsx
@@ -9,6 +9,7 @@ import {
   getPaidWargearOptions,
   getPointsTierRestrictionLabel,
   getSelectablePointsTiers,
+  clampWargearQuantities,
   getWargearQuantity,
   getWargearQuantityMax,
   isSamePointsTier,
@@ -79,6 +80,13 @@ export const UnitConfigModal = ({ isOpen, onClose, card, category, onSave }) => 
       }
     }
   }, [isOpen, card?.uuid]);
+
+  // Wargear is priced per model, so a smaller size tier lowers the ceiling on an
+  // already-picked quantity. Cap the selection whenever the tier changes,
+  // otherwise switching down would keep pricing the larger unit.
+  useEffect(() => {
+    setSelectedWargear((current) => clampWargearQuantities(current, selectedUnitSize));
+  }, [selectedUnitSize]);
 
   // Resolve the detachment separately: it depends on settings and the faction's
   // detachment list, which can arrive/refresh independently of the card.

--- a/src/Components/TreeView/__tests__/UnitConfigModal.test.jsx
+++ b/src/Components/TreeView/__tests__/UnitConfigModal.test.jsx
@@ -280,6 +280,98 @@ describe("UnitConfigModal", () => {
   });
 });
 
+describe("UnitConfigModal 11e wargear", () => {
+  let modalRoot;
+
+  beforeEach(() => {
+    modalRoot = document.createElement("div");
+    modalRoot.setAttribute("id", "modal-root");
+    document.body.appendChild(modalRoot);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(modalRoot);
+    vi.clearAllMocks();
+  });
+
+  // Shaped like the real data: a paid option next to free ones, and the group
+  // repeated once per model.
+  const terminators = {
+    ...baseCard,
+    source: "40k-11e",
+    points: [{ models: 5, cost: 170 }],
+    wargearOptions: [
+      {
+        instruction: { en: "Any number of models can each have their power fist replaced." },
+        options: [
+          { name: { en: "Thunder hammer" }, cost: "5" },
+          { name: { en: "Lightning claw" }, cost: "0" },
+        ],
+      },
+      {
+        instruction: { en: "Any number of models can each have their power fist replaced." },
+        options: [
+          { name: { en: "Thunder hammer" }, cost: "5" },
+          { name: { en: "Lightning claw" }, cost: "0" },
+        ],
+      },
+    ],
+  };
+
+  it("lists each paid option once and hides the free ones", () => {
+    render(<UnitConfigModal isOpen card={terminators} category={baseCategory} onClose={vi.fn()} onSave={vi.fn()} />);
+    expect(screen.getByText("Wargear")).toBeInTheDocument();
+    expect(screen.getAllByText("Thunder hammer")).toHaveLength(1);
+    expect(screen.queryByText("Lightning claw")).not.toBeInTheDocument();
+    expect(screen.getByText("+5 pts each")).toBeInTheDocument();
+  });
+
+  it("does not show the section for a card with no paid wargear", () => {
+    render(<UnitConfigModal isOpen card={baseCard} category={baseCategory} onClose={vi.fn()} onSave={vi.fn()} />);
+    expect(screen.queryByText("Wargear")).not.toBeInTheDocument();
+  });
+
+  it("saves the chosen quantity on the card", () => {
+    const onSave = vi.fn();
+    render(<UnitConfigModal isOpen card={terminators} category={baseCategory} onClose={vi.fn()} onSave={onSave} />);
+    fireEvent.click(screen.getByLabelText("Add one Thunder hammer"));
+    fireEvent.click(screen.getByLabelText("Add one Thunder hammer"));
+    fireEvent.click(screen.getByText("Set unit values"));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedWargear: [{ name: { en: "Thunder hammer" }, cost: 5, quantity: 2 }],
+      }),
+    );
+  });
+
+  it("starts from the card's saved selection", () => {
+    const card = { ...terminators, selectedWargear: [{ name: { en: "Thunder hammer" }, cost: 5, quantity: 3 }] };
+    render(<UnitConfigModal isOpen card={card} category={baseCategory} onClose={vi.fn()} onSave={vi.fn()} />);
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("cannot go below zero, and dropping to zero clears the selection", () => {
+    const onSave = vi.fn();
+    const card = { ...terminators, selectedWargear: [{ name: { en: "Thunder hammer" }, cost: 5, quantity: 1 }] };
+    render(<UnitConfigModal isOpen card={card} category={baseCategory} onClose={vi.fn()} onSave={onSave} />);
+
+    fireEvent.click(screen.getByLabelText("Remove one Thunder hammer"));
+    expect(screen.getByLabelText("Remove one Thunder hammer")).toBeDisabled();
+
+    fireEvent.click(screen.getByText("Set unit values"));
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ selectedWargear: [] }));
+  });
+
+  it("caps the quantity at the model count of the chosen size tier", () => {
+    // Single 5-model tier, so it auto-selects and the cap is 5.
+    render(<UnitConfigModal isOpen card={terminators} category={baseCategory} onClose={vi.fn()} onSave={vi.fn()} />);
+    const add = screen.getByLabelText("Add one Thunder hammer");
+    for (let i = 0; i < 5; i += 1) fireEvent.click(add);
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(add).toBeDisabled();
+  });
+});
+
 describe("UnitConfigModal 11e attachments", () => {
   let modalRoot;
 

--- a/src/Components/TreeView/__tests__/UnitConfigModal.test.jsx
+++ b/src/Components/TreeView/__tests__/UnitConfigModal.test.jsx
@@ -370,6 +370,34 @@ describe("UnitConfigModal 11e wargear", () => {
     expect(screen.getByText("5")).toBeInTheDocument();
     expect(add).toBeDisabled();
   });
+
+  // Wargear is priced per model, so switching down to a smaller tier has to pull
+  // an already-chosen quantity down with it, or the list total keeps charging
+  // for models the unit no longer has.
+  it("lowers an already-chosen quantity when a smaller size tier is picked", () => {
+    const onSave = vi.fn();
+    const twoTiers = {
+      ...terminators,
+      points: [
+        { models: 10, cost: 340 },
+        { models: 5, cost: 170 },
+      ],
+      selectedWargear: [{ name: { en: "Thunder hammer" }, cost: 5, quantity: 10 }],
+      unitSize: { models: 10, cost: 340 },
+    };
+    render(<UnitConfigModal isOpen card={twoTiers} category={baseCategory} onClose={vi.fn()} onSave={onSave} />);
+    expect(screen.getByText("10")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("5 models"));
+    expect(screen.getByText("5")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Set unit values"));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedWargear: [{ name: { en: "Thunder hammer" }, cost: 5, quantity: 5 }],
+      }),
+    );
+  });
 });
 
 describe("UnitConfigModal 11e attachments", () => {

--- a/src/Components/Viewer/ListCreator/ListAdd.css
+++ b/src/Components/Viewer/ListCreator/ListAdd.css
@@ -236,3 +236,70 @@
   color: #64748b;
   cursor: not-allowed;
 }
+
+/* Wargear that costs points (11e). Same card as an option row, but with a
+   stepper: several models in a unit can each take the same paid option. */
+.list-add-wargear {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--bs-surface);
+  border: 1px solid var(--bs-border);
+  border-radius: 8px;
+  font-size: 16px;
+  width: 100%;
+}
+
+.list-add-wargear.selected {
+  background: #f0f9ff;
+  border-color: var(--bs-accent);
+}
+
+.list-add-wargear-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.list-add-wargear-stepper {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.list-add-wargear-step {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: var(--bs-surface);
+  border: 1px solid var(--bs-border);
+  border-radius: 8px;
+  color: var(--bs-text);
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.list-add-wargear-step:active:not(:disabled) {
+  background: var(--bs-surface-hover);
+}
+
+.list-add-wargear-step:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.list-add-wargear-quantity {
+  min-width: 20px;
+  text-align: center;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--bs-text);
+  font-variant-numeric: tabular-nums;
+}

--- a/src/Components/Viewer/ListCreator/ListEditCard.jsx
+++ b/src/Components/Viewer/ListCreator/ListEditCard.jsx
@@ -9,6 +9,7 @@ import {
   getPaidWargearOptions,
   getPointsTierRestrictionLabel,
   getSelectablePointsTiers,
+  clampWargearQuantities,
   getWargearQuantity,
   getWargearQuantityMax,
   isSamePointsTier,
@@ -108,6 +109,13 @@ export const ListEditCard = ({ isVisible, setIsVisible, card }) => {
       setSelectedWargear(Array.isArray(card.selectedWargear) ? card.selectedWargear : []);
     }
   }, [isVisible, card]);
+
+  // Wargear is priced per model, so a smaller size tier lowers the ceiling on an
+  // already-picked quantity. Cap the selection whenever the tier changes,
+  // otherwise switching down would keep pricing the larger unit.
+  useEffect(() => {
+    setSelectedWargear((current) => clampWargearQuantities(current, selectedUnitSize));
+  }, [selectedUnitSize]);
 
   const handleClose = () => setIsVisible(false);
 

--- a/src/Components/Viewer/ListCreator/ListEditCard.jsx
+++ b/src/Components/Viewer/ListCreator/ListEditCard.jsx
@@ -1,14 +1,18 @@
 import { useEffect, useMemo, useState } from "react";
-import { ChevronRight, Crown } from "lucide-react";
+import { ChevronRight, Crown, Minus, Plus } from "lucide-react";
 import { message } from "../../Toast/message";
 import { useDataSourceStorage } from "../../../Hooks/useDataSourceStorage";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
 import { getDetachmentName } from "../../../Helpers/faction.helpers";
 import {
   filterPointsTiersForArmy,
+  getPaidWargearOptions,
   getPointsTierRestrictionLabel,
   getSelectablePointsTiers,
+  getWargearQuantity,
+  getWargearQuantityMax,
   isSamePointsTier,
+  setWargearQuantity,
 } from "../../../Helpers/listPoints.helpers";
 import {
   cardHasKeyword,
@@ -53,6 +57,7 @@ export const ListEditCard = ({ isVisible, setIsVisible, card }) => {
   const [detachmentPickerOpen, setDetachmentPickerOpen] = useState(false);
   const [selectedUnitSize, setSelectedUnitSize] = useState();
   const [selectedAttachment, setSelectedAttachment] = useState();
+  const [selectedWargear, setSelectedWargear] = useState([]);
 
   const cardFaction = dataSource.data.find((faction) => faction.id === card?.faction_id);
   // 11e armies hold several detachments; enhancements from any of them are available.
@@ -70,6 +75,9 @@ export const ListEditCard = ({ isVisible, setIsVisible, card }) => {
     [armyDetachments, lists, selectedList, listFaction?.name],
   );
   const availableTiers = useMemo(() => filterPointsTiersForArmy(getSelectablePointsTiers(card), army), [card, army]);
+  // Only the wargear this datasheet actually charges for; free swaps are noise
+  // here. Empty for every non-11e card, which hides the section entirely.
+  const paidWargear = useMemo(() => getPaidWargearOptions(card), [card]);
 
   // Check warlord — exclude current card's uuid
   const warlordAlreadyAdded = lists[selectedList]?.cards?.find((c) => c.isWarlord && c.uuid !== card?.uuid);
@@ -97,6 +105,7 @@ export const ListEditCard = ({ isVisible, setIsVisible, card }) => {
       setSelectedEnhancement(card.selectedEnhancement || undefined);
       setIsWarlord(card.isWarlord || false);
       setSelectedAttachment(card.attachedTo || undefined);
+      setSelectedWargear(Array.isArray(card.selectedWargear) ? card.selectedWargear : []);
     }
   }, [isVisible, card]);
 
@@ -114,16 +123,16 @@ export const ListEditCard = ({ isVisible, setIsVisible, card }) => {
   const handleSave = () => {
     // Single write: passing the attachment through updateDatacard avoids a second
     // whole-category update that would overwrite this save's other changes.
-    updateDatacard(
-      card.uuid,
-      selectedUnitSize,
-      selectedEnhancement,
-      isWarlord,
-      isAttachableLeader(card) ? { attachedTo: selectedAttachment } : {},
-    );
+    updateDatacard(card.uuid, selectedUnitSize, selectedEnhancement, isWarlord, {
+      ...(isAttachableLeader(card) ? { attachedTo: selectedAttachment } : {}),
+      ...(paidWargear.length > 0 ? { selectedWargear } : {}),
+    });
     handleClose();
     message.success(`${card.name} updated`);
   };
+
+  const changeWargearQuantity = (option, quantity) =>
+    setSelectedWargear((current) => setWargearQuantity(current, option, quantity));
 
   const selectEnhancement = (enhancement) => {
     if (selectedEnhancement?.name === enhancement?.name) {
@@ -239,6 +248,49 @@ export const ListEditCard = ({ isVisible, setIsVisible, card }) => {
                       <span className="option-label">{enhancement.name}</span>
                       <span className="option-value">{enhancement.cost} pts</span>
                     </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Wargear that costs points (11e) */}
+          {paidWargear.length > 0 && (
+            <div className="list-add-section">
+              <h4 className="list-add-section-title">Wargear</h4>
+              <div className="list-add-options">
+                {paidWargear.map((option) => {
+                  const name = localize(option.name, settings.language);
+                  const quantity = getWargearQuantity(selectedWargear, option);
+                  const max = getWargearQuantityMax(selectedUnitSize);
+                  return (
+                    <div
+                      key={`${localize(option.name)}-${option.cost}`}
+                      className={`list-add-wargear ${quantity > 0 ? "selected" : ""}`}>
+                      <div className="list-add-wargear-text">
+                        <span className="option-label">{name}</span>
+                        <span className="option-value">+{option.cost} pts each</span>
+                      </div>
+                      <div className="list-add-wargear-stepper">
+                        <button
+                          className="list-add-wargear-step"
+                          type="button"
+                          aria-label={`Remove one ${name}`}
+                          disabled={quantity <= 0}
+                          onClick={() => changeWargearQuantity(option, quantity - 1)}>
+                          <Minus size={14} />
+                        </button>
+                        <span className="list-add-wargear-quantity">{quantity}</span>
+                        <button
+                          className="list-add-wargear-step"
+                          type="button"
+                          aria-label={`Add one ${name}`}
+                          disabled={quantity >= max}
+                          onClick={() => changeWargearQuantity(option, quantity + 1)}>
+                          <Plus size={14} />
+                        </button>
+                      </div>
+                    </div>
                   );
                 })}
               </div>

--- a/src/Components/Viewer/ListCreator/ListOverview.jsx
+++ b/src/Components/Viewer/ListCreator/ListOverview.jsx
@@ -25,6 +25,7 @@ import { useAuth } from "../../../Premium";
 import { useCategorySharing } from "../../../Hooks/useCategorySharing";
 import { useMobileList } from "../useMobileList";
 import { capitalizeSentence } from "../../../Helpers/external.helpers";
+import { localize } from "../../../Helpers/localization.helpers";
 import { computeCategoryPoints, getCardDisplayCost } from "../../../Helpers/listPoints.helpers";
 import {
   categorize40kUnits,
@@ -163,6 +164,13 @@ const ListItem = ({ item, onNavigate, onDelete, onEdit, isAoS, allCards = [] }) 
         </div>
         {!isAoS && item.selectedEnhancement && (
           <div className="list-overview-item-enhancement">{capitalizeSentence(item.selectedEnhancement.name)}</div>
+        )}
+        {!isAoS && item.selectedWargear?.length > 0 && (
+          <div className="list-overview-item-enhancement">
+            {item.selectedWargear
+              .map((entry) => `${entry?.quantity > 1 ? `${entry.quantity}x ` : ""}${localize(entry?.name)}`)
+              .join(", ")}
+          </div>
         )}
         {attachedSquadName && <div className="list-overview-item-attachment">Attached to {attachedSquadName}</div>}
         {hostedLeaders.length > 0 && (

--- a/src/Components/Viewer/MobileEditor/weapons/WeaponProfileEditor.jsx
+++ b/src/Components/Viewer/MobileEditor/weapons/WeaponProfileEditor.jsx
@@ -5,9 +5,16 @@ import { EditorSelectField } from "../shared/EditorSelectField";
 import { EditorTagInput } from "../shared/EditorTagInput";
 import { EditorToggle } from "../shared/EditorToggle";
 import { getWeaponsArray, setWeaponsOnCard } from "./weaponHelpers";
+import { isReservedWeaponProfileKey, normalizeKeywords } from "../../../../Helpers/weaponProfile.helpers";
 
 // Columns that store arrays and need special handling
 const ARRAY_COLUMNS = new Set(["abilities"]);
+
+// A schema column may collide with a reserved weapon profile field (e.g. a
+// column keyed `keywords`). Rendering a generic text input over it would
+// overwrite the real value with a string, so those columns are skipped here —
+// the dedicated editors below own those fields.
+const editableColumns = (columns) => (columns || []).filter((col) => !isReservedWeaponProfileKey(col.key));
 
 /**
  * Render a single weapon column input using the schema field type so enum
@@ -134,7 +141,7 @@ const ProfileWeaponEditor = ({ weapons, weaponIndex, profileIndex, columns, conf
       />
 
       <div className="mobile-editor-profile-grid">
-        {columns?.map((col) => (
+        {editableColumns(columns).map((col) => (
           <ColumnInput
             key={col.key}
             column={col}
@@ -153,7 +160,7 @@ const ProfileWeaponEditor = ({ weapons, weaponIndex, profileIndex, columns, conf
       {hasKeywords && (
         <EditorTagInput
           label="Keywords"
-          tags={profile.keywords || []}
+          tags={normalizeKeywords(profile.keywords)}
           onChange={(tags) => updateProfile("keywords", tags)}
         />
       )}
@@ -214,8 +221,8 @@ const FlatWeaponEditor = ({ weapons, weaponIndex, columns, config, setWeapons })
       />
 
       <div className="mobile-editor-profile-grid">
-        {columns
-          ?.filter((col) => !ARRAY_COLUMNS.has(col.key))
+        {editableColumns(columns)
+          .filter((col) => !ARRAY_COLUMNS.has(col.key))
           .map((col) => (
             <ColumnInput
               key={col.key}
@@ -226,8 +233,8 @@ const FlatWeaponEditor = ({ weapons, weaponIndex, columns, config, setWeapons })
           ))}
       </div>
 
-      {columns
-        ?.filter((col) => ARRAY_COLUMNS.has(col.key))
+      {editableColumns(columns)
+        .filter((col) => ARRAY_COLUMNS.has(col.key))
         .map((col) => {
           const arr = weapon[col.key];
           return (
@@ -258,7 +265,7 @@ const FlatWeaponEditor = ({ weapons, weaponIndex, columns, config, setWeapons })
       {config?.hasKeywords && (
         <EditorTagInput
           label="Keywords"
-          tags={weapon.keywords || []}
+          tags={normalizeKeywords(weapon.keywords)}
           onChange={(tags) => updateWeapon("keywords", tags)}
         />
       )}

--- a/src/Components/Viewer/useMobileList.jsx
+++ b/src/Components/Viewer/useMobileList.jsx
@@ -176,6 +176,7 @@ export const MobileListProvider = (props) => {
       if (card.uuid !== uuid) return card;
       const next = { ...card, unitSize, selectedEnhancement: enhancement, isWarlord };
       if ("attachedTo" in options) next.attachedTo = options.attachedTo || undefined;
+      if ("selectedWargear" in options) next.selectedWargear = options.selectedWargear || [];
       return next;
     });
     updateCategory({ ...category, cards: updatedCards }, category.uuid);

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitWeapon.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitWeapon.jsx
@@ -1,6 +1,7 @@
 import { Grid } from "antd";
 import { replaceKeywords } from "./UnitAbilityDescription";
 import { UnitWeaponKeywords } from "./UnitWeaponKeyword";
+import { normalizeKeywords } from "../../../Helpers/weaponProfile.helpers";
 
 const { useBreakpoint } = Grid;
 
@@ -11,30 +12,34 @@ export const UnitWeapon = ({ weapon }) => {
     <>
       {weapon.profiles
         ?.filter((line) => line.active)
-        ?.map((line, index, profiles) => (
-          <div
-            className={`weapon${profiles.length > 1 ? " multi-line" : ""}`}
-            key={`weapon-line-${index}`}
-            data-name={line.name}>
-            <div className="line">
-              <div className="value" style={{ display: "flex", flexWrap: "wrap" }}>
-                <span>{line.name}</span>
-                {line.keywords?.length > 0 && !screens.xs && (
-                  <span style={{ paddingLeft: "4px" }}>
-                    <UnitWeaponKeywords keywords={line.keywords} />
-                  </span>
-                )}
+        ?.map((line, index, profiles) => {
+          // Saved cards can carry a string here (see normalizeKeywords).
+          const keywords = normalizeKeywords(line.keywords);
+          return (
+            <div
+              className={`weapon${profiles.length > 1 ? " multi-line" : ""}`}
+              key={`weapon-line-${index}`}
+              data-name={line.name}>
+              <div className="line">
+                <div className="value" style={{ display: "flex", flexWrap: "wrap" }}>
+                  <span>{line.name}</span>
+                  {keywords.length > 0 && !screens.xs && (
+                    <span style={{ paddingLeft: "4px" }}>
+                      <UnitWeaponKeywords keywords={keywords} />
+                    </span>
+                  )}
+                </div>
+                <div className="value center">{line.range}</div>
+                <div className="value center">{line.attacks}</div>
+                <div className="value center">{line.skill}</div>
+                <div className="value center">{line.strength}</div>
+                <div className="value center">{line.ap}</div>
+                <div className="value center">{line.damage}</div>
+                {keywords.length > 0 && screens.xs && <UnitWeaponKeywords keywords={keywords} />}
               </div>
-              <div className="value center">{line.range}</div>
-              <div className="value center">{line.attacks}</div>
-              <div className="value center">{line.skill}</div>
-              <div className="value center">{line.strength}</div>
-              <div className="value center">{line.ap}</div>
-              <div className="value center">{line.damage}</div>
-              {line.keywords?.length > 0 && screens.xs && <UnitWeaponKeywords keywords={line.keywords} />}
             </div>
-          </div>
-        ))}
+          );
+        })}
       {weapon?.abilities && (
         <div className="special">
           {weapon.abilities

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitWeaponKeyword.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitWeaponKeyword.jsx
@@ -1,4 +1,5 @@
 import { KeywordTooltip } from "./KeywordTooltip";
+import { normalizeKeywords } from "../../../Helpers/weaponProfile.helpers";
 
 export const tooltipProps = {
   placement: "bottom",
@@ -6,7 +7,7 @@ export const tooltipProps = {
 };
 
 export const UnitWeaponKeywords = ({ keywords }) => {
-  const tooltips = keywords.map((keyword, index) => {
+  const tooltips = normalizeKeywords(keywords).map((keyword, index) => {
     return <KeywordTooltip keyword={keyword} key={`${keyword}-${index}`} />;
   });
 

--- a/src/Components/Warhammer40k-10e/UnitCardEditor/UnitWeapon.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCardEditor/UnitWeapon.jsx
@@ -3,6 +3,7 @@ import { Button, Card, Divider, Form, Input, Popconfirm, Space, Switch, Typograp
 import React, { useState } from "react";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
 import { CustomMarkdownEditor } from "../../CustomMarkdownEditor";
+import { normalizeKeywords } from "../../../Helpers/weaponProfile.helpers";
 
 export function UnitWeapon({ weapon, index, type }) {
   const { activeCard, updateActiveCard } = useCardStorage();
@@ -161,14 +162,16 @@ export function UnitWeapon({ weapon, index, type }) {
                 </div>
                 <div className="keywords_header">Keywords</div>
                 <div className="keywords_container" style={{ paddingBottom: "4px", paddingTop: "4px" }}>
-                  {line.keywords.map((keyword, kIndex) => {
+                  {normalizeKeywords(line.keywords).map((keyword, kIndex) => {
                     return (
                       <div className="keyword_container" key={`keyword-${index}-${pIndex}-${kIndex}`}>
                         <Typography.Text
                           editable={{
                             onChange: (value) => {
                               const newWeapons = [...activeCard[type]];
-                              newWeapons[index].profiles[pIndex].keywords[kIndex] = value;
+                              const profile = newWeapons[index].profiles[pIndex];
+                              profile.keywords = normalizeKeywords(profile.keywords);
+                              profile.keywords[kIndex] = value;
                               updateActiveCard({
                                 ...activeCard,
                                 [type]: newWeapons,
@@ -184,7 +187,9 @@ export function UnitWeapon({ weapon, index, type }) {
                           onClick={(value) =>
                             updateActiveCard(() => {
                               const newWeapons = [...activeCard[type]];
-                              newWeapons[index].profiles[pIndex].keywords.splice(kIndex, 1);
+                              const profile = newWeapons[index].profiles[pIndex];
+                              profile.keywords = normalizeKeywords(profile.keywords);
+                              profile.keywords.splice(kIndex, 1);
                               return { ...activeCard, [type]: newWeapons };
                             })
                           }></Button>
@@ -198,9 +203,9 @@ export function UnitWeapon({ weapon, index, type }) {
                     onClick={() =>
                       updateActiveCard(() => {
                         const newWeapons = [...activeCard[type]];
-                        newWeapons[index].profiles[pIndex].keywords.push(
-                          `keyword ${newWeapons[index].profiles[pIndex].keywords.length + 1}`,
-                        );
+                        const profile = newWeapons[index].profiles[pIndex];
+                        profile.keywords = normalizeKeywords(profile.keywords);
+                        profile.keywords.push(`keyword ${profile.keywords.length + 1}`);
                         return { ...activeCard, [type]: newWeapons };
                       })
                     }>

--- a/src/Components/Warhammer40k-11e/UnitCard/UnitPoints.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCard/UnitPoints.jsx
@@ -1,5 +1,6 @@
 import { Button, Popover } from "antd";
 import { localize } from "../../../Helpers/localization.helpers";
+import { getPointsTierRestrictionLabel } from "../../../Helpers/listPoints.helpers";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
 
 // 11th edition points have no `active`/`primary` flags; treat the first entry as
@@ -7,6 +8,11 @@ import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
 // 11e data, so it is localised to the selected card language. `additionalCost` is
 // the per-datasheet roster surcharge ({ cost, afterSelections }) shown alongside
 // the tiers.
+//
+// A tier can also be priced only for one detachment or one faction (5 Assault
+// Intercessors are 75, but 80 in a Blood Angels army). That restriction is shown
+// next to the tier so the reader can tell the two prices apart; unrestricted
+// tiers render exactly as they did before.
 export const UnitPoints = ({ points, additionalCost, showAllPoints, showPointsModels }) => {
   const { settings } = useSettingsStorage();
   const allPoints = points || [];
@@ -20,10 +26,12 @@ export const UnitPoints = ({ points, additionalCost, showAllPoints, showPointsMo
 
   const formatPointDisplay = (point) => {
     const keyword = localize(point.keyword, settings.language);
+    const restriction = getPointsTierRestrictionLabel(point, settings.language);
+    const suffix = restriction ? ` (${restriction})` : "";
     if (showPointsModels) {
-      return `${point.models}${keyword ? ` (${keyword})` : ""}: ${point.cost} pts`;
+      return `${point.models}${keyword ? ` (${keyword})` : ""}: ${point.cost} pts${suffix}`;
     }
-    return `${point.cost} pts`;
+    return `${point.cost} pts${suffix}`;
   };
 
   if (showAllPoints) {
@@ -58,9 +66,15 @@ export const UnitPoints = ({ points, additionalCost, showAllPoints, showPointsMo
             <tbody>
               {allPoints.map((point, index) => {
                 const keyword = localize(point.keyword, settings.language);
+                const restriction = getPointsTierRestrictionLabel(point, settings.language);
                 return (
                   <tr className="points" key={`points-${index}`}>
-                    <td>{`${point.models}${keyword ? ` (${keyword})` : ""}`}</td>
+                    <td>
+                      {`${point.models}${keyword ? ` (${keyword})` : ""}`}
+                      {/* A sub-label rather than a second parenthetical, so a
+                          restriction never reads as another tier keyword. */}
+                      {restriction && <span className="points_restriction">{` (${restriction})`}</span>}
+                    </td>
                     <td>{`${point.cost} pts`}</td>
                   </tr>
                 );

--- a/src/Components/Warhammer40k-11e/UnitCard/UnitWargear.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCard/UnitWargear.jsx
@@ -1,9 +1,19 @@
 import { MarkupText } from "./UnitAbilityDescription";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
 import { localize } from "../../../Helpers/localization.helpers";
+import { getWargearOptionGroups } from "../../../Helpers/listPoints.helpers";
 
-// 11th edition wargear is an array of language-keyed strings (often just "None").
-// Render the section only when there are meaningful options.
+// 11th edition carries wargear two ways:
+//
+//   `wargear`       — an array of language-keyed sentences, which in the 11e
+//                     data is usually just "None".
+//   `wargearOptions` — the structured groups the datasheet really offers:
+//                     an instruction plus the swaps it allows, some of which
+//                     cost points.
+//
+// Both are rendered when both have content (the sentences first), and "None"
+// alone is dropped so a datasheet with real options is not described as having
+// none. The section disappears entirely when neither has anything to say.
 export const UnitWargear = ({ unit }) => {
   const { settings } = useSettingsStorage();
   const lang = settings.language;
@@ -12,8 +22,10 @@ export const UnitWargear = ({ unit }) => {
     .map((entry) => localize(entry, lang))
     .filter((entry) => entry && entry.trim().toLowerCase() !== "none");
 
+  const groups = getWargearOptionGroups(unit);
+
   // An absent showWargear flag means shown.
-  if (unit.showWargear === false || items.length === 0) {
+  if (unit.showWargear === false || (items.length === 0 && groups.length === 0)) {
     return <div className="wargear_container" />;
   }
 
@@ -31,6 +43,28 @@ export const UnitWargear = ({ unit }) => {
               </span>
             </div>
           ))}
+          {groups.map((group, index) => {
+            const instruction = localize(group.instruction, lang);
+            return (
+              <div className="item wargear-group" key={`wargear-group-${index}`}>
+                {instruction && (
+                  <span className="description">
+                    <MarkupText content={instruction} />
+                  </span>
+                )}
+                <div className="wargear-options">
+                  {group.options.map((option, optionIndex) => (
+                    <div className="wargear-option" key={`wargear-option-${optionIndex}`}>
+                      <span className="description">
+                        {localize(option.name, lang)}
+                        {option.cost > 0 ? ` (+${option.cost} pts)` : ""}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/Components/Warhammer40k-11e/UnitCard/UnitWeapon.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCard/UnitWeapon.jsx
@@ -2,6 +2,7 @@ import { Grid } from "antd";
 import { UnitWeaponKeywords } from "./UnitWeaponKeyword";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
 import { localize } from "../../../Helpers/localization.helpers";
+import { normalizeKeywords } from "../../../Helpers/weaponProfile.helpers";
 
 const { useBreakpoint } = Grid;
 
@@ -15,6 +16,8 @@ export const UnitWeapon = ({ weapon }) => {
     <>
       {weapon.profiles?.map((line, index, profiles) => {
         const name = localize(line.name, settings.language);
+        // Saved cards can carry a string here (see normalizeKeywords).
+        const keywords = normalizeKeywords(line.keywords);
         return (
           <div
             className={`weapon${profiles.length > 1 ? " multi-line" : ""}`}
@@ -23,9 +26,9 @@ export const UnitWeapon = ({ weapon }) => {
             <div className="line">
               <div className="value" style={{ display: "flex", flexWrap: "wrap" }}>
                 <span>{name}</span>
-                {line.keywords?.length > 0 && !screens.xs && (
+                {keywords.length > 0 && !screens.xs && (
                   <span style={{ paddingLeft: "4px" }}>
-                    <UnitWeaponKeywords keywords={line.keywords} />
+                    <UnitWeaponKeywords keywords={keywords} />
                   </span>
                 )}
               </div>
@@ -35,7 +38,7 @@ export const UnitWeapon = ({ weapon }) => {
               <div className="value center">{line.strength}</div>
               <div className="value center">{line.ap}</div>
               <div className="value center">{line.damage}</div>
-              {line.keywords?.length > 0 && screens.xs && <UnitWeaponKeywords keywords={line.keywords} />}
+              {keywords.length > 0 && screens.xs && <UnitWeaponKeywords keywords={keywords} />}
             </div>
           </div>
         );

--- a/src/Components/Warhammer40k-11e/UnitCard/UnitWeaponKeyword.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCard/UnitWeaponKeyword.jsx
@@ -4,6 +4,7 @@ import { Tooltip } from "../../Tooltip/Tooltip";
 import { LocalizedMarkup } from "./UnitAbilityDescription";
 import { resolveKeywordEntry } from "../../../Helpers/customSchema.helpers";
 import { use11eKeywordGlossary } from "../../../Hooks/use11eKeywordGlossary";
+import { normalizeKeywords } from "../../../Helpers/weaponProfile.helpers";
 
 // 11th edition weapon keywords. When the datasource ships a keyword glossary,
 // keywords that resolve to an entry get a hover tooltip with the localised
@@ -14,7 +15,7 @@ export const UnitWeaponKeywords = ({ keywords }) => {
 
   return (
     <span className="keyword">
-      {keywords?.map((keyword, index) => {
+      {normalizeKeywords(keywords).map((keyword, index) => {
         const entry = resolveKeywordEntry(keyword, glossary, "weapons");
         const button = (
           <Button type="text" size="small" className={`keyword-button${entry ? " keyword-button--has-info" : ""}`}>

--- a/src/Components/Warhammer40k-11e/UnitCardEditor.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCardEditor.jsx
@@ -109,6 +109,38 @@ export const UnitCardEditor = () => {
         }>
         {activeCard.showAbilities?.other !== false && <UnitExtendedAbilities type={"other"} />}
       </Panel>
+      {/* Wargear abilities render right after the other-abilities block on the
+          card (see UnitCard/UnitExtra), so the panels follow the same order.
+          Key "6b" because "7" already belongs to the primarch panel. */}
+      <Panel
+        header="Wargear abilities"
+        style={{ width: "100%" }}
+        key="6b"
+        collapsible={activeCard.showAbilities?.wargear === false ? "disabled" : undefined}
+        extra={
+          <Switch
+            size="small"
+            checked={activeCard.showAbilities?.wargear !== false}
+            onClick={(value, e) => handleAbilityVisibilityChange("wargear", "6b", value, e)}
+          />
+        }>
+        {activeCard.showAbilities?.wargear !== false && <UnitExtendedAbilities type={"wargear"} />}
+      </Panel>
+      {/* Special abilities render straight after the wargear ones on the card. */}
+      <Panel
+        header="Special abilities"
+        style={{ width: "100%" }}
+        key="6c"
+        collapsible={activeCard.showAbilities?.special === false ? "disabled" : undefined}
+        extra={
+          <Switch
+            size="small"
+            checked={activeCard.showAbilities?.special !== false}
+            onClick={(value, e) => handleAbilityVisibilityChange("special", "6c", value, e)}
+          />
+        }>
+        {activeCard.showAbilities?.special !== false && <UnitExtendedAbilities type={"special"} />}
+      </Panel>
       <Panel
         header="Primarch ability"
         style={{ width: "100%" }}

--- a/src/Components/Warhammer40k-11e/UnitCardEditor/UnitPoints.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCardEditor/UnitPoints.jsx
@@ -13,6 +13,10 @@ import { localize, setLocalizedField } from "../../../Helpers/localization.helpe
 // is shown in the active card language and edits merge into just that language
 // (like the other 11e field editors). `additionalCost` is the per-datasheet
 // roster surcharge ({ cost, afterSelections }).
+//
+// A tier can also be priced for a single detachment or a single faction — never
+// both, which is why setting one disables the other. Clearing either stores
+// `null`, the shape the source data uses for an unrestricted tier.
 export function UnitPoints() {
   const { activeCard, updateActiveCard } = useCardStorage();
   const { settings } = useSettingsStorage();
@@ -26,6 +30,19 @@ export function UnitPoints() {
       newPoints[index] = { ...newPoints[index], [field]: value };
       return { ...activeCard, points: newPoints };
     });
+  };
+
+  // Restrictions are language-keyed in the source data, so an edit merges into
+  // the active language and a first value starts a language-keyed object rather
+  // than a bare string. An emptied input drops back to null (unrestricted).
+  const updateRestriction = (index, field, value) => {
+    if (String(value).trim() === "") {
+      updatePoint(index, field, null);
+      return;
+    }
+    const current = points[index]?.[field];
+    const isLocalized = current != null && typeof current === "object" && !Array.isArray(current);
+    updatePoint(index, field, isLocalized ? setLocalizedField(current, language, value) : { [language]: value });
   };
 
   const updateAdditionalCost = (field, value) => {
@@ -122,7 +139,7 @@ export function UnitPoints() {
                                   onChange={(e) => updatePoint(index, "cost", e.target.value)}
                                 />
                               </Form.Item>
-                              <Form.Item label={"Keyword"} style={{ marginBottom: 0 }}>
+                              <Form.Item label={"Keyword"}>
                                 <Input
                                   type={"text"}
                                   value={localize(point.keyword, language)}
@@ -133,6 +150,24 @@ export function UnitPoints() {
                                       setLocalizedField(point.keyword, language, e.target.value),
                                     )
                                   }
+                                />
+                              </Form.Item>
+                              {/* Only one of the two: a tier is priced for a
+                                  detachment or for a faction, never both. */}
+                              <Form.Item label={"Detachment"}>
+                                <Input
+                                  type={"text"}
+                                  value={localize(point.detachment, language)}
+                                  disabled={Boolean(localize(point.faction, language))}
+                                  onChange={(e) => updateRestriction(index, "detachment", e.target.value)}
+                                />
+                              </Form.Item>
+                              <Form.Item label={"Faction"} style={{ marginBottom: 0 }}>
+                                <Input
+                                  type={"text"}
+                                  value={localize(point.faction, language)}
+                                  disabled={Boolean(localize(point.detachment, language))}
+                                  onChange={(e) => updateRestriction(index, "faction", e.target.value)}
                                 />
                               </Form.Item>
                             </Form>

--- a/src/Components/Warhammer40k-11e/UnitCardEditor/UnitWargearOptions.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCardEditor/UnitWargearOptions.jsx
@@ -1,15 +1,26 @@
 import { Trash2 } from "lucide-react";
-import { Button, Card, Form, Popconfirm, Space } from "antd";
+import { Button, Card, Form, Input, Popconfirm, Space } from "antd";
 import { CustomMarkdownEditor } from "../../CustomMarkdownEditor";
 import React from "react";
 import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
 import { reorder } from "../../../Helpers/generic.helpers";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
-import { localize, setLocalizedArrayItem } from "../../../Helpers/localization.helpers";
+import { localize, setLocalizedArrayItem, setLocalizedField } from "../../../Helpers/localization.helpers";
 
-// 11th edition wargear options are an array of language-keyed markdown strings.
-export function UnitWargearOptions() {
+// The wargear panel edits both halves of a card's wargear:
+//
+//   `wargear`        — free-form language-keyed markdown sentences (WargearText).
+//   `wargearOptions` — the structured groups the card back and the list builder
+//                      read: an instruction plus the swaps it offers, each with
+//                      a points cost (WargearGroups).
+//
+// Costs stay strings, the shape the source datasource uses; the points helpers
+// coerce them.
+
+// The free-form sentences. In the 11e data this is usually just "None", so it is
+// the structured groups below that carry the real content.
+function WargearText() {
   const { activeCard, updateActiveCard } = useCardStorage();
   const { settings } = useSettingsStorage();
   const lang = settings.language;
@@ -41,12 +52,12 @@ export function UnitWargearOptions() {
                           <Card
                             type={"inner"}
                             size={"small"}
-                            title={`Wargear option ${index + 1}`}
+                            title={`Wargear text ${index + 1}`}
                             style={{ marginBottom: "16px" }}
                             extra={
                               <Space>
                                 <Popconfirm
-                                  title={"Are you sure you want to delete this wargear option?"}
+                                  title={"Are you sure you want to delete this wargear text?"}
                                   placement="topRight"
                                   onConfirm={() =>
                                     updateActiveCard(() => {
@@ -94,8 +105,128 @@ export function UnitWargearOptions() {
             return { ...activeCard, wargear: newWargear };
           })
         }>
+        Add wargear text
+      </Button>
+    </>
+  );
+}
+
+// The structured groups: what the card back lists and what the list builder
+// charges points for.
+function WargearGroups() {
+  const { activeCard, updateActiveCard } = useCardStorage();
+  const { settings } = useSettingsStorage();
+  const lang = settings.language;
+  const groups = activeCard.wargearOptions || [];
+
+  // Every edit works on a fresh copy of the groups and of their option arrays,
+  // so nothing stored on the card is mutated in place.
+  const updateGroups = (mutate) =>
+    updateActiveCard(() => {
+      const next = groups.map((group) => ({ ...group, options: [...(group?.options || [])] }));
+      mutate(next);
+      return { ...activeCard, wargearOptions: next };
+    });
+
+  const updateOption = (groupIndex, optionIndex, changes) =>
+    updateGroups((next) => {
+      next[groupIndex].options[optionIndex] = { ...next[groupIndex].options[optionIndex], ...changes };
+    });
+
+  return (
+    <>
+      {groups.map((group, groupIndex) => (
+        <Card
+          key={`wargear-group-${groupIndex}`}
+          type={"inner"}
+          size={"small"}
+          title={`Wargear option ${groupIndex + 1}`}
+          style={{ marginBottom: "16px" }}
+          extra={
+            <Space>
+              <Popconfirm
+                title={"Are you sure you want to delete this wargear option?"}
+                placement="topRight"
+                onConfirm={() => updateGroups((next) => next.splice(groupIndex, 1))}>
+                <Button type="icon" shape="circle" size="small" icon={<Trash2 size={14} />}></Button>
+              </Popconfirm>
+            </Space>
+          }>
+          <Form size="small">
+            <Form.Item label={"Instruction"}>
+              <Input.TextArea
+                rows={2}
+                value={localize(group?.instruction, lang)}
+                onChange={(e) =>
+                  updateGroups((next) => {
+                    next[groupIndex].instruction = setLocalizedField(
+                      next[groupIndex].instruction,
+                      lang,
+                      e.target.value,
+                    );
+                  })
+                }
+              />
+            </Form.Item>
+            {(group?.options || []).map((option, optionIndex) => (
+              <Form.Item key={`wargear-group-${groupIndex}-option-${optionIndex}`} label={`Option ${optionIndex + 1}`}>
+                <Space.Compact style={{ width: "100%" }}>
+                  <Input
+                    type={"text"}
+                    placeholder="Name"
+                    value={localize(option?.name, lang)}
+                    onChange={(e) =>
+                      updateOption(groupIndex, optionIndex, {
+                        name: setLocalizedField(option?.name, lang, e.target.value),
+                      })
+                    }
+                  />
+                  <Input
+                    type={"text"}
+                    style={{ width: "90px" }}
+                    placeholder="Cost"
+                    addonAfter="pts"
+                    value={option?.cost ?? ""}
+                    onChange={(e) => updateOption(groupIndex, optionIndex, { cost: e.target.value })}
+                  />
+                  <Button
+                    type="icon"
+                    icon={<Trash2 size={14} />}
+                    onClick={() => updateGroups((next) => next[groupIndex].options.splice(optionIndex, 1))}
+                  />
+                </Space.Compact>
+              </Form.Item>
+            ))}
+            <Form.Item style={{ marginBottom: 0 }}>
+              <Button
+                type="dashed"
+                style={{ width: "100%" }}
+                onClick={() =>
+                  updateGroups((next) => next[groupIndex].options.push({ name: { [lang]: "" }, cost: "0" }))
+                }>
+                Add option
+              </Button>
+            </Form.Item>
+          </Form>
+        </Card>
+      ))}
+      <Button
+        type="dashed"
+        style={{ width: "100%" }}
+        onClick={() => updateGroups((next) => next.push({ instruction: { [lang]: "" }, options: [] }))}>
         Add wargear option
       </Button>
+    </>
+  );
+}
+
+export function UnitWargearOptions() {
+  return (
+    <>
+      <WargearGroups />
+      <Card type={"inner"} size={"small"} title="Wargear text" style={{ marginTop: "16px" }} bodyStyle={{ padding: 8 }}>
+        <WargearText />
+      </Card>
     </>
   );
 }

--- a/src/Components/Warhammer40k-11e/UnitCardEditor/UnitWeapon.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCardEditor/UnitWeapon.jsx
@@ -4,6 +4,7 @@ import React from "react";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
 import { localize, setLocalizedField } from "../../../Helpers/localization.helpers";
+import { normalizeKeywords } from "../../../Helpers/weaponProfile.helpers";
 
 // 11th edition weapons have profiles only (no weapon-level abilities) and no
 // per-profile `active` flag. The profile name is language-keyed; range/attacks/
@@ -162,7 +163,7 @@ export function UnitWeapon({ weapon, index, type }) {
               </div>
               <div className="keywords_header">Keywords</div>
               <div className="keywords_container" style={{ paddingBottom: "4px", paddingTop: "4px" }}>
-                {(line.keywords || []).map((keyword, kIndex) => {
+                {normalizeKeywords(line.keywords).map((keyword, kIndex) => {
                   return (
                     <div className="keyword_container" key={`keyword-${index}-${pIndex}-${kIndex}`}>
                       <Typography.Text
@@ -170,7 +171,7 @@ export function UnitWeapon({ weapon, index, type }) {
                           onChange: (value) => {
                             const newWeapons = [...activeCard[type]];
                             const profiles = [...newWeapons[index].profiles];
-                            const keywords = [...(profiles[pIndex].keywords || [])];
+                            const keywords = [...normalizeKeywords(profiles[pIndex].keywords)];
                             keywords[kIndex] = value;
                             profiles[pIndex] = { ...profiles[pIndex], keywords };
                             newWeapons[index] = { ...newWeapons[index], profiles };
@@ -187,7 +188,7 @@ export function UnitWeapon({ weapon, index, type }) {
                           updateActiveCard(() => {
                             const newWeapons = [...activeCard[type]];
                             const profiles = [...newWeapons[index].profiles];
-                            const keywords = [...(profiles[pIndex].keywords || [])];
+                            const keywords = [...normalizeKeywords(profiles[pIndex].keywords)];
                             keywords.splice(kIndex, 1);
                             profiles[pIndex] = { ...profiles[pIndex], keywords };
                             newWeapons[index] = { ...newWeapons[index], profiles };
@@ -205,7 +206,7 @@ export function UnitWeapon({ weapon, index, type }) {
                     updateActiveCard(() => {
                       const newWeapons = [...activeCard[type]];
                       const profiles = [...newWeapons[index].profiles];
-                      const keywords = [...(profiles[pIndex].keywords || [])];
+                      const keywords = [...normalizeKeywords(profiles[pIndex].keywords)];
                       keywords.push(`keyword ${keywords.length + 1}`);
                       profiles[pIndex] = { ...profiles[pIndex], keywords };
                       newWeapons[index] = { ...newWeapons[index], profiles };

--- a/src/Components/Warhammer40k-11e/UnitCardFullEditor.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCardFullEditor.jsx
@@ -128,6 +128,38 @@ export const UnitCardFullEditor = () => {
         }>
         {activeCard.showAbilities?.other !== false && <UnitExtendedAbilities type={"other"} />}
       </Panel>
+      {/* Wargear abilities render right after the other-abilities block on the
+          card (see UnitCard/UnitExtra), so the panels follow the same order.
+          Key "6b" because "7" already belongs to the primarch panel. */}
+      <Panel
+        header="Wargear abilities"
+        style={{ width: "100%" }}
+        key="6b"
+        collapsible={activeCard.showAbilities?.wargear === false ? "disabled" : undefined}
+        extra={
+          <Switch
+            size="small"
+            checked={activeCard.showAbilities?.wargear !== false}
+            onClick={(value, e) => handleAbilityVisibilityChange("wargear", "6b", value, e)}
+          />
+        }>
+        {activeCard.showAbilities?.wargear !== false && <UnitExtendedAbilities type={"wargear"} />}
+      </Panel>
+      {/* Special abilities render straight after the wargear ones on the card. */}
+      <Panel
+        header="Special abilities"
+        style={{ width: "100%" }}
+        key="6c"
+        collapsible={activeCard.showAbilities?.special === false ? "disabled" : undefined}
+        extra={
+          <Switch
+            size="small"
+            checked={activeCard.showAbilities?.special !== false}
+            onClick={(value, e) => handleAbilityVisibilityChange("special", "6c", value, e)}
+          />
+        }>
+        {activeCard.showAbilities?.special !== false && <UnitExtendedAbilities type={"special"} />}
+      </Panel>
       <Panel
         header="Primarch ability"
         style={{ width: "100%" }}

--- a/src/Components/Warhammer40k-11e/__tests__/UnitCardEditor.test.jsx
+++ b/src/Components/Warhammer40k-11e/__tests__/UnitCardEditor.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 
 const mockUpdateActiveCard = vi.fn();
@@ -69,6 +69,8 @@ describe("UnitCardEditor (11e)", () => {
       "Core abilities",
       "Faction abilities",
       "Other abilities",
+      "Wargear abilities",
+      "Special abilities",
       "Primarch ability",
       "Damaged ability",
       "Invulnerable save",
@@ -76,9 +78,9 @@ describe("UnitCardEditor (11e)", () => {
     ].forEach((label) => expect(screen.getByText(label)).toBeInTheDocument());
   });
 
-  it("renders 8 visibility toggles", () => {
+  it("renders 10 visibility toggles", () => {
     const { container } = render(<UnitCardEditor />);
-    expect(container.querySelectorAll(".ant-collapse-extra .ant-switch").length).toBe(8);
+    expect(container.querySelectorAll(".ant-collapse-extra .ant-switch").length).toBe(10);
   });
 
   it("defaults every visibility toggle to checked when no flags are set", () => {
@@ -99,15 +101,54 @@ describe("UnitCardEditor (11e)", () => {
     mockActiveCard.ref = { showDamaged: false, showInvul: false };
     const { container } = render(<UnitCardEditor />);
     const panels = container.querySelectorAll(".ant-collapse-item");
-    // Damaged ability (10) and Invulnerable save (11)
-    expect(panels[10].classList.contains("ant-collapse-item-disabled")).toBe(true);
-    expect(panels[11].classList.contains("ant-collapse-item-disabled")).toBe(true);
+    // Damaged ability (12) and Invulnerable save (13)
+    expect(panels[12].classList.contains("ant-collapse-item-disabled")).toBe(true);
+    expect(panels[13].classList.contains("ant-collapse-item-disabled")).toBe(true);
   });
 
   it("disables the primarch panel when showAbilities.primarch is false", () => {
     mockActiveCard.ref = { showAbilities: { primarch: false } };
     const { container } = render(<UnitCardEditor />);
     const panels = container.querySelectorAll(".ant-collapse-item");
-    expect(panels[9].classList.contains("ant-collapse-item-disabled")).toBe(true);
+    expect(panels[11].classList.contains("ant-collapse-item-disabled")).toBe(true);
+  });
+
+  // Wargear and special abilities both render on the card (UnitCard/UnitExtra)
+  // but had no editor panel, so they could not be edited or hidden.
+  describe.each([
+    { label: "Wargear abilities", type: "wargear", panelIndex: 9, switchIndex: 5 },
+    { label: "Special abilities", type: "special", panelIndex: 10, switchIndex: 6 },
+  ])("$label panel", ({ label, type, panelIndex, switchIndex }) => {
+    it("edits its ability list when expanded", () => {
+      render(<UnitCardEditor />);
+      fireEvent.click(screen.getByText(label));
+      expect(screen.getByTestId(`extended-${type}`)).toBeInTheDocument();
+    });
+
+    it("writes its visibility flag when the toggle is switched off", () => {
+      const { container } = render(<UnitCardEditor />);
+      fireEvent.click(container.querySelectorAll(".ant-collapse-extra .ant-switch")[switchIndex]);
+      expect(mockUpdateActiveCard).toHaveBeenCalledWith(
+        expect.objectContaining({ showAbilities: expect.objectContaining({ [type]: false }) }),
+      );
+    });
+
+    it("disables the panel when its flag is false", () => {
+      mockActiveCard.ref = { showAbilities: { [type]: false } };
+      const { container } = render(<UnitCardEditor />);
+      const panels = container.querySelectorAll(".ant-collapse-item");
+      expect(panels[panelIndex].classList.contains("ant-collapse-item-disabled")).toBe(true);
+      const toggle = container.querySelectorAll(".ant-collapse-extra .ant-switch")[switchIndex];
+      expect(toggle.classList.contains("ant-switch-checked")).toBe(false);
+    });
+  });
+
+  it("orders the ability panels the way the card renders them", () => {
+    const { container } = render(<UnitCardEditor />);
+    const headers = [...container.querySelectorAll(".ant-collapse-header")].map((h) => h.textContent);
+    expect(headers[8]).toContain("Other abilities");
+    expect(headers[9]).toContain("Wargear abilities");
+    expect(headers[10]).toContain("Special abilities");
+    expect(headers[11]).toContain("Primarch ability");
   });
 });

--- a/src/Components/Warhammer40k-11e/__tests__/UnitPoints.test.jsx
+++ b/src/Components/Warhammer40k-11e/__tests__/UnitPoints.test.jsx
@@ -8,6 +8,21 @@ vi.mock("../../../Hooks/useSettingsStorage", () => ({
   useSettingsStorage: () => ({ settings: { language: mockLanguage } }),
 }));
 
+// Render the popover's table inline instead of on hover into a portal, so the
+// tier rows can be inspected directly.
+vi.mock("antd", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    Popover: ({ content, children }) => (
+      <div>
+        {content}
+        {children}
+      </div>
+    ),
+  };
+});
+
 import { UnitPoints } from "../UnitCard/UnitPoints";
 
 // 11e-shaped tiers: string values, language-keyed keyword, no active flags.
@@ -45,5 +60,48 @@ describe("UnitPoints (11e card display)", () => {
     const { container } = render(<UnitPoints points={points} showAllPoints={true} showPointsModels={true} />);
     expect(container.textContent).toContain("2 (Imperium-DE): 425 pts");
     mockLanguage = "en";
+  });
+});
+
+// A tier can be priced for one detachment or one faction only.
+describe("UnitPoints restricted tiers (11e)", () => {
+  const restricted = [
+    { models: "5", cost: "75", keyword: null, faction: null, detachment: null },
+    { models: "5", cost: "80", keyword: null, faction: { en: "Blood Angels", de: "Blutengel" }, detachment: null },
+    { models: "1", cost: "300", keyword: null, faction: null, detachment: { en: "Pantheon of Woe" } },
+  ];
+
+  it("names the restriction on the chips when showAllPoints is on", () => {
+    const { container } = render(<UnitPoints points={restricted} showAllPoints={true} showPointsModels={true} />);
+    expect(container.textContent).toContain("5: 75 pts");
+    expect(container.textContent).toContain("5: 80 pts (Blood Angels)");
+    expect(container.textContent).toContain("1: 300 pts (Pantheon of Woe)");
+  });
+
+  it("names the restriction without the model count too", () => {
+    const { container } = render(<UnitPoints points={restricted} showAllPoints={true} />);
+    expect(container.textContent).toContain("80 pts (Blood Angels)");
+  });
+
+  it("lists the restriction in the popover table, set apart from the keyword", () => {
+    const { container } = render(<UnitPoints points={restricted} />);
+    const rows = Array.from(container.querySelectorAll("tr.points"));
+    // The popover renders inline in the test DOM; the second tier is the
+    // restricted one.
+    expect(rows[1].textContent).toContain("5 (Blood Angels)");
+    expect(rows[1].querySelector(".points_restriction")).not.toBeNull();
+    expect(rows[0].querySelector(".points_restriction")).toBeNull();
+  });
+
+  it("localises the restriction to the selected card language", () => {
+    mockLanguage = "de";
+    const { container } = render(<UnitPoints points={restricted} showAllPoints={true} showPointsModels={true} />);
+    expect(container.textContent).toContain("5: 80 pts (Blutengel)");
+    mockLanguage = "en";
+  });
+
+  it("leaves unrestricted tiers exactly as they were", () => {
+    const { container } = render(<UnitPoints points={points} showAllPoints={true} showPointsModels={true} />);
+    expect(container.textContent).toBe("1: 405 pts2 (Imperium): 425 pts");
   });
 });

--- a/src/Components/Warhammer40k-11e/__tests__/UnitPointsEditor.test.jsx
+++ b/src/Components/Warhammer40k-11e/__tests__/UnitPointsEditor.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 
 // antd Form.Item renders an internal Row which subscribes to matchMedia.
 Object.defineProperty(window, "matchMedia", {
@@ -24,14 +24,15 @@ vi.mock("react-beautiful-dnd", () => ({
   Draggable: ({ children }) => children({ draggableProps: {}, dragHandleProps: {}, innerRef: vi.fn() }),
 }));
 
-const activeCard = {
+const baseCard = () => ({
   points: [{ models: "1", cost: "405", keyword: { en: "Imperium", de: "Imperium-DE" } }],
   additionalCost: { cost: "20", afterSelections: 1 },
-};
+});
+const mockActiveCard = { ref: baseCard() };
 const updateActiveCard = vi.fn();
 
 vi.mock("../../../Hooks/useCardStorage", () => ({
-  useCardStorage: () => ({ activeCard, updateActiveCard }),
+  useCardStorage: () => ({ activeCard: mockActiveCard.ref, updateActiveCard }),
 }));
 vi.mock("../../../Hooks/useSettingsStorage", () => ({
   useSettingsStorage: () => ({ settings: { language: "de" } }),
@@ -39,7 +40,18 @@ vi.mock("../../../Hooks/useSettingsStorage", () => ({
 
 import { UnitPoints } from "../UnitCardEditor/UnitPoints";
 
+const nextCardFrom = (call) => (typeof call[0] === "function" ? call[0]() : call[0]);
+const inputAfterLabel = (container, label) => {
+  const item = Array.from(container.querySelectorAll(".ant-form-item")).find((el) => el.textContent.includes(label));
+  return item.querySelector("input");
+};
+
 describe("UnitPoints editor (11e)", () => {
+  beforeEach(() => {
+    mockActiveCard.ref = baseCard();
+    updateActiveCard.mockClear();
+  });
+
   it("shows the keyword in the active card language", () => {
     const { container } = render(<UnitPoints />);
     const inputs = Array.from(container.querySelectorAll("input"));
@@ -47,13 +59,67 @@ describe("UnitPoints editor (11e)", () => {
   });
 
   it("merges keyword edits into the active language only", () => {
-    updateActiveCard.mockClear();
     const { container } = render(<UnitPoints />);
     const keywordInput = Array.from(container.querySelectorAll("input")).find((i) => i.value === "Imperium-DE");
     fireEvent.change(keywordInput, { target: { value: "Neu" } });
 
-    const updater = updateActiveCard.mock.calls[0][0];
-    const nextCard = typeof updater === "function" ? updater() : updater;
-    expect(nextCard.points[0].keyword).toEqual({ en: "Imperium", de: "Neu" });
+    expect(nextCardFrom(updateActiveCard.mock.calls[0]).points[0].keyword).toEqual({ en: "Imperium", de: "Neu" });
+  });
+});
+
+// A tier can be priced for one detachment or one faction; unrestricted tiers
+// store null, the shape the source data uses.
+describe("UnitPoints editor tier restrictions (11e)", () => {
+  beforeEach(() => {
+    mockActiveCard.ref = baseCard();
+    updateActiveCard.mockClear();
+  });
+
+  it("starts a language-keyed value for a tier that had no restriction", () => {
+    const { container } = render(<UnitPoints />);
+    fireEvent.change(inputAfterLabel(container, "Detachment"), { target: { value: "Pantheon of Woe" } });
+
+    expect(nextCardFrom(updateActiveCard.mock.calls[0]).points[0].detachment).toEqual({ de: "Pantheon of Woe" });
+  });
+
+  it("merges into the active language when a restriction already exists", () => {
+    mockActiveCard.ref.points[0].faction = { en: "Blood Angels" };
+    const { container } = render(<UnitPoints />);
+    fireEvent.change(inputAfterLabel(container, "Faction"), { target: { value: "Blutengel" } });
+
+    expect(nextCardFrom(updateActiveCard.mock.calls[0]).points[0].faction).toEqual({
+      en: "Blood Angels",
+      de: "Blutengel",
+    });
+  });
+
+  it("clears an emptied restriction back to null", () => {
+    mockActiveCard.ref.points[0].detachment = { en: "Pantheon of Woe" };
+    const { container } = render(<UnitPoints />);
+    fireEvent.change(inputAfterLabel(container, "Detachment"), { target: { value: "  " } });
+
+    expect(nextCardFrom(updateActiveCard.mock.calls[0]).points[0].detachment).toBeNull();
+  });
+
+  it("shows an existing restriction in the active card language", () => {
+    mockActiveCard.ref.points[0].faction = { en: "Blood Angels", de: "Blutengel" };
+    const { container } = render(<UnitPoints />);
+    expect(inputAfterLabel(container, "Faction").value).toBe("Blutengel");
+  });
+
+  it("allows only one restriction per tier", () => {
+    mockActiveCard.ref.points[0].faction = { en: "Blood Angels" };
+    const { container } = render(<UnitPoints />);
+    expect(inputAfterLabel(container, "Detachment").disabled).toBe(true);
+    expect(inputAfterLabel(container, "Faction").disabled).toBe(false);
+  });
+
+  it("adds new tiers without a restriction", () => {
+    const { getByText } = render(<UnitPoints />);
+    fireEvent.click(getByText("Add points"));
+
+    const added = nextCardFrom(updateActiveCard.mock.calls[0]).points[1];
+    expect(added.detachment).toBeUndefined();
+    expect(added.faction).toBeUndefined();
   });
 });

--- a/src/Components/Warhammer40k-11e/__tests__/UnitWargearOptions.test.jsx
+++ b/src/Components/Warhammer40k-11e/__tests__/UnitWargearOptions.test.jsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { vi, describe, it, expect } from "vitest";
+
+let mockLanguage = "en";
+vi.mock("../../../Hooks/useSettingsStorage", () => ({
+  useSettingsStorage: () => ({ settings: { language: mockLanguage } }),
+}));
+
+import { UnitWargear } from "../UnitCard/UnitWargear";
+
+const grav = {
+  instruction: { en: "Any number of models can each have their grav-cannon replaced.", de: "Ersetze die Grav-Kanone." },
+  options: [
+    { name: { en: "Twin lascannon", de: "Doppel-Laserkanone" }, cost: "5" },
+    { name: { en: "Heavy bolter" }, cost: "0" },
+  ],
+};
+
+describe("11e card back wargear options", () => {
+  it("lists each group's instruction and options, pricing only the paid ones", () => {
+    const { container } = render(<UnitWargear unit={{ wargear: [], wargearOptions: [grav] }} />);
+    expect(container.textContent).toContain("Any number of models can each have their grav-cannon replaced.");
+    expect(container.textContent).toContain("Twin lascannon (+5 pts)");
+    expect(container.textContent).toContain("Heavy bolter");
+    expect(container.textContent).not.toContain("Heavy bolter (+0 pts)");
+  });
+
+  it("collapses the duplicate groups the 11e data repeats per model", () => {
+    const { container } = render(<UnitWargear unit={{ wargearOptions: [grav, { ...grav }] }} />);
+    expect(container.querySelectorAll(".wargear-group")).toHaveLength(1);
+  });
+
+  it("drops a flat 'None' when there are real options to show instead", () => {
+    const { container } = render(<UnitWargear unit={{ wargear: [{ en: "None" }], wargearOptions: [grav] }} />);
+    expect(container.textContent).not.toContain("None");
+    expect(container.textContent).toContain("Twin lascannon (+5 pts)");
+  });
+
+  it("shows the flat text first when both have real content", () => {
+    const { container } = render(
+      <UnitWargear unit={{ wargear: [{ en: "Take a plasma pistol." }], wargearOptions: [grav] }} />,
+    );
+    const items = Array.from(container.querySelectorAll(".content > .item"));
+    expect(items[0].textContent).toContain("Take a plasma pistol.");
+    expect(items[1].textContent).toContain("Twin lascannon (+5 pts)");
+  });
+
+  it("falls back to the flat text alone when there are no structured options", () => {
+    const { container } = render(<UnitWargear unit={{ wargear: [{ en: "Take a plasma pistol." }] }} />);
+    expect(container.textContent).toContain("Take a plasma pistol.");
+    expect(container.querySelectorAll(".wargear-group")).toHaveLength(0);
+  });
+
+  it("renders an empty section when neither has anything to say", () => {
+    const { container } = render(<UnitWargear unit={{ wargear: [{ en: "None" }], wargearOptions: [] }} />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("stays hidden when showWargear is false", () => {
+    const { container } = render(<UnitWargear unit={{ wargearOptions: [grav], showWargear: false }} />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("localises instructions and option names to the card language", () => {
+    mockLanguage = "de";
+    const { container } = render(<UnitWargear unit={{ wargearOptions: [grav] }} />);
+    expect(container.textContent).toContain("Ersetze die Grav-Kanone.");
+    expect(container.textContent).toContain("Doppel-Laserkanone (+5 pts)");
+    mockLanguage = "en";
+  });
+});

--- a/src/Components/Warhammer40k-11e/__tests__/UnitWargearOptionsEditor.test.jsx
+++ b/src/Components/Warhammer40k-11e/__tests__/UnitWargearOptionsEditor.test.jsx
@@ -1,0 +1,155 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+// The active card is swapped per test; updateActiveCard resolves an updater
+// thunk synchronously, like the real hook, and records the resulting card.
+let capturedCard;
+const mockUpdateActiveCard = vi.fn((arg) => {
+  capturedCard = typeof arg === "function" ? arg() : arg;
+});
+const mockActiveCard = { ref: {} };
+
+vi.mock("../../../Hooks/useCardStorage", () => ({
+  useCardStorage: () => ({ activeCard: mockActiveCard.ref, updateActiveCard: mockUpdateActiveCard }),
+}));
+
+// Edit in German so we can assert English siblings survive.
+vi.mock("../../../Hooks/useSettingsStorage", () => ({
+  useSettingsStorage: () => ({ settings: { language: "de" } }),
+}));
+
+vi.mock("../../CustomMarkdownEditor", () => ({
+  CustomMarkdownEditor: ({ value, onChange }) => (
+    <textarea data-testid="md" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+vi.mock("react-beautiful-dnd", () => ({
+  DragDropContext: ({ children }) => <div>{children}</div>,
+  Droppable: ({ children }) => children({ droppableProps: {}, innerRef: vi.fn(), placeholder: null }),
+  Draggable: ({ children }) => children({ draggableProps: {}, dragHandleProps: {}, innerRef: vi.fn() }),
+}));
+
+// antd Form.Item renders an internal Row which subscribes to matchMedia.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+import { UnitWargearOptions } from "../UnitCardEditor/UnitWargearOptions";
+
+const card = (over = {}) => ({
+  wargear: [],
+  wargearOptions: [
+    {
+      instruction: { en: "Replace the grav-cannon:", de: "Ersetze die Grav-Kanone:" },
+      options: [{ name: { en: "Twin lascannon", de: "Doppel-Laserkanone" }, cost: "5" }],
+    },
+  ],
+  ...over,
+});
+
+const byLabel = (container, label) =>
+  Array.from(container.querySelectorAll(".ant-form-item")).find((item) => item.textContent.includes(label));
+
+const buttonNamed = (getAllByText, text) => getAllByText(text)[0].closest("button");
+
+describe("11e wargear options editor", () => {
+  beforeEach(() => {
+    capturedCard = undefined;
+    mockUpdateActiveCard.mockClear();
+    mockActiveCard.ref = card();
+  });
+
+  it("shows instructions, option names and costs in the active card language", () => {
+    const { container } = render(<UnitWargearOptions />);
+    const values = Array.from(container.querySelectorAll("input, textarea")).map((el) => el.value);
+    expect(values).toContain("Ersetze die Grav-Kanone:");
+    expect(values).toContain("Doppel-Laserkanone");
+    expect(values).toContain("5");
+  });
+
+  it("merges instruction edits into the active language only", () => {
+    const { container } = render(<UnitWargearOptions />);
+    const textarea = container.querySelector("textarea.ant-input");
+    fireEvent.change(textarea, { target: { value: "Neue Anweisung" } });
+    expect(capturedCard.wargearOptions[0].instruction).toEqual({
+      en: "Replace the grav-cannon:",
+      de: "Neue Anweisung",
+    });
+  });
+
+  it("merges option name edits into the active language only", () => {
+    const { container } = render(<UnitWargearOptions />);
+    const nameInput = Array.from(container.querySelectorAll("input")).find((i) => i.value === "Doppel-Laserkanone");
+    fireEvent.change(nameInput, { target: { value: "Plasmakanone" } });
+    expect(capturedCard.wargearOptions[0].options[0].name).toEqual({
+      en: "Twin lascannon",
+      de: "Plasmakanone",
+    });
+  });
+
+  it("stores the cost as the string the datasource uses", () => {
+    const { container } = render(<UnitWargearOptions />);
+    const costInput = Array.from(container.querySelectorAll("input")).find((i) => i.value === "5");
+    fireEvent.change(costInput, { target: { value: "15" } });
+    expect(capturedCard.wargearOptions[0].options[0].cost).toBe("15");
+  });
+
+  it("adds an option to a group, priced at nothing until edited", () => {
+    const { getAllByText, container } = render(<UnitWargearOptions />);
+    fireEvent.click(buttonNamed(getAllByText, "Add option"));
+    expect(capturedCard.wargearOptions[0].options).toHaveLength(2);
+    expect(capturedCard.wargearOptions[0].options[1]).toEqual({ name: { de: "" }, cost: "0" });
+    expect(byLabel(container, "Option 1")).toBeTruthy();
+  });
+
+  it("adds an empty group", () => {
+    const { getAllByText } = render(<UnitWargearOptions />);
+    fireEvent.click(buttonNamed(getAllByText, "Add wargear option"));
+    expect(capturedCard.wargearOptions).toHaveLength(2);
+    expect(capturedCard.wargearOptions[1]).toEqual({ instruction: { de: "" }, options: [] });
+  });
+
+  it("removes an option without touching the rest of the group", () => {
+    mockActiveCard.ref = card({
+      wargearOptions: [
+        {
+          instruction: { en: "Replace:" },
+          options: [
+            { name: { en: "Axe" }, cost: "0" },
+            { name: { en: "Hammer" }, cost: "5" },
+          ],
+        },
+      ],
+    });
+    const { container } = render(<UnitWargearOptions />);
+    // Each option row ends in its own remove button.
+    fireEvent.click(byLabel(container, "Option 1").querySelector("button"));
+    expect(capturedCard.wargearOptions[0].options).toEqual([{ name: { en: "Hammer" }, cost: "5" }]);
+  });
+
+  it("leaves the card's stored groups untouched when editing", () => {
+    const original = mockActiveCard.ref.wargearOptions;
+    const { getAllByText } = render(<UnitWargearOptions />);
+    fireEvent.click(buttonNamed(getAllByText, "Add option"));
+    expect(original[0].options).toHaveLength(1);
+  });
+
+  it("still edits the flat wargear text", () => {
+    mockActiveCard.ref = card({ wargear: [{ en: "None" }] });
+    const { getByTestId } = render(<UnitWargearOptions />);
+    fireEvent.change(getByTestId("md"), { target: { value: "Nimm eine Plasmapistole." } });
+    expect(capturedCard.wargear).toEqual([{ en: "None", de: "Nimm eine Plasmapistole." }]);
+  });
+});

--- a/src/Components/Warhammer40k-11e/__tests__/WeaponKeywordsCorruption.test.jsx
+++ b/src/Components/Warhammer40k-11e/__tests__/WeaponKeywordsCorruption.test.jsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression cover for the production crash
+// `TypeError: (x.keywords || []).map is not a function`.
+//
+// A datasource weapon column keyed `keywords` used to render a plain text input
+// over the profile's keywords array, so the first keystroke replaced
+// `["Assault"]` with `"A"`. Every consumer then did `(profile.keywords || [])
+// .map(...)` — and `"A" || []` is `"A"` — so opening the weapons tab threw and
+// the card white-screened. The corrupted value lives in the saved card, so the
+// crash survived refreshes.
+
+const mockUpdateActiveCard = vi.fn();
+const mockActiveCard = { ref: {} };
+
+vi.mock("../../../Hooks/useCardStorage", () => ({
+  useCardStorage: () => ({
+    activeCard: mockActiveCard.ref,
+    updateActiveCard: mockUpdateActiveCard,
+  }),
+}));
+
+vi.mock("../../../Hooks/useSettingsStorage", () => ({
+  useSettingsStorage: () => ({ settings: { language: "en" } }),
+}));
+
+vi.mock("../../../Hooks/use11eKeywordGlossary", () => ({
+  use11eKeywordGlossary: () => [],
+}));
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+import { UnitWeapon as UnitWeaponEditor } from "../UnitCardEditor/UnitWeapon";
+import { UnitWeapon as UnitWeaponCard } from "../UnitCard/UnitWeapon";
+
+const corruptedWeapon = {
+  profiles: [
+    {
+      name: { en: "Bolt rifle" },
+      range: "24",
+      attacks: "2",
+      skill: "3+",
+      strength: "4",
+      ap: "-1",
+      damage: "1",
+      // The corrupted shape: a string where an array belongs.
+      keywords: "T",
+    },
+  ],
+};
+
+describe("11e weapons with a corrupted string keywords value", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveCard.ref = { rangedWeapons: [corruptedWeapon] };
+  });
+
+  it("renders the weapons editor panel without throwing", () => {
+    expect(() => render(<UnitWeaponEditor weapon={corruptedWeapon} index={0} type="rangedWeapons" />)).not.toThrow();
+  });
+
+  it("shows the stray keyword as an editable keyword the user can delete", () => {
+    render(<UnitWeaponEditor weapon={corruptedWeapon} index={0} type="rangedWeapons" />);
+    expect(screen.getByText("T")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /add keyword/i })).toBeInTheDocument();
+  });
+
+  it("renders the card itself without throwing and shows the keyword", () => {
+    expect(() => render(<UnitWeaponCard weapon={corruptedWeapon} />)).not.toThrow();
+    expect(screen.getByText("T")).toBeInTheDocument();
+  });
+
+  it("still renders a profile with a proper keywords array", () => {
+    const healthy = {
+      profiles: [{ ...corruptedWeapon.profiles[0], keywords: ["Assault", "Torrent"] }],
+    };
+    render(<UnitWeaponCard weapon={healthy} />);
+    expect(screen.getByText("Assault")).toBeInTheDocument();
+    expect(screen.getByText("Torrent")).toBeInTheDocument();
+  });
+});

--- a/src/Helpers/__tests__/customDatasource.helpers.test.js
+++ b/src/Helpers/__tests__/customDatasource.helpers.test.js
@@ -15,6 +15,7 @@ import {
   formatCardBreakdown,
   exportDatasourceSchema,
   downloadJsonFile,
+  prepareDatasourceForImport,
 } from "../customDatasource.helpers";
 
 // Helper to create a minimal valid datasource
@@ -525,5 +526,61 @@ describe("downloadJsonFile", () => {
     removeChildSpy.mockRestore();
     URL.createObjectURL = originalCreateObjectURL;
     URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+});
+
+describe("prepareDatasourceForImport - reserved weapon columns", () => {
+  const datasourceWithColumn = (key) => ({
+    name: "Imported",
+    version: "1.0.0",
+    data: [],
+    schema: {
+      version: "1.0.0",
+      baseSystem: "blank",
+      cardTypes: [
+        {
+          key: "unit",
+          label: "Unit",
+          baseType: "unit",
+          schema: {
+            weaponTypes: {
+              label: "Weapons",
+              allowMultiple: true,
+              types: [
+                {
+                  key: "ranged",
+                  label: "Ranged",
+                  hasKeywords: true,
+                  hasProfiles: true,
+                  columns: [
+                    { key: "range", label: "Range", type: "string" },
+                    { key, label: "Extra", type: "string" },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  });
+
+  const importedColumns = (datasource) =>
+    prepareDatasourceForImport(datasource, "local").schema.cardTypes[0].schema.weaponTypes.types[0].columns;
+
+  // A weapon column keyed after a reserved profile field corrupts card data as
+  // soon as it is edited, so imports drop it instead of failing.
+  it("strips a weapon column that collides with a reserved profile field", () => {
+    expect(importedColumns(datasourceWithColumn("keywords")).map((c) => c.key)).toEqual(["range"]);
+  });
+
+  it("keeps ordinary weapon columns", () => {
+    expect(importedColumns(datasourceWithColumn("ap")).map((c) => c.key)).toEqual(["range", "ap"]);
+  });
+
+  it("imports a datasource without a schema unchanged", () => {
+    const result = prepareDatasourceForImport({ name: "No schema", version: "1.0.0", data: [] }, "local");
+    expect(result.schema).toBeUndefined();
+    expect(result.name).toBe("No schema");
   });
 });

--- a/src/Helpers/__tests__/customSchema.helpers.test.js
+++ b/src/Helpers/__tests__/customSchema.helpers.test.js
@@ -18,6 +18,7 @@ import {
   validateSchema,
   getDefaultValueForType,
   migrateCardToSchema,
+  stripReservedWeaponColumns,
 } from "../customSchema.helpers";
 
 describe("customSchema.helpers - constants", () => {
@@ -1879,5 +1880,88 @@ describe("customSchema.helpers - migrateCardToSchema", () => {
       expect(result.sections["new-section"]).toEqual([]);
       expect(result.sections["old-section"]).toBeUndefined();
     });
+  });
+});
+
+// A weapon column keyed after a reserved weapon profile field makes the card
+// editors render a generic text input over that field, so the first keystroke
+// replaces e.g. the keywords array with a string and the card stops rendering.
+describe("customSchema.helpers - stripReservedWeaponColumns", () => {
+  const schemaWithColumns = (columns) => ({
+    version: SCHEMA_VERSION,
+    baseSystem: "blank",
+    cardTypes: [
+      {
+        key: "unit",
+        label: "Unit",
+        baseType: "unit",
+        schema: {
+          weaponTypes: {
+            label: "Weapons",
+            allowMultiple: true,
+            types: [{ key: "ranged", label: "Ranged", hasKeywords: true, hasProfiles: true, columns }],
+          },
+        },
+      },
+    ],
+  });
+
+  const columnsOf = (schema) => schema.cardTypes[0].schema.weaponTypes.types[0].columns;
+
+  it("drops a column keyed after a reserved profile field", () => {
+    const schema = schemaWithColumns([
+      { key: "range", label: "Range", type: "string" },
+      { key: "keywords", label: "Keywords", type: "string" },
+    ]);
+    const result = stripReservedWeaponColumns(schema);
+    expect(columnsOf(result).map((c) => c.key)).toEqual(["range"]);
+  });
+
+  it("drops reserved keys regardless of casing", () => {
+    const schema = schemaWithColumns([
+      { key: "range", label: "Range", type: "string" },
+      { key: "Keywords", label: "Keywords", type: "string" },
+      { key: "NAME", label: "Name", type: "string" },
+      { key: "Active", label: "Active", type: "boolean" },
+      { key: "upgrade", label: "Upgrade", type: "boolean" },
+    ]);
+    expect(columnsOf(stripReservedWeaponColumns(schema)).map((c) => c.key)).toEqual(["range"]);
+  });
+
+  it("keeps columns whose keys merely resemble reserved fields", () => {
+    const schema = schemaWithColumns([
+      { key: "keyword", label: "Keyword", type: "string" },
+      { key: "keywordsNote", label: "Keywords note", type: "string" },
+    ]);
+    expect(columnsOf(stripReservedWeaponColumns(schema)).map((c) => c.key)).toEqual(["keyword", "keywordsNote"]);
+  });
+
+  it("returns the same reference when there is nothing to strip", () => {
+    const schema = schemaWithColumns([{ key: "range", label: "Range", type: "string" }]);
+    expect(stripReservedWeaponColumns(schema)).toBe(schema);
+  });
+
+  it("does not mutate the input schema", () => {
+    const schema = schemaWithColumns([
+      { key: "range", label: "Range", type: "string" },
+      { key: "keywords", label: "Keywords", type: "string" },
+    ]);
+    stripReservedWeaponColumns(schema);
+    expect(columnsOf(schema)).toHaveLength(2);
+  });
+
+  it("leaves a sanitised schema valid", () => {
+    const schema = schemaWithColumns([{ key: "keywords", label: "Keywords", type: "string" }]);
+    expect(() => stripReservedWeaponColumns(schema)).not.toThrow();
+    expect(columnsOf(stripReservedWeaponColumns(schema))).toEqual([]);
+  });
+
+  it("handles schemas with no card types or weapon types", () => {
+    expect(stripReservedWeaponColumns(null)).toBe(null);
+    expect(stripReservedWeaponColumns(undefined)).toBe(undefined);
+    const noCardTypes = { version: SCHEMA_VERSION, baseSystem: "blank" };
+    expect(stripReservedWeaponColumns(noCardTypes)).toBe(noCardTypes);
+    const noWeapons = { version: SCHEMA_VERSION, baseSystem: "blank", cardTypes: [{ key: "r", schema: {} }] };
+    expect(stripReservedWeaponColumns(noWeapons)).toBe(noWeapons);
   });
 });

--- a/src/Helpers/__tests__/listPoints.test.js
+++ b/src/Helpers/__tests__/listPoints.test.js
@@ -4,10 +4,15 @@ import {
   filterPointsTiersForArmy,
   getCardBaseCost,
   getCardDisplayCost,
+  getCardWargearCost,
   getCategoryPointsTotal,
+  getPaidWargearOptions,
   getPointsTierRestrictionLabel,
   getSelectablePointsTiers,
+  getWargearQuantity,
+  getWargearQuantityMax,
   isSamePointsTier,
+  setWargearQuantity,
 } from "../listPoints.helpers";
 
 const atrapos = (over = {}) => ({
@@ -205,6 +210,184 @@ describe("getCardDisplayCost", () => {
     const plain = { uuid: "a", unitSize: { cost: "100" } };
     expect(getCardDisplayCost(plain, undefined)).toBe(100);
     expect(getCardDisplayCost(knight("a"), undefined)).toBe(400);
+  });
+});
+
+describe("getPaidWargearOptions", () => {
+  // The shape of a Terminator Assault Squad: the same group repeated once per
+  // model, mixing a free swap with a paid one.
+  const assaultTerminators = {
+    source: "40k-11e",
+    wargearOptions: [
+      {
+        instruction: { en: "Any number of models can each have their power fist replaced." },
+        options: [
+          { name: { en: "Thunder hammer" }, cost: "5" },
+          { name: { en: "Lightning claw" }, cost: "0" },
+        ],
+      },
+      {
+        instruction: { en: "Any number of models can each have their power fist replaced." },
+        options: [
+          { name: { en: "Thunder hammer" }, cost: "5" },
+          { name: { en: "Lightning claw" }, cost: "0" },
+        ],
+      },
+    ],
+  };
+
+  it("keeps only the options that cost points", () => {
+    expect(getPaidWargearOptions(assaultTerminators)).toEqual([{ name: { en: "Thunder hammer" }, cost: 5 }]);
+  });
+
+  it("collapses the duplicate groups the 11e data repeats per model", () => {
+    expect(getPaidWargearOptions(assaultTerminators)).toHaveLength(1);
+  });
+
+  it("keeps distinct paid options and coerces string costs to numbers", () => {
+    const victrix = {
+      wargearOptions: [
+        {
+          options: [
+            { name: { en: "Banner of Macragge" }, cost: "15" },
+            { name: { en: "Blades of honour" }, cost: "10" },
+          ],
+        },
+      ],
+    };
+    expect(getPaidWargearOptions(victrix)).toEqual([
+      { name: { en: "Banner of Macragge" }, cost: 15 },
+      { name: { en: "Blades of honour" }, cost: 10 },
+    ]);
+  });
+
+  it("treats the same option at two prices as two choices", () => {
+    const card = {
+      wargearOptions: [
+        { options: [{ name: { en: "Storm shield" }, cost: "5" }] },
+        { options: [{ name: { en: "Storm shield" }, cost: "10" }] },
+      ],
+    };
+    expect(getPaidWargearOptions(card)).toHaveLength(2);
+  });
+
+  it("returns nothing for cards without (or with only free) wargear options", () => {
+    expect(
+      getPaidWargearOptions({ wargearOptions: [{ options: [{ name: { en: "Chainsword" }, cost: "0" }] }] }),
+    ).toEqual([]);
+    expect(getPaidWargearOptions({ source: "40k-10e" })).toEqual([]);
+    expect(getPaidWargearOptions(undefined)).toEqual([]);
+  });
+});
+
+describe("getWargearQuantity / setWargearQuantity", () => {
+  const hammer = { name: { en: "Thunder hammer" }, cost: 5 };
+
+  it("reports 0 for an option that is not taken", () => {
+    expect(getWargearQuantity([], hammer)).toBe(0);
+    expect(getWargearQuantity(undefined, hammer)).toBe(0);
+  });
+
+  it("adds, updates and removes an option", () => {
+    let selected = setWargearQuantity([], hammer, 2);
+    expect(selected).toEqual([{ name: { en: "Thunder hammer" }, cost: 5, quantity: 2 }]);
+    expect(getWargearQuantity(selected, hammer)).toBe(2);
+
+    selected = setWargearQuantity(selected, hammer, 3);
+    expect(selected).toHaveLength(1);
+    expect(getWargearQuantity(selected, hammer)).toBe(3);
+
+    // Dropping to zero removes the entry rather than storing a zero quantity.
+    expect(setWargearQuantity(selected, hammer, 0)).toEqual([]);
+  });
+
+  it("keeps existing entries in place so the list does not reshuffle", () => {
+    const banner = { name: { en: "Banner of Macragge" }, cost: 15 };
+    const selected = setWargearQuantity(setWargearQuantity([], hammer, 1), banner, 1);
+    const updated = setWargearQuantity(selected, hammer, 2);
+    expect(updated.map((entry) => entry.name.en)).toEqual(["Thunder hammer", "Banner of Macragge"]);
+  });
+
+  it("matches a selection saved as a plain string name", () => {
+    const selected = [{ name: "Thunder hammer", cost: 5, quantity: 2 }];
+    expect(getWargearQuantity(selected, hammer)).toBe(2);
+  });
+
+  it("counts a legacy entry with no quantity as one", () => {
+    expect(getWargearQuantity([{ name: { en: "Thunder hammer" }, cost: 5 }], hammer)).toBe(1);
+  });
+});
+
+describe("getWargearQuantityMax", () => {
+  it("caps quantities at the model count of the chosen tier", () => {
+    expect(getWargearQuantityMax({ models: "5", cost: "170" })).toBe(5);
+    expect(getWargearQuantityMax({ models: 10 })).toBe(10);
+  });
+
+  it("falls back to a sane cap when the tier says nothing useful", () => {
+    expect(getWargearQuantityMax(undefined)).toBe(10);
+    expect(getWargearQuantityMax({ models: "0" })).toBe(10);
+    expect(getWargearQuantityMax({ models: "?" })).toBe(10);
+  });
+});
+
+describe("getCardWargearCost", () => {
+  it("multiplies each selection by its quantity", () => {
+    const card = {
+      selectedWargear: [
+        { name: { en: "Thunder hammer" }, cost: 5, quantity: 3 },
+        { name: { en: "Banner of Macragge" }, cost: 15, quantity: 1 },
+      ],
+    };
+    expect(getCardWargearCost(card)).toBe(30);
+  });
+
+  it("counts an entry with no quantity once", () => {
+    expect(getCardWargearCost({ selectedWargear: [{ cost: 10 }] })).toBe(10);
+  });
+
+  it("accepts string costs", () => {
+    expect(getCardWargearCost({ selectedWargear: [{ cost: "10", quantity: 2 }] })).toBe(20);
+  });
+
+  it("is 0 for cards with no (or invalid) wargear selection", () => {
+    expect(getCardWargearCost({ source: "40k-10e" })).toBe(0);
+    expect(getCardWargearCost({ selectedWargear: [] })).toBe(0);
+    expect(getCardWargearCost({ selectedWargear: [{ cost: "free" }, null] })).toBe(0);
+    expect(getCardWargearCost({ selectedWargear: "nonsense" })).toBe(0);
+    expect(getCardWargearCost(undefined)).toBe(0);
+  });
+});
+
+describe("wargear points in list totals", () => {
+  const redemptor = (uuid) => ({
+    uuid,
+    id: "redemptor",
+    source: "40k-11e",
+    unitSize: { models: 1, cost: "210" },
+    selectedWargear: [{ name: { en: "Macro plasma incinerator" }, cost: 10, quantity: 1 }],
+  });
+
+  it("adds wargear to a card's displayed cost", () => {
+    const cards = [redemptor("a")];
+    expect(getCardDisplayCost(cards[0], cards)).toBe(220);
+  });
+
+  it("adds wargear to the category base, alongside the enhancement", () => {
+    const cards = [{ ...redemptor("a"), selectedEnhancement: { cost: "15" } }];
+    expect(computeCategoryPoints(cards)).toEqual({ base: 235, surcharge: 0, total: 235 });
+  });
+
+  it("keeps the displayed rows summing to the list total", () => {
+    const cards = [redemptor("a"), redemptor("b")];
+    const rows = cards.map((card) => getCardDisplayCost(card, cards));
+    expect(rows).toEqual([220, 220]);
+    expect(rows.reduce((sum, n) => sum + n, 0)).toBe(getCategoryPointsTotal(cards));
+  });
+
+  it("leaves cards without a wargear selection untouched", () => {
+    const cards = [{ source: "40k-10e", unitSize: { cost: "100" } }];
+    expect(computeCategoryPoints(cards)).toEqual({ base: 100, surcharge: 0, total: 100 });
   });
 });
 

--- a/src/Helpers/__tests__/listPoints.test.js
+++ b/src/Helpers/__tests__/listPoints.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  clampWargearQuantities,
   computeCategoryPoints,
   filterPointsTiersForArmy,
   getCardBaseCost,
@@ -378,6 +379,45 @@ describe("getWargearQuantityMax", () => {
     expect(getWargearQuantityMax(undefined)).toBe(10);
     expect(getWargearQuantityMax({ models: "0" })).toBe(10);
     expect(getWargearQuantityMax({ models: "?" })).toBe(10);
+  });
+});
+
+describe("clampWargearQuantities", () => {
+  const thunderHammer = { name: { en: "Thunder hammer" }, cost: 5 };
+
+  it("caps a quantity that exceeds the new tier's model count", () => {
+    const selected = [{ ...thunderHammer, quantity: 10 }];
+    expect(clampWargearQuantities(selected, { models: "5" })).toEqual([{ ...thunderHammer, quantity: 5 }]);
+  });
+
+  it("leaves a quantity the tier still allows untouched", () => {
+    const selected = [{ ...thunderHammer, quantity: 3 }];
+    expect(clampWargearQuantities(selected, { models: "5" })).toBe(selected);
+  });
+
+  it("caps every entry independently", () => {
+    const selected = [
+      { ...thunderHammer, quantity: 8 },
+      { name: { en: "Storm shield" }, cost: 10, quantity: 2 },
+    ];
+    expect(clampWargearQuantities(selected, { models: "5" })).toEqual([
+      { ...thunderHammer, quantity: 5 },
+      { name: { en: "Storm shield" }, cost: 10, quantity: 2 },
+    ]);
+  });
+
+  it("treats a missing quantity as one, so it never gets capped", () => {
+    const selected = [thunderHammer];
+    expect(clampWargearQuantities(selected, { models: "1" })).toBe(selected);
+  });
+
+  it("uses the fallback cap when the tier says nothing useful", () => {
+    const selected = [{ ...thunderHammer, quantity: 25 }];
+    expect(clampWargearQuantities(selected, undefined)).toEqual([{ ...thunderHammer, quantity: 10 }]);
+  });
+
+  it("is safe for a card with no selection", () => {
+    expect(clampWargearQuantities(undefined, { models: "5" })).toEqual([]);
   });
 });
 

--- a/src/Helpers/__tests__/listPoints.test.js
+++ b/src/Helpers/__tests__/listPoints.test.js
@@ -9,6 +9,7 @@ import {
   getPaidWargearOptions,
   getPointsTierRestrictionLabel,
   getSelectablePointsTiers,
+  getWargearOptionGroups,
   getWargearQuantity,
   getWargearQuantityMax,
   isSamePointsTier,
@@ -210,6 +211,55 @@ describe("getCardDisplayCost", () => {
     const plain = { uuid: "a", unitSize: { cost: "100" } };
     expect(getCardDisplayCost(plain, undefined)).toBe(100);
     expect(getCardDisplayCost(knight("a"), undefined)).toBe(400);
+  });
+});
+
+describe("getWargearOptionGroups", () => {
+  const group = {
+    instruction: { en: "Any number of models can each have their power fist replaced." },
+    options: [
+      { name: { en: "Thunder hammer" }, cost: "5" },
+      { name: { en: "Lightning claw" }, cost: "0" },
+    ],
+  };
+
+  it("keeps free options as well as paid ones, with numeric costs", () => {
+    expect(getWargearOptionGroups({ wargearOptions: [group] })).toEqual([
+      {
+        instruction: { en: "Any number of models can each have their power fist replaced." },
+        options: [
+          { name: { en: "Thunder hammer" }, cost: 5 },
+          { name: { en: "Lightning claw" }, cost: 0 },
+        ],
+      },
+    ]);
+  });
+
+  it("collapses the identical groups the 11e data repeats per model", () => {
+    expect(getWargearOptionGroups({ wargearOptions: [group, { ...group }] })).toHaveLength(1);
+  });
+
+  it("keeps groups that differ in their instruction or in their prices", () => {
+    const other = { ...group, instruction: { en: "One model can be equipped with:" } };
+    const dearer = { ...group, options: [{ name: { en: "Thunder hammer" }, cost: "10" }] };
+    expect(getWargearOptionGroups({ wargearOptions: [group, other, dearer] })).toHaveLength(3);
+  });
+
+  it("keeps the language-keyed shape of instructions and names", () => {
+    const localized = {
+      wargearOptions: [
+        { instruction: { en: "Replace:", de: "Ersetze:" }, options: [{ name: { en: "Axe", de: "Axt" } }] },
+      ],
+    };
+    const [only] = getWargearOptionGroups(localized);
+    expect(only.instruction).toEqual({ en: "Replace:", de: "Ersetze:" });
+    expect(only.options[0]).toEqual({ name: { en: "Axe", de: "Axt" }, cost: 0 });
+  });
+
+  it("drops groups that offer nothing, and is safe on cards without wargear", () => {
+    expect(getWargearOptionGroups({ wargearOptions: [{ instruction: { en: "Nothing to pick" } }] })).toEqual([]);
+    expect(getWargearOptionGroups({ source: "40k-10e" })).toEqual([]);
+    expect(getWargearOptionGroups(undefined)).toEqual([]);
   });
 });
 

--- a/src/Helpers/__tests__/weaponProfile.helpers.test.js
+++ b/src/Helpers/__tests__/weaponProfile.helpers.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { RESERVED_WEAPON_PROFILE_KEYS, isReservedWeaponProfileKey, normalizeKeywords } from "../weaponProfile.helpers";
+
+describe("normalizeKeywords", () => {
+  it("returns arrays unchanged (same reference)", () => {
+    const keywords = ["Assault", "Rapid Fire 1"];
+    expect(normalizeKeywords(keywords)).toBe(keywords);
+  });
+
+  it("returns an empty array unchanged", () => {
+    expect(normalizeKeywords([])).toEqual([]);
+  });
+
+  it("wraps a non-empty string in an array", () => {
+    expect(normalizeKeywords("T")).toEqual(["T"]);
+    expect(normalizeKeywords("Torrent")).toEqual(["Torrent"]);
+  });
+
+  it("trims a wrapped string", () => {
+    expect(normalizeKeywords("  Torrent  ")).toEqual(["Torrent"]);
+  });
+
+  it("returns an empty array for empty or whitespace-only strings", () => {
+    expect(normalizeKeywords("")).toEqual([]);
+    expect(normalizeKeywords("   ")).toEqual([]);
+  });
+
+  it("returns an empty array for null and undefined", () => {
+    expect(normalizeKeywords(null)).toEqual([]);
+    expect(normalizeKeywords(undefined)).toEqual([]);
+  });
+
+  it("returns an empty array for numbers, booleans and objects", () => {
+    expect(normalizeKeywords(0)).toEqual([]);
+    expect(normalizeKeywords(42)).toEqual([]);
+    expect(normalizeKeywords(true)).toEqual([]);
+    expect(normalizeKeywords({ 0: "T", length: 1 })).toEqual([]);
+  });
+});
+
+describe("isReservedWeaponProfileKey", () => {
+  it("flags every reserved profile field", () => {
+    RESERVED_WEAPON_PROFILE_KEYS.forEach((key) => {
+      expect(isReservedWeaponProfileKey(key)).toBe(true);
+    });
+  });
+
+  it("matches case-insensitively and ignores surrounding whitespace", () => {
+    expect(isReservedWeaponProfileKey("Keywords")).toBe(true);
+    expect(isReservedWeaponProfileKey("KEYWORDS")).toBe(true);
+    expect(isReservedWeaponProfileKey("  keywords ")).toBe(true);
+  });
+
+  it("allows ordinary column keys", () => {
+    ["range", "attacks", "skill", "strength", "ap", "damage", "keyword", "keywordsNote"].forEach((key) => {
+      expect(isReservedWeaponProfileKey(key)).toBe(false);
+    });
+  });
+
+  it("is safe for non-string input", () => {
+    expect(isReservedWeaponProfileKey(undefined)).toBe(false);
+    expect(isReservedWeaponProfileKey(null)).toBe(false);
+    expect(isReservedWeaponProfileKey(7)).toBe(false);
+  });
+});

--- a/src/Helpers/customDatasource.helpers.js
+++ b/src/Helpers/customDatasource.helpers.js
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
-import { validateSchema, getDefaultValueForType } from "./customSchema.helpers";
+import { validateSchema, getDefaultValueForType, stripReservedWeaponColumns } from "./customSchema.helpers";
 
 // Valid display formats that map to existing card renderers
 export const VALID_DISPLAY_FORMATS = ["40k-10e", "40k", "basic", "necromunda", "aos", "custom"];
@@ -300,6 +300,10 @@ export const prepareDatasourceForImport = (datasource, sourceType, sourceUrl = n
 
   return {
     ...datasource,
+    // Older/hand-edited schemas may declare a weapon column keyed after a
+    // reserved profile field (e.g. `keywords`), which corrupts card data as
+    // soon as it is edited. Strip those on the way in.
+    ...(datasource.schema ? { schema: stripReservedWeaponColumns(datasource.schema) } : {}),
     id: storageId,
     uuid: uuidv4(),
     sourceType,

--- a/src/Helpers/customSchema.helpers.js
+++ b/src/Helpers/customSchema.helpers.js
@@ -8,6 +8,7 @@
 
 import { WARHAMMER_40K_10E_KEYWORD_GLOSSARY } from "./keywordGlossaryDefaults";
 import { WARHAMMER_40K_11E_KEYWORD_GLOSSARY } from "./keywordGlossary11eDefaults";
+import { isReservedWeaponProfileKey } from "./weaponProfile.helpers";
 
 // Valid base types for card type definitions
 export const VALID_BASE_TYPES = ["unit", "rule", "enhancement", "stratagem"];
@@ -929,6 +930,53 @@ const validateEnhancementSchema = (schema, path) => {
  */
 const validateStratagemSchema = (schema, path) => {
   return validateFieldArray(schema.fields, `${path}.fields`);
+};
+
+/**
+ * Drops weapon columns whose `key` collides with a reserved weapon profile
+ * field (see `RESERVED_WEAPON_PROFILE_KEYS`).
+ *
+ * Such a column makes the card editors render a generic text input over a field
+ * the data model owns — the first keystroke replaces e.g. the keywords array
+ * with a string, and the card can no longer render. The schema editor blocks
+ * these keys, but imported and older schemas may still carry one, so they are
+ * stripped on the way in rather than rejected: keeping the datasource usable
+ * matters more than the extra column.
+ *
+ * Returns the schema unchanged (same reference) when there is nothing to strip.
+ *
+ * @param {object} schema - A datasource schema
+ * @returns {object} The schema, with colliding weapon columns removed
+ */
+export const stripReservedWeaponColumns = (schema) => {
+  if (!schema || typeof schema !== "object" || !Array.isArray(schema.cardTypes)) return schema;
+
+  let changed = false;
+  const cardTypes = schema.cardTypes.map((cardType) => {
+    const types = cardType?.schema?.weaponTypes?.types;
+    if (!Array.isArray(types)) return cardType;
+
+    let typeChanged = false;
+    const cleanedTypes = types.map((wt) => {
+      if (!Array.isArray(wt?.columns)) return wt;
+      const columns = wt.columns.filter((col) => !isReservedWeaponProfileKey(col?.key));
+      if (columns.length === wt.columns.length) return wt;
+      typeChanged = true;
+      return { ...wt, columns };
+    });
+    if (!typeChanged) return cardType;
+
+    changed = true;
+    return {
+      ...cardType,
+      schema: {
+        ...cardType.schema,
+        weaponTypes: { ...cardType.schema.weaponTypes, types: cleanedTypes },
+      },
+    };
+  });
+
+  return changed ? { ...schema, cardTypes } : schema;
 };
 
 /**

--- a/src/Helpers/listCategories.helpers.js
+++ b/src/Helpers/listCategories.helpers.js
@@ -1,5 +1,5 @@
 import { capitalizeSentence } from "./external.helpers";
-import { getCardBaseCost } from "./listPoints.helpers";
+import { getCardBaseCost, getCardWargearCost } from "./listPoints.helpers";
 import { localize } from "./localization.helpers";
 
 // ===========================================
@@ -239,7 +239,8 @@ export const format40kListText = (sortedCards, sections) => {
     if (cards.length === 0) return;
     listText += `\n\n${clipboardLabel}`;
     sortCards(cards).forEach((val) => {
-      const totalCost = getCardBaseCost(val) + (Number(val.selectedEnhancement?.cost) || 0) || "?";
+      const totalCost =
+        getCardBaseCost(val) + (Number(val.selectedEnhancement?.cost) || 0) + getCardWargearCost(val) || "?";
       listText += `\n\n${val.name} ${val.unitSize?.models > 1 ? val.unitSize?.models + "x" : ""} (${totalCost} pts)`;
       if (val.isWarlord) {
         listText += `\n   • Warlord`;
@@ -247,6 +248,10 @@ export const format40kListText = (sortedCards, sections) => {
       if (val.selectedEnhancement) {
         listText += `\n   • Enhancements: ${capitalizeSentence(val.selectedEnhancement?.name)} (+${val.selectedEnhancement?.cost} pts)`;
       }
+      (val.selectedWargear || []).forEach((entry) => {
+        const quantity = Number(entry?.quantity) > 1 ? `${entry.quantity}x ` : "";
+        listText += `\n   • Wargear: ${quantity}${localize(entry?.name)} (+${getCardWargearCost({ selectedWargear: [entry] })} pts)`;
+      });
     });
   };
 

--- a/src/Helpers/listPoints.helpers.js
+++ b/src/Helpers/listPoints.helpers.js
@@ -139,36 +139,75 @@ export const getCardBaseCost = (card) => {
   return 0;
 };
 
+/** A wargear group's identity: its instruction plus the options it offers. */
+const wargearGroupKey = (instruction, options) =>
+  `${localize(instruction, "en")}::${options.map((option) => `${localize(option.name, "en")}@${option.cost}`).join("|")}`;
+
+/**
+ * Every wargear choice a card offers, free ones included, ready to show on the
+ * card back and in the editor.
+ *
+ * The 11e data repeats an identical option group once per model in the unit (a
+ * Terminator Assault Squad lists the same thunder hammer swap twice), which
+ * reads as noise on a card, so identical groups — same instruction, same
+ * options at the same prices — are collapsed into one.
+ *
+ * Groups that offer nothing are dropped; a bare instruction has nothing to
+ * choose from.
+ *
+ * @param {Object} card
+ * @returns {Array<{ instruction: string|Object, options: Array<{ name: string|Object, cost: number }> }>}
+ *   `instruction` and `name` keep their stored (possibly language-keyed) shape
+ *   so callers can localise them; `cost` is normalised to a number (0 when the
+ *   data has none).
+ */
+export const getWargearOptionGroups = (card) => {
+  const groups = Array.isArray(card?.wargearOptions) ? card.wargearOptions : [];
+  const seen = new Set();
+  const result = [];
+
+  for (const group of groups) {
+    const options = (Array.isArray(group?.options) ? group.options : []).map((option) => {
+      const cost = Number(option?.cost);
+      return { name: option?.name, cost: Number.isFinite(cost) ? cost : 0 };
+    });
+    if (options.length === 0) continue;
+
+    // Matched in English, the one language every entry is guaranteed to have.
+    const key = wargearGroupKey(group?.instruction, options);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push({ instruction: group?.instruction, options });
+  }
+
+  return result;
+};
+
 /**
  * The wargear options a card charges points for, ready to offer in the list
- * builder. Free options (cost "0", the overwhelming majority) are dropped as
+ * builder. Free options (cost 0, the overwhelming majority) are dropped as
  * noise — they change the model's loadout, not its price.
  *
- * The 11e data repeats an identical option group once per model in the unit
- * (a Terminator Assault Squad lists the same thunder hammer swap twice), so
- * options are deduplicated by name + cost. That collapses those literal
- * duplicates and, incidentally, the same paid item offered under two different
- * instructions — for pricing purposes they are one choice with a quantity.
+ * On top of the group-level deduplication of getWargearOptionGroups, options
+ * are deduplicated by name + cost. That also collapses the same paid item
+ * offered under two different instructions — for pricing purposes they are one
+ * choice with a quantity.
  *
  * @param {Object} card
  * @returns {Array<{ name: string|Object, cost: number }>} `name` keeps its
  *   stored (possibly language-keyed) shape so callers can localise it.
  */
 export const getPaidWargearOptions = (card) => {
-  const groups = Array.isArray(card?.wargearOptions) ? card.wargearOptions : [];
   const seen = new Set();
   const paid = [];
 
-  for (const group of groups) {
-    const options = Array.isArray(group?.options) ? group.options : [];
-    for (const option of options) {
-      const cost = Number(option?.cost);
-      if (!Number.isFinite(cost) || cost <= 0) continue;
-      // Matched in English, the one language every entry is guaranteed to have.
-      const key = `${localize(option?.name, "en")}::${cost}`;
+  for (const group of getWargearOptionGroups(card)) {
+    for (const option of group.options) {
+      if (option.cost <= 0) continue;
+      const key = `${localize(option.name, "en")}::${option.cost}`;
       if (seen.has(key)) continue;
       seen.add(key);
-      paid.push({ name: option?.name, cost });
+      paid.push({ name: option.name, cost: option.cost });
     }
   }
 

--- a/src/Helpers/listPoints.helpers.js
+++ b/src/Helpers/listPoints.helpers.js
@@ -12,6 +12,11 @@ import { localize } from "./localization.helpers";
 // `afterSelections` selections adds `cost` to the list total (independent of the
 // unit's size), e.g. Cerastus Knight Atrapos is 405 for the first, +20 for each
 // after that.
+//
+// A handful of 11e datasheets also charge for wargear: `wargearOptions` groups
+// of `{ instruction, options: [{ name, cost }] }`. Most options are free, but
+// e.g. a Redemptor Dreadnought's macro plasma incinerator costs 10. What the
+// user picked is stored on the card as `selectedWargear`, see getCardWargearCost.
 
 /**
  * The size tiers a user can pick for a card in a list. 10e tiers carry an
@@ -134,6 +139,124 @@ export const getCardBaseCost = (card) => {
   return 0;
 };
 
+/**
+ * The wargear options a card charges points for, ready to offer in the list
+ * builder. Free options (cost "0", the overwhelming majority) are dropped as
+ * noise — they change the model's loadout, not its price.
+ *
+ * The 11e data repeats an identical option group once per model in the unit
+ * (a Terminator Assault Squad lists the same thunder hammer swap twice), so
+ * options are deduplicated by name + cost. That collapses those literal
+ * duplicates and, incidentally, the same paid item offered under two different
+ * instructions — for pricing purposes they are one choice with a quantity.
+ *
+ * @param {Object} card
+ * @returns {Array<{ name: string|Object, cost: number }>} `name` keeps its
+ *   stored (possibly language-keyed) shape so callers can localise it.
+ */
+export const getPaidWargearOptions = (card) => {
+  const groups = Array.isArray(card?.wargearOptions) ? card.wargearOptions : [];
+  const seen = new Set();
+  const paid = [];
+
+  for (const group of groups) {
+    const options = Array.isArray(group?.options) ? group.options : [];
+    for (const option of options) {
+      const cost = Number(option?.cost);
+      if (!Number.isFinite(cost) || cost <= 0) continue;
+      // Matched in English, the one language every entry is guaranteed to have.
+      const key = `${localize(option?.name, "en")}::${cost}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      paid.push({ name: option?.name, cost });
+    }
+  }
+
+  return paid;
+};
+
+/** Identity of a wargear selection: its English name paired with its price. */
+const wargearKey = (entry) => `${localize(entry?.name, "en")}::${Number(entry?.cost)}`;
+
+/**
+ * How many of `option` the current selection holds.
+ *
+ * @param {Array|undefined} selected - a card's `selectedWargear`
+ * @param {Object} option - an entry from getPaidWargearOptions
+ * @returns {number} 0 when the option is not taken
+ */
+export const getWargearQuantity = (selected, option) => {
+  const list = Array.isArray(selected) ? selected : [];
+  const match = list.find((entry) => wargearKey(entry) === wargearKey(option));
+  const quantity = Number(match?.quantity);
+  if (!match) return 0;
+  return Number.isFinite(quantity) && quantity > 0 ? quantity : 1;
+};
+
+/**
+ * Set how many of `option` the selection holds, returning a new array. A
+ * quantity of 0 (or less) drops the entry entirely rather than storing a zero,
+ * so a card that takes no paid wargear saves an empty list.
+ *
+ * Existing entries keep their position so the section does not reshuffle while
+ * the user clicks the stepper.
+ *
+ * @param {Array|undefined} selected - a card's `selectedWargear`
+ * @param {Object} option - an entry from getPaidWargearOptions
+ * @param {number} quantity
+ * @returns {Array}
+ */
+export const setWargearQuantity = (selected, option, quantity) => {
+  const next = Array.isArray(selected) ? [...selected] : [];
+  const index = next.findIndex((entry) => wargearKey(entry) === wargearKey(option));
+  const count = Number(quantity);
+
+  if (!Number.isFinite(count) || count <= 0) {
+    if (index >= 0) next.splice(index, 1);
+    return next;
+  }
+
+  const entry = { name: option?.name, cost: Number(option?.cost), quantity: count };
+  if (index >= 0) next[index] = entry;
+  else next.push(entry);
+  return next;
+};
+
+// Ceiling for wargear quantities when the chosen size tier does not say how many
+// models the unit has. Generous enough not to block any real unit, low enough to
+// keep an accidental click from inflating a list.
+const WARGEAR_QUANTITY_FALLBACK_MAX = 10;
+
+/**
+ * The most copies of one wargear option a unit can take: its model count, since
+ * instructions like "any number of models can each have..." are per model.
+ *
+ * @param {Object|undefined} unitSize - the selected points tier
+ * @returns {number}
+ */
+export const getWargearQuantityMax = (unitSize) => {
+  const models = Number(unitSize?.models);
+  return Number.isFinite(models) && models > 0 ? models : WARGEAR_QUANTITY_FALLBACK_MAX;
+};
+
+/**
+ * The points a card's selected wargear adds. An entry without a usable quantity
+ * counts once, so a selection saved before quantities existed still prices.
+ *
+ * @param {Object} card
+ * @returns {number}
+ */
+export const getCardWargearCost = (card) => {
+  const selected = Array.isArray(card?.selectedWargear) ? card.selectedWargear : [];
+
+  return selected.reduce((sum, entry) => {
+    const cost = Number(entry?.cost);
+    if (!Number.isFinite(cost)) return sum;
+    const quantity = Number(entry?.quantity);
+    return sum + cost * (Number.isFinite(quantity) && quantity > 0 ? quantity : 1);
+  }, 0);
+};
+
 /** Datasheet identity used to group duplicate selections. */
 const datasheetKey = (card) => `${card?.source ?? ""}::${card?.id ?? card?.name ?? ""}`;
 
@@ -142,8 +265,8 @@ const isSameCard = (a, b) => (a?.uuid != null && b?.uuid != null ? a.uuid === b.
 
 /**
  * The points a single card contributes to its list: its base cost, its
- * enhancement, and — for the copies beyond `additionalCost.afterSelections` —
- * that datasheet's roster surcharge.
+ * enhancement, its paid wargear, and — for the copies beyond
+ * `additionalCost.afterSelections` — that datasheet's roster surcharge.
  *
  * The surcharge is an army-level rule, but it has to be attributed to a row so
  * the displayed unit costs add up to the list total (e.g. two Knight Castellans
@@ -161,6 +284,8 @@ export const getCardDisplayCost = (card, cards) => {
   const enhancement = Number(card?.selectedEnhancement?.cost);
   if (Number.isFinite(enhancement)) cost += enhancement;
 
+  cost += getCardWargearCost(card);
+
   const additional = card?.additionalCost;
   if (additional?.cost != null && Array.isArray(cards)) {
     const key = datasheetKey(card);
@@ -175,9 +300,12 @@ export const getCardDisplayCost = (card, cards) => {
 
 /**
  * Total points for a set of cards, split into the base total (sum of unit sizes
- * + enhancements) and the roster surcharge from duplicated datasheets that carry
- * an `additionalCost`. Duplicates are grouped by datasheet identity (`id` +
- * `source`).
+ * + enhancements + paid wargear) and the roster surcharge from duplicated
+ * datasheets that carry an `additionalCost`. Duplicates are grouped by datasheet
+ * identity (`id` + `source`).
+ *
+ * The base total must stay in step with getCardDisplayCost: together they are
+ * what makes the displayed rows add up to the list total.
  *
  * @param {Array} cards
  * @returns {{ base: number, surcharge: number, total: number }}
@@ -192,6 +320,8 @@ export const computeCategoryPoints = (cards) => {
 
     const enhancement = Number(card?.selectedEnhancement?.cost);
     if (Number.isFinite(enhancement)) base += enhancement;
+
+    base += getCardWargearCost(card);
 
     const additional = card?.additionalCost;
     if (additional && additional.cost != null) {

--- a/src/Helpers/listPoints.helpers.js
+++ b/src/Helpers/listPoints.helpers.js
@@ -279,6 +279,34 @@ export const getWargearQuantityMax = (unitSize) => {
 };
 
 /**
+ * Cap every selected quantity at what the given size tier allows, so switching
+ * to a smaller tier after picking wargear cannot leave a selection that prices
+ * more models than the unit has.
+ *
+ * Returns the original array when nothing needed capping, so callers can store
+ * the result without triggering a needless re-render.
+ *
+ * @param {Array|undefined} selected - a card's `selectedWargear`
+ * @param {Object|undefined} unitSize - the selected points tier
+ * @returns {Array}
+ */
+export const clampWargearQuantities = (selected, unitSize) => {
+  const list = Array.isArray(selected) ? selected : [];
+  const max = getWargearQuantityMax(unitSize);
+  let capped = false;
+
+  const next = list.map((entry) => {
+    const quantity = Number(entry?.quantity);
+    const current = Number.isFinite(quantity) && quantity > 0 ? quantity : 1;
+    if (current <= max) return entry;
+    capped = true;
+    return { ...entry, quantity: max };
+  });
+
+  return capped ? next : list;
+};
+
+/**
  * The points a card's selected wargear adds. An entry without a usable quantity
  * counts once, so a selection saved before quantities existed still prices.
  *

--- a/src/Helpers/weaponProfile.helpers.js
+++ b/src/Helpers/weaponProfile.helpers.js
@@ -1,0 +1,51 @@
+/**
+ * Helpers for weapon profile data that both the community app and the premium
+ * card editor consume. Kept dependency-free so gdc-premium can import it
+ * through the shared-helpers resolver.
+ */
+
+/**
+ * Field names the weapon profile data model owns. A schema column may not use
+ * one of these as its `key`: the generic column editors would render a plain
+ * text input over the reserved field and overwrite its real (array/boolean)
+ * value with a string, corrupting the card.
+ *
+ * - `name`     — profile name (rendered separately from the columns)
+ * - `active`   — per-profile visibility toggle
+ * - `keywords` — array of weapon keyword tags
+ * - `upgrade`  — marks a parent-child child profile
+ */
+export const RESERVED_WEAPON_PROFILE_KEYS = ["name", "active", "keywords", "upgrade"];
+
+/**
+ * Whether a schema column key collides with a reserved weapon profile field.
+ * Comparison is case-insensitive and trims surrounding whitespace.
+ *
+ * @param {string} key
+ * @returns {boolean}
+ */
+export const isReservedWeaponProfileKey = (key) =>
+  typeof key === "string" && RESERVED_WEAPON_PROFILE_KEYS.includes(key.trim().toLowerCase());
+
+/**
+ * Coerces a weapon profile's `keywords` value into an array.
+ *
+ * Saved cards can carry a plain string here — a schema column keyed `keywords`
+ * used to render a text input over the array, so a single keystroke replaced
+ * `["Assault"]` with `"A"`. Every consumer used `(profile.keywords || []).map`,
+ * and `"A" || []` is `"A"`, so rendering threw and the editor white-screened.
+ * Normalising on read heals those cards: the stray characters surface as one
+ * ordinary keyword tag the user can delete.
+ *
+ * @param {*} value - Raw `keywords` value off a weapon profile
+ * @returns {Array} The value if it is already an array, `[value]` for a
+ *   non-empty string, otherwise an empty array
+ */
+export const normalizeKeywords = (value) => {
+  if (Array.isArray(value)) return value;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  return [];
+};

--- a/src/styles/40k-10e.less
+++ b/src/styles/40k-10e.less
@@ -74,6 +74,15 @@
           white-space: nowrap;
         }
       }
+
+      // 11th edition prices a tier for one detachment or faction; shown under
+      // the model count so it never reads as another tier keyword.
+      .points_restriction {
+        display: block;
+        font-size: 0.8em;
+        font-weight: 400;
+        font-style: italic;
+      }
     }
   }
 }
@@ -2536,6 +2545,19 @@
                   color: black;
                   font-weight: 400;
                   padding-left: 4px;
+                }
+              }
+              // 11th edition structured wargear: the instruction keeps the
+              // square bullet of a plain item, the swaps it allows are listed
+              // underneath it.
+              .wargear-group {
+                .wargear-options {
+                  padding-left: 16px;
+                  .wargear-option {
+                    &:before {
+                      content: "–";
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Summary

- Add missing "Wargear abilities" and "Special abilities" panels to the 11e card editor sidebar (both rendered on the card and editable on mobile, but absent from the desktop editors)
- Add wargear points support to the list builder: paid wargear options are selectable with quantity steppers in the unit config modal (desktop and mobile) and counted in all list totals and exports
- Show detachment/faction-restricted points tiers on the card (popover and show-all views) and make the restriction editable per tier
- Render structured wargear options with point costs on the card back instead of the flat "None" text, with a matching structured editor
- Fix weapons tab crash when a weapon profile's keywords became a string (reserved schema column key collision); corrupted cards heal on next load, reserved keys are now rejected in the schema editor and stripped on import

Companion PR in gdc-premium covers the premium card-data editor side of the keywords fix.

## Test plan

- yarn test:ci: 3159 tests across 194 files, all passing
- Browser-verified against the live 11e datasource (editor panels, Redemptor Dreadnought wargear cost 355 -> 365 in list totals)