### PR TITLE
Stop 11e markup doubling every line break

### DIFF
--- a/src/Components/Warhammer40k-11e/UnitCard/UnitAbilityDescription.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCard/UnitAbilityDescription.jsx
@@ -52,6 +52,11 @@ export const MarkupText = ({ content }) => {
       remarkPlugins={[[remarkGfm, { stringLength: stringWidth }], remarkBreaks]}
       rehypePlugins={[rehypeRaw, [rehypeSanitize, schema11e]]}
       components={{
+        // `remarkBreaks` already turns every newline into a <br>, so the text
+        // must not also honour the literal newline it left behind: `pre-wrap`
+        // (inherited from `.item`) would render both and put a blank line
+        // between every bullet. Markdown strips leading indentation before we
+        // get here, so there is no whitespace left for `pre-wrap` to preserve.
         p(props) {
           const { node, ...rest } = props;
           paragraphCount++;
@@ -59,11 +64,11 @@ export const MarkupText = ({ content }) => {
             return (
               <React.Fragment>
                 <span style={{ display: "block", height: "8px" }} aria-hidden="true" />
-                <span style={{ whiteSpace: "pre-wrap" }} {...rest} />
+                <span style={{ whiteSpace: "normal" }} {...rest} />
               </React.Fragment>
             );
           }
-          return <span style={{ whiteSpace: "pre-wrap" }} {...rest} />;
+          return <span style={{ whiteSpace: "normal" }} {...rest} />;
         },
         br() {
           return <br />;

--- a/src/Components/Warhammer40k-11e/__tests__/UnitAbilityDescription.test.jsx
+++ b/src/Components/Warhammer40k-11e/__tests__/UnitAbilityDescription.test.jsx
@@ -42,4 +42,23 @@ describe("MarkupText", () => {
     const { container } = render(<MarkupText content={"<ul><li>first</li><li>second</li></ul>"} />);
     expect(container.querySelectorAll("li")).toHaveLength(2);
   });
+
+  // `remarkBreaks` emits a <br> for every newline and leaves the newline in the
+  // text. Honouring both — which `white-space: pre-wrap` on the surrounding
+  // `.item` would do — put a blank line between every bullet of a wargear
+  // instruction, so the paragraph has to collapse the leftover newline itself.
+  it("breaks each line exactly once, so bullet lines stay together", () => {
+    const { container } = render(
+      <MarkupText content={"Replace with one of the following:\n◦ 1 power fist\n◦ 1 plasma pistol"} />,
+    );
+
+    const paragraph = container.querySelector("span");
+    expect(paragraph.style.whiteSpace).toBe("normal");
+    expect(container.querySelectorAll("br")).toHaveLength(2);
+  });
+
+  it("still separates real paragraphs", () => {
+    const { container } = render(<MarkupText content={"First paragraph.\n\nSecond paragraph."} />);
+    expect(container.querySelector('span[aria-hidden="true"]')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## What

Render 11e markup line breaks once instead of twice, by setting `white-space: normal` on the paragraph spans in `MarkupText`.

## Why

Multi-line wargear instructions rendered with a blank line between every bullet:

```
This model's blessed halberd can be replaced with one of the following:

- 1 holy eviscerator

- 1 Ministorum hand flamer and 1 power weapon
```

Two mechanisms were both breaking the line. `remarkBreaks` emits a `<br>` for every newline and leaves the newline in the text node, and `white-space: pre-wrap` (inherited from `.item`) then rendered that leftover newline as a second break. The generated HTML shows it directly:

```html
<span style="white-space: pre-wrap;">...one of the following:<br>
&#9702; 1 heavy bolt pistol and 1 power fist<br>
```

`pre-wrap` was not preserving anything else here: markdown strips leading indentation before this layer, so collapsing whitespace costs nothing and the `<br>` alone gives exactly one break.

## Scope

This affects all 11e markup with newlines, not just wargear options: the box-bullet lists in Leader, Transport and Support blocks had the same doubling and are now tight as well. Real paragraph breaks (a blank line in the source) keep their deliberate 8px gap.

## Test plan

- 3171 tests passing, lint and prettier clean
- Two new tests: one pinning a single `<br>` per newline plus the collapsed white-space, one asserting real paragraphs stay separated
- Verified in the browser against the live 11e datasource (Canoness with Jump Pack): bullet lines and the Leader block now sit directly under each other, no new console errors

Follow-up to #258, which merged before this fix was pushed.