### PR TITLE
Fix mobile card crash on Age of Sigmar warscrolls, and surface AoS enhancements

### DIFF
--- a/changes/unreleased/aos-enhancements.json
+++ b/changes/unreleased/aos-enhancements.json
@@ -1,0 +1,5 @@
+{
+  "title": "Age of Sigmar artefacts and heroic traits are now in the app",
+  "body": "Every faction's artefacts of power, heroic traits and other enhancements can now be browsed from the faction screen, found through search, and opened as a card showing its cost, phase and rules text. They were in the data all along but had nowhere to appear.",
+  "severity": "info"
+}

--- a/changes/unreleased/aos-mobile-card-crash.json
+++ b/changes/unreleased/aos-mobile-card-crash.json
@@ -1,0 +1,5 @@
+{
+  "title": "Age of Sigmar warscrolls open again on mobile",
+  "body": "Tapping any Age of Sigmar warscroll on mobile showed a \"Sorry, something went wrong\" error instead of the card. Warscrolls now open normally, for every faction.",
+  "severity": "error"
+}

--- a/src/Components/AgeOfSigmar/CardDisplay.jsx
+++ b/src/Components/AgeOfSigmar/CardDisplay.jsx
@@ -5,6 +5,7 @@ import { useSettingsStorage } from "../../Hooks/useSettingsStorage";
 import { useDataSourceStorage } from "../../Hooks/useDataSourceStorage";
 import { WarscrollCard } from "./WarscrollCard";
 import { SpellCard } from "./SpellCard";
+import { EnhancementCard } from "./EnhancementCard";
 import { TemplateRenderer } from "../../Premium";
 import { AOS_COLOURS } from "../../Helpers/printcolours";
 
@@ -163,6 +164,24 @@ export const AgeOfSigmarCardDisplay = ({
               />
             </div>
           )}
+          {activeCard?.cardType === "enhancement" && !activeCard?.templateId && (
+            <div
+              className={`data-aos ${grandAlliance} ${fontClass}`}
+              style={{
+                "--card-scaling-factor": "inherit",
+                ...(displayCard?.useCustomColours && {
+                  "--bg-header": headerColour,
+                  "--banner-colour": bannerColour,
+                }),
+              }}>
+              <EnhancementCard
+                enhancement={activeCard}
+                groupName={activeCard.enhancementGroup}
+                faction={cardFaction}
+                grandAlliance={grandAlliance}
+              />
+            </div>
+          )}
           {activeCard?.templateId && (
             <TemplateRenderer templateId={activeCard.templateId} card={activeCard} faction={cardFaction} />
           )}
@@ -227,6 +246,26 @@ export const AgeOfSigmarCardDisplay = ({
           <SpellCard spell={card} loreName={card.loreName} faction={cardFaction} grandAlliance={grandAlliance} />
         </div>
       )}
+      {type === "print" && card && card?.cardType === "enhancement" && !card?.templateId && (
+        <div
+          className={`data-aos ${grandAlliance} ${fontClass}`}
+          style={{
+            zoom: cardScaling / 100,
+            "--card-scaling-factor": 1,
+            ...bgOverrides,
+            ...(displayCard?.useCustomColours && {
+              "--bg-header": headerColour,
+              "--banner-colour": bannerColour,
+            }),
+          }}>
+          <EnhancementCard
+            enhancement={card}
+            groupName={card.enhancementGroup}
+            faction={cardFaction}
+            grandAlliance={grandAlliance}
+          />
+        </div>
+      )}
       {type === "print" && card && card?.templateId && (
         <div
           className={`data-aos ${grandAlliance} ${fontClass}`}
@@ -278,6 +317,16 @@ export const AgeOfSigmarCardDisplay = ({
               onBack={onBack}
             />
           )}
+          {activeCard?.cardType === "enhancement" && !activeCard?.templateId && (
+            <EnhancementCard
+              enhancement={activeCard}
+              groupName={activeCard.enhancementGroup}
+              faction={cardFaction}
+              grandAlliance={grandAlliance}
+              isMobile={true}
+              onBack={onBack}
+            />
+          )}
           {activeCard?.templateId && (
             <div className="data-aos" style={{ display: "flex", justifyContent: "center", width: "100%" }}>
               <TemplateRenderer templateId={activeCard.templateId} card={activeCard} faction={cardFaction} />
@@ -304,6 +353,16 @@ export const AgeOfSigmarCardDisplay = ({
               grandAlliance={grandAlliance}
               isMobile={true}
               onViewWarscroll={handleViewWarscroll}
+              onBack={onBack}
+            />
+          )}
+          {card?.cardType === "enhancement" && !card?.templateId && (
+            <EnhancementCard
+              enhancement={card}
+              groupName={card.enhancementGroup}
+              faction={cardFaction}
+              grandAlliance={grandAlliance}
+              isMobile={true}
               onBack={onBack}
             />
           )}

--- a/src/Components/AgeOfSigmar/EnhancementCard.jsx
+++ b/src/Components/AgeOfSigmar/EnhancementCard.jsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { ArrowLeft } from "lucide-react";
+import { MarkdownDisplay } from "../MarkdownDisplay";
+
+/**
+ * An Age of Sigmar enhancement — an artefact of power, heroic trait or other
+ * battletome enhancement. Shares the spell card's layout and styling: the data
+ * has the same declare/effect shape, with a points or command point cost in
+ * place of a casting value.
+ */
+export const EnhancementCard = ({
+  enhancement,
+  groupName,
+  faction,
+  grandAlliance = "order",
+  isMobile = false,
+  onBack,
+}) => {
+  if (!enhancement) return null;
+
+  const cost = Number.isFinite(Number(enhancement.points)) && enhancement.points !== null ? enhancement.points : null;
+  const cpCost = Number.isFinite(Number(enhancement.cpCost)) && enhancement.cpCost !== null ? enhancement.cpCost : null;
+
+  return (
+    <div className={`spell-card enhancement-card ${grandAlliance} ${isMobile ? "mobile" : ""}`}>
+      {/* Header */}
+      <div className="spell-card-header">
+        {/* Mobile Back Button */}
+        {isMobile && onBack && (
+          <button className="spell-back-button" onClick={onBack} type="button">
+            <ArrowLeft size={20} />
+          </button>
+        )}
+        <div className="spell-card-title-row">
+          <h1 className="spell-card-name">{enhancement.name}</h1>
+          {cost !== null && (
+            <div className="enhancement-card-cost">
+              <span className="enhancement-cost-number">{cost}</span>
+              <span className="enhancement-cost-label">pts</span>
+            </div>
+          )}
+          {cost === null && cpCost !== null && (
+            <div className="enhancement-card-cost">
+              <span className="enhancement-cost-number">{cpCost}</span>
+              <span className="enhancement-cost-label">CP</span>
+            </div>
+          )}
+        </div>
+        {groupName && <div className="spell-card-lore-name">{groupName}</div>}
+      </div>
+
+      {/* Body */}
+      <div className="spell-card-body">
+        <div className="spell-card-content">
+          {enhancement.phaseDetails && <div className="enhancement-card-phase">{enhancement.phaseDetails}</div>}
+          {enhancement.declare && (
+            <div className="spell-card-section">
+              <div className="spell-card-section-label">Declare</div>
+              <div className="spell-card-section-text">
+                <MarkdownDisplay content={enhancement.declare} />
+              </div>
+            </div>
+          )}
+          {enhancement.effect && (
+            <div className="spell-card-section">
+              <div className="spell-card-section-label">Effect</div>
+              <div className="spell-card-section-text">
+                <MarkdownDisplay content={enhancement.effect} />
+              </div>
+            </div>
+          )}
+          {/* Custom datasources and older exports keep a single description */}
+          {!enhancement.declare && !enhancement.effect && enhancement.description && (
+            <div className="spell-card-section">
+              <div className="spell-card-section-text">
+                <MarkdownDisplay content={enhancement.description} />
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Keywords */}
+        {enhancement.keywords?.length > 0 && (
+          <div className="spell-card-keywords">
+            <span className="spell-card-keywords-label">Keywords:</span>
+            <span className="spell-card-keywords-list">{enhancement.keywords.join(", ")}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/Components/AgeOfSigmar/EnhancementCard.jsx
+++ b/src/Components/AgeOfSigmar/EnhancementCard.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ArrowLeft } from "lucide-react";
 import { MarkdownDisplay } from "../MarkdownDisplay";
+import { getEnhancementCost } from "../../Helpers/faction.helpers";
 
 /**
  * An Age of Sigmar enhancement — an artefact of power, heroic trait or other
@@ -18,8 +19,7 @@ export const EnhancementCard = ({
 }) => {
   if (!enhancement) return null;
 
-  const cost = Number.isFinite(Number(enhancement.points)) && enhancement.points !== null ? enhancement.points : null;
-  const cpCost = Number.isFinite(Number(enhancement.cpCost)) && enhancement.cpCost !== null ? enhancement.cpCost : null;
+  const cost = getEnhancementCost(enhancement);
 
   return (
     <div className={`spell-card enhancement-card ${grandAlliance} ${isMobile ? "mobile" : ""}`}>
@@ -33,16 +33,10 @@ export const EnhancementCard = ({
         )}
         <div className="spell-card-title-row">
           <h1 className="spell-card-name">{enhancement.name}</h1>
-          {cost !== null && (
+          {cost && (
             <div className="enhancement-card-cost">
-              <span className="enhancement-cost-number">{cost}</span>
-              <span className="enhancement-cost-label">pts</span>
-            </div>
-          )}
-          {cost === null && cpCost !== null && (
-            <div className="enhancement-card-cost">
-              <span className="enhancement-cost-number">{cpCost}</span>
-              <span className="enhancement-cost-label">CP</span>
+              <span className="enhancement-cost-number">{cost.value}</span>
+              <span className="enhancement-cost-label">{cost.label}</span>
             </div>
           )}
         </div>

--- a/src/Components/AgeOfSigmar/__tests__/EnhancementCard.test.jsx
+++ b/src/Components/AgeOfSigmar/__tests__/EnhancementCard.test.jsx
@@ -33,8 +33,14 @@ describe("EnhancementCard", () => {
     expect(screen.queryByText("pts")).not.toBeInTheDocument();
   });
 
-  it("shows no cost badge when the enhancement is free", () => {
+  it("shows no cost badge when the enhancement carries no cost", () => {
     render(<EnhancementCard enhancement={{ ...artefact, points: null, cpCost: null }} />);
+    expect(screen.queryByText("pts")).not.toBeInTheDocument();
+    expect(screen.queryByText("CP")).not.toBeInTheDocument();
+  });
+
+  it("shows no cost badge for a blank cost rather than reading it as free", () => {
+    render(<EnhancementCard enhancement={{ ...artefact, points: "", cpCost: "" }} />);
     expect(screen.queryByText("pts")).not.toBeInTheDocument();
     expect(screen.queryByText("CP")).not.toBeInTheDocument();
   });

--- a/src/Components/AgeOfSigmar/__tests__/EnhancementCard.test.jsx
+++ b/src/Components/AgeOfSigmar/__tests__/EnhancementCard.test.jsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EnhancementCard } from "../EnhancementCard";
+
+// Shaped like the real AoS data: declare/effect prose, a points or CP cost, and
+// a phase line.
+const artefact = {
+  name: "Pennant of Azyrite Majesty",
+  points: 20,
+  cpCost: null,
+  phaseDetails: "Start of Any Turn",
+  declare: 'Pick a visible enemy unit within 18" of this unit.',
+  effect: "Add 1 to the control score of that unit.",
+};
+
+describe("EnhancementCard", () => {
+  it("renders the name, group, cost, phase and prose", () => {
+    render(<EnhancementCard enhancement={artefact} groupName="Artefacts of Power" />);
+
+    expect(screen.getByText("Pennant of Azyrite Majesty")).toBeInTheDocument();
+    expect(screen.getByText("Artefacts of Power")).toBeInTheDocument();
+    expect(screen.getByText("20")).toBeInTheDocument();
+    expect(screen.getByText("pts")).toBeInTheDocument();
+    expect(screen.getByText("Start of Any Turn")).toBeInTheDocument();
+    expect(screen.getByText("Declare")).toBeInTheDocument();
+    expect(screen.getByText("Effect")).toBeInTheDocument();
+  });
+
+  it("shows a command point cost when the enhancement is not priced in points", () => {
+    render(<EnhancementCard enhancement={{ ...artefact, points: null, cpCost: 1 }} />);
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("CP")).toBeInTheDocument();
+    expect(screen.queryByText("pts")).not.toBeInTheDocument();
+  });
+
+  it("shows no cost badge when the enhancement is free", () => {
+    render(<EnhancementCard enhancement={{ ...artefact, points: null, cpCost: null }} />);
+    expect(screen.queryByText("pts")).not.toBeInTheDocument();
+    expect(screen.queryByText("CP")).not.toBeInTheDocument();
+  });
+
+  it("falls back to a plain description when there is no declare/effect split", () => {
+    render(
+      <EnhancementCard
+        enhancement={{ name: "Old Export", declare: null, effect: null, description: "Adds 1 to hit rolls." }}
+      />,
+    );
+    expect(screen.getByText("Adds 1 to hit rolls.")).toBeInTheDocument();
+  });
+
+  it("renders a back button on mobile only", () => {
+    const onBack = vi.fn();
+    const { rerender } = render(<EnhancementCard enhancement={artefact} isMobile onBack={onBack} />);
+    expect(document.querySelector(".spell-back-button")).toBeInTheDocument();
+
+    rerender(<EnhancementCard enhancement={artefact} onBack={onBack} />);
+    expect(document.querySelector(".spell-back-button")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing without an enhancement", () => {
+    const { container } = render(<EnhancementCard enhancement={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/Components/LeftPanel/ContentTypeSelector.jsx
+++ b/src/Components/LeftPanel/ContentTypeSelector.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from "react";
 import { ChevronDown } from "lucide-react";
 import { useDataSourceStorage } from "../../Hooks/useDataSourceStorage";
 import { getTargetArray } from "../../Helpers/customDatasource.helpers";
+import { getBrowsableEnhancements } from "../../Helpers/faction.helpers";
 import "./ContentTypeSelector.css";
 
 const CONTENT_TYPES_40K = [
@@ -15,6 +16,7 @@ const CONTENT_TYPES_40K = [
 
 const CONTENT_TYPES_AOS = [
   { value: "warscrolls", label: "Warscrolls", key: "warscrolls" },
+  { value: "enhancements", label: "Enhancements", key: "enhancements" },
   { value: "manifestationLores", label: "Manifestation Lores", key: "manifestationLores" },
   { value: "spellLores", label: "Spell Lores", key: "lores" },
 ];
@@ -64,6 +66,10 @@ export const ContentTypeSelector = ({ selectedContentType, setSelectedContentTyp
           // Rules have a different structure with army and detachment sub-arrays
           const rules = selectedFaction?.rules;
           return rules && (rules.army?.length > 0 || rules.detachment?.length > 0);
+        }
+        if (type.key === "enhancements") {
+          // AoS groups enhancements in an object, so a plain length check misses them
+          return getBrowsableEnhancements(selectedFaction).length > 0;
         }
         const data = selectedFaction?.[type.key];
         return data && data.length > 0;

--- a/src/Components/LeftPanel/__tests__/useDataSourceItems.test.jsx
+++ b/src/Components/LeftPanel/__tests__/useDataSourceItems.test.jsx
@@ -63,11 +63,23 @@ describe("useDataSourceItems enhancements section", () => {
     expect(result.current[0].cardType).toBe("enhancement");
   });
 
-  // AoS factions group enhancements in an object of category-keyed arrays, which
-  // this 40K-shaped list cannot read.
-  it("returns nothing for a faction whose enhancements are grouped by category", () => {
+  // AoS factions group enhancements in an object of category-keyed arrays, and
+  // carry a source ("aos-4e") that no card renderer is keyed on.
+  it("flattens an AoS faction's grouped enhancements and routes them to the AoS renderer", () => {
     mockState.settings = { selectedDataSource: "aos" };
-    mockState.selectedFaction = { enhancements: { artefacts: [{ name: "Amulet" }], heroicTraits: [], other: [] } };
+    mockState.selectedFaction = {
+      warscrolls: [],
+      enhancements: { artefacts: [{ name: "Amulet", source: "aos-4e" }], heroicTraits: [], other: [] },
+    };
+    const { result } = renderHook(() => useDataSourceItems("enhancements", ""));
+    expect(result.current).toEqual([
+      expect.objectContaining({ name: "Amulet", cardType: "enhancement", source: "aos" }),
+    ]);
+  });
+
+  it("returns nothing for a faction with no enhancements", () => {
+    mockState.settings = { selectedDataSource: "aos" };
+    mockState.selectedFaction = { warscrolls: [], enhancements: { artefacts: [], heroicTraits: [], other: [] } };
     const { result } = renderHook(() => useDataSourceItems("enhancements", ""));
     expect(result.current).toEqual([]);
   });

--- a/src/Components/LeftPanel/__tests__/useDataSourceItems.test.jsx
+++ b/src/Components/LeftPanel/__tests__/useDataSourceItems.test.jsx
@@ -53,3 +53,22 @@ describe("useDataSourceItems stratagems section", () => {
     expect(result.current.map((i) => i.name)).toEqual(["Faction Strat"]);
   });
 });
+
+describe("useDataSourceItems enhancements section", () => {
+  it("lists a 40K faction's enhancements", () => {
+    mockState.settings = { selectedDataSource: "40k-10e" };
+    mockState.selectedFaction = { enhancements: [{ name: "Artificer Armour" }] };
+    const { result } = renderHook(() => useDataSourceItems("enhancements", ""));
+    expect(result.current.map((i) => i.name)).toEqual(["Artificer Armour"]);
+    expect(result.current[0].cardType).toBe("enhancement");
+  });
+
+  // AoS factions group enhancements in an object of category-keyed arrays, which
+  // this 40K-shaped list cannot read.
+  it("returns nothing for a faction whose enhancements are grouped by category", () => {
+    mockState.settings = { selectedDataSource: "aos" };
+    mockState.selectedFaction = { enhancements: { artefacts: [{ name: "Amulet" }], heroicTraits: [], other: [] } };
+    const { result } = renderHook(() => useDataSourceItems("enhancements", ""));
+    expect(result.current).toEqual([]);
+  });
+});

--- a/src/Components/LeftPanel/useDataSourceItems.js
+++ b/src/Components/LeftPanel/useDataSourceItems.js
@@ -1,5 +1,6 @@
 import { useDataSourceStorage } from "../../Hooks/useDataSourceStorage";
 import { useSettingsStorage } from "../../Hooks/useSettingsStorage";
+import { getFactionEnhancements } from "../../Helpers/listCategories.helpers";
 
 /**
  * Group warscrolls by their role keywords (Hero, Battleline, Monster, etc.)
@@ -234,7 +235,7 @@ export const useDataSourceItems = (selectedContentType, searchText) => {
     }
 
     if (selectedContentType === "enhancements") {
-      const filteredEnhancements = selectedFaction?.enhancements?.map((enhancement) => {
+      const filteredEnhancements = getFactionEnhancements(selectedFaction).map((enhancement) => {
         // Preserve the card's own source (e.g. "40k-11e") so it routes to the
         // correct renderer; fall back to the faction/datasource source.
         return {
@@ -245,7 +246,7 @@ export const useDataSourceItems = (selectedContentType, searchText) => {
       });
 
       const mainEnhancements = searchText
-        ? filteredEnhancements?.filter((enhancement) =>
+        ? filteredEnhancements.filter((enhancement) =>
             enhancement.name.toLowerCase().includes(searchText.toLowerCase()),
           )
         : filteredEnhancements;

--- a/src/Components/LeftPanel/useDataSourceItems.js
+++ b/src/Components/LeftPanel/useDataSourceItems.js
@@ -1,6 +1,6 @@
 import { useDataSourceStorage } from "../../Hooks/useDataSourceStorage";
 import { useSettingsStorage } from "../../Hooks/useSettingsStorage";
-import { getFactionEnhancements } from "../../Helpers/listCategories.helpers";
+import { getBrowsableEnhancements } from "../../Helpers/faction.helpers";
 
 /**
  * Group warscrolls by their role keywords (Hero, Battleline, Monster, etc.)
@@ -235,13 +235,15 @@ export const useDataSourceItems = (selectedContentType, searchText) => {
     }
 
     if (selectedContentType === "enhancements") {
-      const filteredEnhancements = getFactionEnhancements(selectedFaction).map((enhancement) => {
+      const isAoSFaction = Boolean(selectedFaction?.warscrolls);
+      const filteredEnhancements = getBrowsableEnhancements(selectedFaction).map((enhancement) => {
         // Preserve the card's own source (e.g. "40k-11e") so it routes to the
-        // correct renderer; fall back to the faction/datasource source.
+        // correct renderer; fall back to the faction/datasource source. AoS
+        // entries carry "aos-4e", which no renderer is keyed on.
         return {
           ...enhancement,
           cardType: "enhancement",
-          source: enhancement.source ?? selectedFaction?.source ?? "40k-10e",
+          source: isAoSFaction ? "aos" : (enhancement.source ?? selectedFaction?.source ?? "40k-10e"),
         };
       });
 

--- a/src/Components/TreeView/UnitConfigModal.jsx
+++ b/src/Components/TreeView/UnitConfigModal.jsx
@@ -17,6 +17,7 @@ import {
 } from "../../Helpers/listPoints.helpers";
 import {
   cardHasKeyword,
+  getFactionEnhancements,
   isEnhancementAtCopyLimit,
   isUnitEnhancementEligible,
 } from "../../Helpers/listCategories.helpers";
@@ -139,11 +140,11 @@ export const UnitConfigModal = ({ isOpen, onClose, card, category, onSave }) => 
   // (equipableByNonCharacter). Epic Heroes take neither.
   const filteredEnhancements = isEpicHero
     ? []
-    : cardFaction?.enhancements
-        ?.filter((enhancement) => isEnhancementInDetachments(enhancement, category?.detachments, selectedDetachment))
-        ?.filter((enhancement) => isUnitEnhancementEligible(card, enhancement));
+    : getFactionEnhancements(cardFaction)
+        .filter((enhancement) => isEnhancementInDetachments(enhancement, category?.detachments, selectedDetachment))
+        .filter((enhancement) => isUnitEnhancementEligible(card, enhancement));
 
-  const showEnhancements = !isEpicHero && (filteredEnhancements?.length || 0) > 0;
+  const showEnhancements = !isEpicHero && filteredEnhancements.length > 0;
   const showDetachments = showEnhancements && detachments?.length > 1;
   const enhancementLabel = isCharacter ? "Enhancement" : "Upgrade";
   // Leaders may stand alone; Support units must be attached to an eligible squad

--- a/src/Components/Viewer/AoS/MobileAoSEnhancements.jsx
+++ b/src/Components/Viewer/AoS/MobileAoSEnhancements.jsx
@@ -1,0 +1,97 @@
+import { ArrowLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { useDataSourceStorage } from "../../../Hooks/useDataSourceStorage";
+import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
+import { getBrowsableEnhancements } from "../../../Helpers/faction.helpers";
+import "./MobileAoS.css";
+
+// Enhancement list item component
+const EnhancementItem = ({ enhancement, onClick }) => {
+  const cost = enhancement.points ?? enhancement.cpCost;
+  const costLabel = enhancement.points != null ? "pts" : "CP";
+
+  return (
+    <button className="aos-units-item" onClick={onClick}>
+      <span className="aos-units-item-name">{enhancement.name}</span>
+      {cost != null && (
+        <span className="aos-units-item-points">
+          {cost} {costLabel}
+        </span>
+      )}
+    </button>
+  );
+};
+
+// Section header component
+const SectionHeader = ({ title, count }) => (
+  <div className="aos-units-section-header">
+    <span>{title}</span>
+    <span className="aos-units-section-count">{count}</span>
+  </div>
+);
+
+export const MobileAoSEnhancements = () => {
+  const navigate = useNavigate();
+  const { selectedFaction } = useDataSourceStorage();
+  const { settings } = useSettingsStorage();
+
+  const factionSlug = selectedFaction?.name?.toLowerCase().replaceAll(" ", "-");
+  const grandAlliance = selectedFaction?.grandAlliance?.toLowerCase() || "order";
+  const fontClass = settings.useFancyFonts === false ? "aos-regular-fonts" : "";
+
+  const handleBack = () => {
+    navigate(`/mobile/${factionSlug}`);
+  };
+
+  const handleEnhancementClick = (enhancement) => {
+    const slug = enhancement.name?.toLowerCase().replaceAll(" ", "-");
+    navigate(`/mobile/${factionSlug}/enhancement/${slug}`);
+  };
+
+  const enhancements = getBrowsableEnhancements(selectedFaction);
+
+  // Keep the battletome's group order rather than sorting the groups themselves.
+  const groups = enhancements.reduce((acc, enhancement) => {
+    const name = enhancement.enhancementGroup || "Enhancements";
+    if (!acc.some((group) => group.name === name)) acc.push({ name, items: [] });
+    acc.find((group) => group.name === name).items.push(enhancement);
+    return acc;
+  }, []);
+
+  if (!selectedFaction) {
+    return null;
+  }
+
+  return (
+    <div className={`aos-units-page ${grandAlliance} ${fontClass}`}>
+      {/* Header */}
+      <div className="aos-units-header">
+        <button className="aos-units-back" onClick={handleBack}>
+          <ArrowLeft size={20} />
+        </button>
+        <h1 className="aos-units-title">Enhancements</h1>
+        <div className="aos-units-count">
+          {enhancements.length} {enhancements.length === 1 ? "enhancement" : "enhancements"}
+        </div>
+      </div>
+
+      {/* Grouped List */}
+      <div className="aos-units-list">
+        {groups.map((group) => (
+          <div key={group.name} className="aos-units-section">
+            <SectionHeader title={group.name} count={group.items.length} />
+            {[...group.items]
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((enhancement) => (
+                <EnhancementItem
+                  key={enhancement.id || enhancement.name}
+                  enhancement={enhancement}
+                  onClick={() => handleEnhancementClick(enhancement)}
+                />
+              ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/Components/Viewer/AoS/MobileAoSEnhancements.jsx
+++ b/src/Components/Viewer/AoS/MobileAoSEnhancements.jsx
@@ -2,20 +2,19 @@ import { ArrowLeft } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { useDataSourceStorage } from "../../../Hooks/useDataSourceStorage";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
-import { getBrowsableEnhancements } from "../../../Helpers/faction.helpers";
+import { getBrowsableEnhancements, getEnhancementCost } from "../../../Helpers/faction.helpers";
 import "./MobileAoS.css";
 
 // Enhancement list item component
 const EnhancementItem = ({ enhancement, onClick }) => {
-  const cost = enhancement.points ?? enhancement.cpCost;
-  const costLabel = enhancement.points != null ? "pts" : "CP";
+  const cost = getEnhancementCost(enhancement);
 
   return (
     <button className="aos-units-item" onClick={onClick}>
       <span className="aos-units-item-name">{enhancement.name}</span>
-      {cost != null && (
+      {cost && (
         <span className="aos-units-item-points">
-          {cost} {costLabel}
+          {cost.value} {cost.label}
         </span>
       )}
     </button>

--- a/src/Components/Viewer/AoS/MobileAoSFaction.jsx
+++ b/src/Components/Viewer/AoS/MobileAoSFaction.jsx
@@ -1,7 +1,8 @@
 import { useNavigate } from "react-router-dom";
-import { ChevronRight, List, Sparkles, BookOpen } from "lucide-react";
+import { ChevronRight, List, Sparkles, BookOpen, Gem } from "lucide-react";
 import { useDataSourceStorage } from "../../../Hooks/useDataSourceStorage";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
+import { getBrowsableEnhancements } from "../../../Helpers/faction.helpers";
 import "./MobileAoS.css";
 
 export const MobileAoSFaction = () => {
@@ -39,6 +40,9 @@ export const MobileAoSFaction = () => {
   const spellLores = selectedFaction.lores || [];
   const spellLoreCount = spellLores.reduce((total, lore) => total + (lore.spells?.length || 0), 0);
 
+  // Artefacts of power, heroic traits and other battletome enhancements
+  const enhancementCount = getBrowsableEnhancements(selectedFaction).length;
+
   const factionSlug = selectedFaction.name?.toLowerCase().replaceAll(" ", "-");
 
   const handleViewUnits = () => {
@@ -51,6 +55,10 @@ export const MobileAoSFaction = () => {
 
   const handleViewSpellLores = () => {
     navigate(`/mobile/${factionSlug}/spell-lores`);
+  };
+
+  const handleViewEnhancements = () => {
+    navigate(`/mobile/${factionSlug}/enhancements`);
   };
 
   return (
@@ -75,6 +83,16 @@ export const MobileAoSFaction = () => {
           <BookOpen size={18} />
           <span>Spell Lores</span>
           <span className="units-count">{spellLoreCount}</span>
+          <ChevronRight size={18} />
+        </button>
+      )}
+
+      {/* Enhancements Button */}
+      {enhancementCount > 0 && (
+        <button className="aos-faction-units-button" onClick={handleViewEnhancements} type="button">
+          <Gem size={18} />
+          <span>Enhancements</span>
+          <span className="units-count">{enhancementCount}</span>
           <ChevronRight size={18} />
         </button>
       )}

--- a/src/Components/Viewer/AoS/index.js
+++ b/src/Components/Viewer/AoS/index.js
@@ -2,3 +2,4 @@ export { MobileAoSFaction } from "./MobileAoSFaction";
 export { MobileAoSFactionUnits } from "./MobileAoSFactionUnits";
 export { MobileAoSManifestationLores } from "./MobileAoSManifestationLores";
 export { MobileAoSSpellLores } from "./MobileAoSSpellLores";
+export { MobileAoSEnhancements } from "./MobileAoSEnhancements";

--- a/src/Components/Viewer/ListCreator/ListAdd.jsx
+++ b/src/Components/Viewer/ListCreator/ListAdd.jsx
@@ -13,6 +13,7 @@ import {
 } from "../../../Helpers/listPoints.helpers";
 import {
   cardHasKeyword,
+  getFactionEnhancements,
   isEnhancementAtCopyLimit,
   isUnitEnhancementEligible,
 } from "../../../Helpers/listCategories.helpers";
@@ -143,9 +144,9 @@ export const ListAdd = ({ isVisible, setIsVisible }) => {
   // enhancements; non-character units can take enhancements flagged as upgrades
   // (equipableByNonCharacter). Epic Heroes take neither.
   const getAvailableEnhancements = () => {
-    if (!cardFaction?.enhancements || isEpicHero) return [];
+    if (isEpicHero) return [];
 
-    return cardFaction.enhancements
+    return getFactionEnhancements(cardFaction)
       .filter((enhancement) => isEnhancementInDetachments(enhancement, armyDetachments, selectedDetachment))
       .filter((enhancement) => isUnitEnhancementEligible(activeCard, enhancement));
   };

--- a/src/Components/Viewer/ListCreator/ListEditCard.jsx
+++ b/src/Components/Viewer/ListCreator/ListEditCard.jsx
@@ -17,6 +17,7 @@ import {
 } from "../../../Helpers/listPoints.helpers";
 import {
   cardHasKeyword,
+  getFactionEnhancements,
   isEnhancementAtCopyLimit,
   isUnitEnhancementEligible,
 } from "../../../Helpers/listCategories.helpers";
@@ -162,9 +163,9 @@ export const ListEditCard = ({ isVisible, setIsVisible, card }) => {
   // Characters take regular enhancements; non-character units can take upgrades
   // (equipableByNonCharacter). Epic Heroes take neither.
   const getAvailableEnhancements = () => {
-    if (!cardFaction?.enhancements || isEpicHero) return [];
+    if (isEpicHero) return [];
 
-    return cardFaction.enhancements
+    return getFactionEnhancements(cardFaction)
       .filter((enhancement) => isEnhancementInDetachments(enhancement, armyDetachments, selectedDetachment))
       .filter((enhancement) => isUnitEnhancementEligible(card, enhancement));
   };

--- a/src/Components/Viewer/ListCreator/__tests__/ListAdd.test.jsx
+++ b/src/Components/Viewer/ListCreator/__tests__/ListAdd.test.jsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ListAdd } from "../ListAdd";
+
+// Age of Sigmar factions group enhancements in an object of category-keyed
+// arrays; 40K factions use a flat array. ListAdd stays mounted behind every
+// mobile card, so an AoS warscroll used to take the whole page down with
+// "enhancements.filter is not a function" before it could bail out.
+const aosFaction = {
+  id: "KRULEBOYZ",
+  name: "Kruleboyz",
+  enhancements: { artefacts: [], heroicTraits: [], other: [] },
+};
+
+const k40Faction = {
+  id: "faction-1",
+  name: "Space Marines",
+  detachments: [{ name: "Gladius Task Force" }],
+  enhancements: [{ name: "Artificer Armour", cost: 15, keywords: ["Adeptus Astartes"] }],
+};
+
+let activeCard;
+
+vi.mock("../../../../Hooks/useCardStorage", () => ({
+  useCardStorage: () => ({ activeCard }),
+}));
+
+vi.mock("../../../../Hooks/useDataSourceStorage", () => ({
+  useDataSourceStorage: () => ({ dataSource: { data: [aosFaction, k40Faction] } }),
+}));
+
+vi.mock("../../../../Hooks/useSettingsStorage", () => ({
+  useSettingsStorage: () => ({ settings: {}, updateSettings: vi.fn() }),
+}));
+
+vi.mock("../../../../Hooks/useUmami", () => ({
+  useUmami: () => ({ trackEvent: vi.fn() }),
+}));
+
+vi.mock("../../useMobileList", () => ({
+  useMobileList: () => ({ lists: [{ cards: [] }], selectedList: 0, addDatacard: vi.fn() }),
+}));
+
+describe("ListAdd", () => {
+  let modalRoot;
+
+  beforeEach(() => {
+    modalRoot = document.createElement("div");
+    modalRoot.setAttribute("id", "modal-root");
+    document.body.appendChild(modalRoot);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(modalRoot);
+    document.body.style.overflow = "";
+  });
+
+  it("renders nothing for an AoS warscroll instead of crashing on grouped enhancements", () => {
+    activeCard = {
+      name: "Killaboss on Great Gnashtoof",
+      id: "warscroll-1",
+      faction_id: "KRULEBOYZ",
+      cardType: "warscroll",
+      source: "aos",
+      keywords: ["Hero", "Character"],
+      points: 170,
+    };
+
+    const { container } = render(<ListAdd isVisible={false} setIsVisible={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("offers a 40K unit's eligible enhancements", () => {
+    activeCard = {
+      name: "Captain",
+      id: "unit-1",
+      faction_id: "faction-1",
+      source: "40k-10e",
+      keywords: ["Character"],
+      factions: ["Adeptus Astartes"],
+      points: [{ models: 1, cost: 80, active: true }],
+    };
+
+    render(<ListAdd isVisible={true} setIsVisible={vi.fn()} />);
+    expect(screen.getByText("Add Captain")).toBeInTheDocument();
+    expect(screen.getByText("Artificer Armour")).toBeInTheDocument();
+  });
+});

--- a/src/Components/Viewer/MobileFaction.jsx
+++ b/src/Components/Viewer/MobileFaction.jsx
@@ -5,6 +5,7 @@ import { useDataSourceStorage } from "../../Hooks/useDataSourceStorage";
 import { useSettingsStorage } from "../../Hooks/useSettingsStorage";
 import { useCombinedDatasheets } from "../../Hooks/useCombinedDatasheets";
 import { getDetachmentName } from "../../Helpers/faction.helpers";
+import { getFactionEnhancements } from "../../Helpers/listCategories.helpers";
 import { MarkdownDisplay } from "../MarkdownDisplay";
 import { StratagemCard } from "../Warhammer40k-10e/StratagemCard";
 import { StratagemCard as StratagemCard11e } from "../Warhammer40k-11e/StratagemCard";
@@ -139,12 +140,10 @@ export const MobileFaction = () => {
   const coreStratagems = selectedFaction?.basicStratagems || [];
 
   // Filter enhancements by selected detachment
-  const enhancements = Array.isArray(selectedFaction?.enhancements)
-    ? selectedFaction.enhancements.filter(
-        (enhancement) =>
-          enhancement?.detachment?.toLowerCase() === selectedDetachment?.toLowerCase() || !enhancement.detachment,
-      )
-    : [];
+  const enhancements = getFactionEnhancements(selectedFaction).filter(
+    (enhancement) =>
+      enhancement?.detachment?.toLowerCase() === selectedDetachment?.toLowerCase() || !enhancement.detachment,
+  );
 
   // Get detachment rules for selected detachment
   const detachmentRules =

--- a/src/Components/Viewer/mobileDatasourceConfig.jsx
+++ b/src/Components/Viewer/mobileDatasourceConfig.jsx
@@ -7,7 +7,13 @@ import { AgeOfSigmarCardDisplay } from "../AgeOfSigmar/CardDisplay";
 import { CustomCardDisplay } from "../Custom/CustomCardDisplay";
 import { MobileFaction } from "./MobileFaction";
 import { MobileFactionUnits } from "./MobileFactionUnits";
-import { MobileAoSFaction, MobileAoSFactionUnits, MobileAoSManifestationLores, MobileAoSSpellLores } from "./AoS";
+import {
+  MobileAoSFaction,
+  MobileAoSFactionUnits,
+  MobileAoSManifestationLores,
+  MobileAoSSpellLores,
+  MobileAoSEnhancements,
+} from "./AoS";
 import { MobileSettings40k } from "./MobileSettings40k";
 import { MobileSettingsAoS } from "./MobileSettingsAoS";
 
@@ -112,6 +118,7 @@ export const BUILTIN_CONFIGS = {
     extraRouteViews: [
       { prop: "showManifestationLores", Component: MobileAoSManifestationLores },
       { prop: "showSpellLores", Component: MobileAoSSpellLores },
+      { prop: "showEnhancements", Component: MobileAoSEnhancements },
     ],
     SettingsSection: MobileSettingsAoS,
     GameSystemSettingsScreen: "aos",

--- a/src/Helpers/__tests__/faction.helpers.test.js
+++ b/src/Helpers/__tests__/faction.helpers.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { getBrowsableEnhancements, getDetachmentName, getDetachmentFaction } from "../faction.helpers";
+import {
+  getBrowsableEnhancements,
+  getDetachmentName,
+  getDetachmentFaction,
+  getEnhancementCost,
+} from "../faction.helpers";
 
 describe("getDetachmentName", () => {
   it("handles the string, object and language-keyed formats", () => {
@@ -17,6 +22,33 @@ describe("getDetachmentFaction", () => {
     expect(getDetachmentFaction({ name: "Gladius", faction: "Ultramarines" })).toBe("Ultramarines");
     expect(getDetachmentFaction("Gladius")).toBeNull();
     expect(getDetachmentFaction({ name: "Gladius" })).toBeNull();
+  });
+});
+
+describe("getEnhancementCost", () => {
+  it("prefers points over command points", () => {
+    expect(getEnhancementCost({ points: 20, cpCost: 1 })).toEqual({ value: 20, label: "pts" });
+  });
+
+  it("falls back to command points when there is no points cost", () => {
+    expect(getEnhancementCost({ points: null, cpCost: 1 })).toEqual({ value: 1, label: "CP" });
+  });
+
+  it("reads numeric strings as numbers", () => {
+    expect(getEnhancementCost({ points: "20" })).toEqual({ value: 20, label: "pts" });
+  });
+
+  it("treats an explicit 0 as a real, free price", () => {
+    expect(getEnhancementCost({ points: 0 })).toEqual({ value: 0, label: "pts" });
+  });
+
+  // Number("") and Number(null) are both 0, so blanks must not read as free.
+  it("reports no cost for blank, missing or non-numeric values", () => {
+    expect(getEnhancementCost({ points: "", cpCost: "" })).toBeNull();
+    expect(getEnhancementCost({ points: null, cpCost: null })).toBeNull();
+    expect(getEnhancementCost({})).toBeNull();
+    expect(getEnhancementCost(undefined)).toBeNull();
+    expect(getEnhancementCost({ points: "free" })).toBeNull();
   });
 });
 

--- a/src/Helpers/__tests__/faction.helpers.test.js
+++ b/src/Helpers/__tests__/faction.helpers.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { getBrowsableEnhancements, getDetachmentName, getDetachmentFaction } from "../faction.helpers";
+
+describe("getDetachmentName", () => {
+  it("handles the string, object and language-keyed formats", () => {
+    expect(getDetachmentName("Gladius Task Force")).toBe("Gladius Task Force");
+    expect(getDetachmentName({ name: "Gladius Task Force" })).toBe("Gladius Task Force");
+    expect(getDetachmentName({ name: { en: "Gladius Task Force", de: "Gladius-Einsatztruppe" } })).toBe(
+      "Gladius Task Force",
+    );
+    expect(getDetachmentName(undefined)).toBe("");
+  });
+});
+
+describe("getDetachmentFaction", () => {
+  it("returns the faction only for the object format", () => {
+    expect(getDetachmentFaction({ name: "Gladius", faction: "Ultramarines" })).toBe("Ultramarines");
+    expect(getDetachmentFaction("Gladius")).toBeNull();
+    expect(getDetachmentFaction({ name: "Gladius" })).toBeNull();
+  });
+});
+
+describe("getBrowsableEnhancements", () => {
+  it("returns a 40K faction's flat array unchanged", () => {
+    const enhancements = [{ name: "Artificer Armour" }];
+    expect(getBrowsableEnhancements({ enhancements })).toBe(enhancements);
+  });
+
+  it("flattens an AoS faction's groups in order, tagging each with its group label", () => {
+    const faction = {
+      enhancements: {
+        artefacts: [{ name: "Pennant of Azyrite Majesty" }],
+        heroicTraits: [{ name: "Staunch Defender" }],
+        other: [{ name: "Uncaged Lightning" }],
+      },
+    };
+
+    expect(getBrowsableEnhancements(faction)).toEqual([
+      { name: "Pennant of Azyrite Majesty", enhancementGroup: "Artefacts of Power" },
+      { name: "Staunch Defender", enhancementGroup: "Heroic Traits" },
+      { name: "Uncaged Lightning", enhancementGroup: "Other Enhancements" },
+    ]);
+  });
+
+  it("humanises an unrecognised group key rather than dropping the group", () => {
+    const faction = { enhancements: { battleTraits: [{ name: "Grudgebound" }] } };
+    expect(getBrowsableEnhancements(faction)).toEqual([{ name: "Grudgebound", enhancementGroup: "Battle Traits" }]);
+  });
+
+  it("returns none for empty groups, a missing faction, or a non-collection value", () => {
+    expect(getBrowsableEnhancements({ enhancements: { artefacts: [], heroicTraits: [], other: [] } })).toEqual([]);
+    expect(getBrowsableEnhancements(undefined)).toEqual([]);
+    expect(getBrowsableEnhancements({})).toEqual([]);
+    expect(getBrowsableEnhancements({ enhancements: null })).toEqual([]);
+    expect(getBrowsableEnhancements({ enhancements: "none" })).toEqual([]);
+  });
+});

--- a/src/Helpers/__tests__/listCategories.helpers.test.js
+++ b/src/Helpers/__tests__/listCategories.helpers.test.js
@@ -3,6 +3,7 @@ import {
   cardHasKeyword,
   cardHasKeywordOrFaction,
   categorize40kUnits,
+  getFactionEnhancements,
   isEnhancementAtCopyLimit,
   isUpgradeEnhancement,
   getEnhancementCopyLimit,
@@ -113,6 +114,24 @@ describe("isUnitEnhancementEligible", () => {
   it("respects excludes", () => {
     const excluded = { name: "Y", keywords: ["Adeptus Custodes"], excludes: [{ en: "Infantry" }] };
     expect(isUnitEnhancementEligible(character, excluded)).toBe(false);
+  });
+});
+
+describe("getFactionEnhancements", () => {
+  it("returns a 40K faction's enhancement array as-is", () => {
+    const enhancements = [{ name: "Superior Creation" }];
+    expect(getFactionEnhancements({ enhancements })).toBe(enhancements);
+  });
+
+  it("returns none for an AoS faction, which groups enhancements in an object", () => {
+    const aosFaction = { enhancements: { artefacts: [{ name: "Amulet" }], heroicTraits: [], other: [] } };
+    expect(getFactionEnhancements(aosFaction)).toEqual([]);
+  });
+
+  it("returns none for a missing faction or missing enhancements", () => {
+    expect(getFactionEnhancements(undefined)).toEqual([]);
+    expect(getFactionEnhancements({})).toEqual([]);
+    expect(getFactionEnhancements({ enhancements: null })).toEqual([]);
   });
 });
 

--- a/src/Helpers/faction.helpers.js
+++ b/src/Helpers/faction.helpers.js
@@ -57,6 +57,32 @@ const humaniseGroupKey = (key) =>
  * @param {Object} faction - faction from the datasource
  * @returns {Array} enhancements, each with an `enhancementGroup` label when grouped
  */
+const toCostNumber = (value) => {
+  // Number("") and Number(null) are both 0, so blanks have to be rejected first
+  // or an unpriced enhancement reads as free rather than as having no cost.
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+/**
+ * What an enhancement costs and in which currency, or null when it carries no
+ * cost at all. Points win over command points; a blank or non-numeric value
+ * counts as no cost, while an explicit 0 is a real (free) price.
+ *
+ * @param {Object} enhancement
+ * @returns {{value: number, label: string}|null}
+ */
+export const getEnhancementCost = (enhancement) => {
+  const points = toCostNumber(enhancement?.points);
+  if (points !== null) return { value: points, label: "pts" };
+
+  const commandPoints = toCostNumber(enhancement?.cpCost);
+  if (commandPoints !== null) return { value: commandPoints, label: "CP" };
+
+  return null;
+};
+
 export const getBrowsableEnhancements = (faction) => {
   const enhancements = faction?.enhancements;
   if (Array.isArray(enhancements)) return enhancements;

--- a/src/Helpers/faction.helpers.js
+++ b/src/Helpers/faction.helpers.js
@@ -24,3 +24,48 @@ export const getDetachmentFaction = (detachment) => {
   }
   return detachment?.faction || null;
 };
+
+/**
+ * Display labels for the groups an Age of Sigmar faction sorts its enhancements
+ * into. Unknown group keys fall back to a humanised form of the key itself, so
+ * a datasource that adds a group still lists it.
+ */
+const AOS_ENHANCEMENT_GROUPS = {
+  artefacts: "Artefacts of Power",
+  heroicTraits: "Heroic Traits",
+  other: "Other Enhancements",
+};
+
+const humaniseGroupKey = (key) =>
+  String(key)
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/^./, (c) => c.toUpperCase());
+
+/**
+ * Every enhancement a faction has, flattened for browsing and search, each
+ * tagged with the group it came from.
+ *
+ * 40K factions keep a flat array and have no groups. Age of Sigmar factions
+ * keep an object of group-keyed arrays (`{ artefacts, heroicTraits, other }`);
+ * those are flattened in group order so the list reads the way the battletome
+ * presents it.
+ *
+ * This is the browsing view. List building uses `getFactionEnhancements` from
+ * `listCategories.helpers`, which deliberately only accepts the 40K array shape
+ * because the enhancement picker cannot price or validate AoS entries.
+ *
+ * @param {Object} faction - faction from the datasource
+ * @returns {Array} enhancements, each with an `enhancementGroup` label when grouped
+ */
+export const getBrowsableEnhancements = (faction) => {
+  const enhancements = faction?.enhancements;
+  if (Array.isArray(enhancements)) return enhancements;
+  if (!enhancements || typeof enhancements !== "object") return [];
+
+  return Object.entries(enhancements).flatMap(([key, group]) =>
+    (Array.isArray(group) ? group : []).map((enhancement) => ({
+      ...enhancement,
+      enhancementGroup: AOS_ENHANCEMENT_GROUPS[key] || humaniseGroupKey(key),
+    })),
+  );
+};

--- a/src/Helpers/listCategories.helpers.js
+++ b/src/Helpers/listCategories.helpers.js
@@ -89,6 +89,19 @@ export const isEnhancementAtCopyLimit = (enhancement, cards, excludeUuid) => {
   return used >= getEnhancementCopyLimit(enhancement);
 };
 
+/**
+ * A faction's enhancements as a flat array, whatever shape the datasource uses.
+ *
+ * 40K factions store `enhancements` as an array. Age of Sigmar factions store an
+ * object of category-keyed arrays (`{ artefacts, heroicTraits, other }`), which
+ * the 40K enhancement picker cannot read — those factions report no enhancements
+ * instead of crashing the page on `.filter`.
+ *
+ * @param {Object} faction - faction from the datasource
+ * @returns {Array} the faction's enhancements, or `[]` when it has none usable
+ */
+export const getFactionEnhancements = (faction) => (Array.isArray(faction?.enhancements) ? faction.enhancements : []);
+
 export const isUnitEnhancementEligible = (card, enhancement) => {
   if (!enhancement) return false;
   if (cardHasKeyword(card, "Epic Hero")) return false;

--- a/src/Hooks/__tests__/useGlobalSearch.test.jsx
+++ b/src/Hooks/__tests__/useGlobalSearch.test.jsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const mockState = { dataSource: { data: [] } };
+
+vi.mock("../useDataSourceStorage", () => ({
+  useDataSourceStorage: () => ({ dataSource: mockState.dataSource }),
+}));
+
+// The real hook debounces by 150ms; searching immediately is what the tests want.
+vi.mock("../useDebounce", () => ({
+  useDebounce: (value) => value,
+}));
+
+import { useGlobalSearch } from "../useGlobalSearch";
+
+describe("useGlobalSearch", () => {
+  it("finds a 40K faction's enhancements", () => {
+    mockState.dataSource = {
+      data: [{ id: "SM", name: "Space Marines", enhancements: [{ name: "Artificer Armour" }] }],
+    };
+
+    const { result } = renderHook(() => useGlobalSearch("artificer"));
+
+    expect(result.current.results).toEqual([
+      expect.objectContaining({ name: "Artificer Armour", cardType: "enhancement", factionName: "Space Marines" }),
+    ]);
+  });
+
+  // AoS factions group enhancements by artefact/heroic trait/other, so they used
+  // to be missing from search entirely.
+  it("finds an AoS faction's grouped enhancements", () => {
+    mockState.dataSource = {
+      data: [
+        {
+          id: "STORMCAST_ETERNALS",
+          name: "Stormcast Eternals",
+          warscrolls: [],
+          enhancements: {
+            artefacts: [{ name: "Pennant of Azyrite Majesty" }],
+            heroicTraits: [{ name: "Staunch Defender" }],
+            other: [],
+          },
+        },
+      ],
+    };
+
+    const { result } = renderHook(() => useGlobalSearch("staunch"));
+
+    expect(result.current.results).toEqual([
+      expect.objectContaining({
+        name: "Staunch Defender",
+        cardType: "enhancement",
+        factionName: "Stormcast Eternals",
+        factionId: "STORMCAST_ETERNALS",
+      }),
+    ]);
+  });
+
+  it("needs at least two characters", () => {
+    mockState.dataSource = { data: [{ id: "SM", name: "Space Marines", enhancements: [{ name: "Aegis" }] }] };
+    const { result } = renderHook(() => useGlobalSearch("a"));
+    expect(result.current.results).toEqual([]);
+  });
+});

--- a/src/Hooks/__tests__/useViewerNavigation.test.jsx
+++ b/src/Hooks/__tests__/useViewerNavigation.test.jsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const mockState = { params: {}, dataSource: { data: [] } };
+const setActiveCard = vi.fn();
+
+vi.mock("react-router-dom", () => ({
+  useParams: () => mockState.params,
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: "/viewer", state: null }),
+}));
+
+vi.mock("../useDataSourceStorage", () => ({
+  useDataSourceStorage: () => ({
+    dataSource: mockState.dataSource,
+    selectedFaction: undefined,
+    updateSelectedFaction: vi.fn(),
+    clearSelectedFaction: vi.fn(),
+  }),
+}));
+
+vi.mock("../useCardStorage", () => ({
+  useCardStorage: () => ({ activeCard: undefined, setActiveCard }),
+}));
+
+vi.mock("../useSettingsStorage", () => ({
+  useSettingsStorage: () => ({ settings: {} }),
+}));
+
+import { useViewerNavigation } from "../useViewerNavigation";
+
+describe("useViewerNavigation enhancement route", () => {
+  beforeEach(() => {
+    setActiveCard.mockClear();
+  });
+
+  it("opens a 40K faction's enhancement", () => {
+    mockState.params = { faction: "space-marines", enhancement: "artificer-armour" };
+    mockState.dataSource = {
+      data: [{ id: "SM", name: "Space Marines", datasheets: [], enhancements: [{ name: "Artificer Armour" }] }],
+    };
+
+    renderHook(() => useViewerNavigation());
+
+    expect(setActiveCard).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Artificer Armour", cardType: "enhancement", faction_id: "SM" }),
+    );
+  });
+
+  // AoS factions group enhancements in an object of category-keyed arrays, so
+  // the array-shaped lookup must not run against them.
+  it("finds nothing for a faction whose enhancements are grouped by category", () => {
+    mockState.params = { faction: "kruleboyz", enhancement: "amulet" };
+    mockState.dataSource = {
+      data: [
+        {
+          id: "KRULEBOYZ",
+          name: "Kruleboyz",
+          warscrolls: [],
+          enhancements: { artefacts: [{ name: "Amulet" }], heroicTraits: [], other: [] },
+        },
+      ],
+    };
+
+    renderHook(() => useViewerNavigation());
+
+    expect(setActiveCard).toHaveBeenCalledWith();
+  });
+});

--- a/src/Hooks/__tests__/useViewerNavigation.test.jsx
+++ b/src/Hooks/__tests__/useViewerNavigation.test.jsx
@@ -47,19 +47,42 @@ describe("useViewerNavigation enhancement route", () => {
     );
   });
 
-  // AoS factions group enhancements in an object of category-keyed arrays, so
-  // the array-shaped lookup must not run against them.
-  it("finds nothing for a faction whose enhancements are grouped by category", () => {
-    mockState.params = { faction: "kruleboyz", enhancement: "amulet" };
+  // AoS factions group enhancements in an object of category-keyed arrays.
+  it("opens an AoS faction's grouped enhancement with the AoS renderer", () => {
+    mockState.params = { faction: "kruleboyz", enhancement: "amulet-of-destiny" };
     mockState.dataSource = {
       data: [
         {
           id: "KRULEBOYZ",
           name: "Kruleboyz",
           warscrolls: [],
-          enhancements: { artefacts: [{ name: "Amulet" }], heroicTraits: [], other: [] },
+          enhancements: {
+            artefacts: [{ name: "Amulet of Destiny", source: "aos-4e" }],
+            heroicTraits: [],
+            other: [],
+          },
         },
       ],
+    };
+
+    renderHook(() => useViewerNavigation());
+
+    expect(setActiveCard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Amulet of Destiny",
+        cardType: "enhancement",
+        faction_id: "KRULEBOYZ",
+        // "aos-4e" from the data would reach no renderer
+        source: "aos",
+        enhancementGroup: "Artefacts of Power",
+      }),
+    );
+  });
+
+  it("finds nothing when no enhancement matches the slug", () => {
+    mockState.params = { faction: "kruleboyz", enhancement: "not-a-real-artefact" };
+    mockState.dataSource = {
+      data: [{ id: "KRULEBOYZ", name: "Kruleboyz", warscrolls: [], enhancements: { artefacts: [], other: [] } }],
     };
 
     renderHook(() => useViewerNavigation());

--- a/src/Hooks/useGlobalSearch.js
+++ b/src/Hooks/useGlobalSearch.js
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useDataSourceStorage } from "./useDataSourceStorage";
 import { useDebounce } from "./useDebounce";
+import { getBrowsableEnhancements } from "../Helpers/faction.helpers";
 
 /**
  * Custom hook for cross-faction search
@@ -35,7 +36,9 @@ export function useGlobalSearch(searchText, factionFilter = null) {
         { items: toArray(faction.datasheets || faction.warscrolls), type: "unit", isBasic: false },
         { items: toArray(faction.stratagems), type: "stratagem", isBasic: false },
         { items: toArray(faction.basicStratagems), type: "stratagem", isBasic: true },
-        { items: toArray(faction.enhancements), type: "enhancement", isBasic: false },
+        // AoS factions group enhancements by artefact/heroic trait/other, so they
+        // need flattening before they can be searched alongside the 40K array.
+        { items: getBrowsableEnhancements(faction), type: "enhancement", isBasic: false },
         { items: toArray(faction.rules?.army), type: "rule", isBasic: false },
         { items: toArray(faction.rules?.detachment).flatMap((d) => toArray(d.rules)), type: "rule", isBasic: false },
         // AoS lores

--- a/src/Hooks/useViewerNavigation.jsx
+++ b/src/Hooks/useViewerNavigation.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { useDataSourceStorage } from "./useDataSourceStorage";
 import { useCardStorage } from "./useCardStorage";
 import { useSettingsStorage } from "./useSettingsStorage";
+import { getFactionEnhancements } from "../Helpers/listCategories.helpers";
 
 export function useViewerNavigation() {
   const { faction, unit, alliedFaction, alliedUnit, stratagem, spell, enhancement, rule } = useParams();
@@ -127,7 +128,7 @@ export function useViewerNavigation() {
         updateSelectedFaction(foundFaction);
       }
 
-      const foundEnhancement = foundFaction?.enhancements?.find((e) => {
+      const foundEnhancement = getFactionEnhancements(foundFaction).find((e) => {
         return e.name.replaceAll(" ", "-").toLowerCase() === enhancement;
       });
 

--- a/src/Hooks/useViewerNavigation.jsx
+++ b/src/Hooks/useViewerNavigation.jsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { useDataSourceStorage } from "./useDataSourceStorage";
 import { useCardStorage } from "./useCardStorage";
 import { useSettingsStorage } from "./useSettingsStorage";
-import { getFactionEnhancements } from "../Helpers/listCategories.helpers";
+import { getBrowsableEnhancements } from "../Helpers/faction.helpers";
 
 export function useViewerNavigation() {
   const { faction, unit, alliedFaction, alliedUnit, stratagem, spell, enhancement, rule } = useParams();
@@ -128,17 +128,20 @@ export function useViewerNavigation() {
         updateSelectedFaction(foundFaction);
       }
 
-      const foundEnhancement = getFactionEnhancements(foundFaction).find((e) => {
+      const foundEnhancement = getBrowsableEnhancements(foundFaction).find((e) => {
         return e.name.replaceAll(" ", "-").toLowerCase() === enhancement;
       });
 
       if (foundEnhancement) {
+        // AoS enhancements carry their own `source` ("aos-4e"), which no renderer
+        // is keyed on — the faction's shape decides which card display to use.
+        const enhancementSource = foundFaction?.warscrolls ? "aos" : foundFaction?.datasheets ? "40k-10e" : "40k";
         setActiveCard({
           ...foundEnhancement,
           id: `enhancement-${foundEnhancement.name}`, // Add unique id for changeActiveCard comparison
           cardType: "enhancement",
           faction_id: foundFaction?.id,
-          source: foundFaction?.datasheets ? "40k-10e" : "40k",
+          source: enhancementSource,
         });
       } else {
         setActiveCard();

--- a/src/Pages/ViewerMobile.jsx
+++ b/src/Pages/ViewerMobile.jsx
@@ -44,6 +44,7 @@ export const ViewerMobile = ({
   showUnits = false,
   showManifestationLores = false,
   showSpellLores = false,
+  showEnhancements = false,
   showGlossary = false,
 }) => {
   const [parent] = useAutoAnimate({ duration: 75 });
@@ -234,6 +235,7 @@ export const ViewerMobile = ({
   const activeExtraView = config.extraRouteViews.find((view) => {
     if (view.prop === "showManifestationLores") return showManifestationLores;
     if (view.prop === "showSpellLores") return showSpellLores;
+    if (view.prop === "showEnhancements") return showEnhancements;
     return false;
   });
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -439,6 +439,7 @@ const router = createBrowserRouter([
       { path: "mobile/:faction/manifestation-lore/:spell", element: <ViewerMobile /> },
       { path: "mobile/:faction/spell-lores", element: <ViewerMobile showSpellLores /> },
       { path: "mobile/:faction/spell-lore/:spell", element: <ViewerMobile /> },
+      { path: "mobile/:faction/enhancements", element: <ViewerMobile showEnhancements /> },
       { path: "mobile/:faction/enhancement/:enhancement", element: <ViewerMobile /> },
       { path: "mobile/:faction/rule/:rule", element: <ViewerMobile /> },
       { path: "mobile/:faction/stratagem/:stratagem", element: <ViewerMobile /> },

--- a/src/styles/aos.less
+++ b/src/styles/aos.less
@@ -1436,6 +1436,55 @@
   }
 
   // ============================================
+  // ENHANCEMENT CARD
+  // ============================================
+  // Reuses the spell card layout; only the cost badge and the phase line differ,
+  // since an enhancement is priced rather than cast.
+  .enhancement-card-cost {
+    background: var(--stat-wheel-gold);
+    color: #fff;
+    min-width: 50px;
+    height: 50px;
+    padding: 0 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    border-radius: 25px;
+    flex-shrink: 0;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+
+    .enhancement-cost-number {
+      font-family: "Cinzel", serif;
+      font-size: 20px;
+      font-weight: 800;
+      line-height: 1;
+      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+    }
+
+    .enhancement-cost-label {
+      font-family: "Cinzel", serif;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+    }
+  }
+
+  .enhancement-card-phase {
+    font-family: "Cinzel", serif;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: #666;
+    padding-bottom: 12px;
+    margin-bottom: 16px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+  }
+
+  // ============================================
   // LINKED WARSCROLL BUTTON (on spell cards)
   // ============================================
   .linked-warscroll-button {


### PR DESCRIPTION
## Proposed Changes

Opening any Age of Sigmar warscroll on mobile replaced the page with the "Sorry, something went wrong" error boundary and `d.enhancements.filter is not a function` (reported on Discord for Kruleboyz, reproduces for every AoS faction).

Cause: `ListAdd` is mounted unconditionally behind every mobile card in `ViewerMobile`, and it computes the card faction's available enhancements *before* the `!Array.isArray(activeCard?.points)` guard that is supposed to skip AoS warscrolls. 40K factions store `enhancements` as a flat array; AoS factions store an object of category-keyed arrays (`{ artefacts, heroicTraits, other }`), so `.filter` threw during render. Optional chaining did not help — the property exists, it is just not an array. Verified against the deployed bundle: the reported stack frame `index-DhF_6p-W.js:1199:35262` lands exactly on that expression.

### The crash

- Add `getFactionEnhancements(faction)` to `listCategories.helpers.js`, returning the enhancement array for 40K factions and `[]` for shapes the 40K enhancement picker cannot read.
- Use it in `ListAdd`, and in the other enhancement pickers with the same exposure: `ListEditCard`, `UnitConfigModal`, and `MobileFaction` (which had the guard inline).

### Hardening

`useDataSourceItems` and the `/enhancement/:name` route still indexed enhancements as an array. Neither was reachable for AoS at the time, so this was hardening rather than a live crash.

### Surfacing AoS enhancements

Chasing the shape mismatch turned up why nothing had hit it: AoS artefacts of power, heroic traits and other enhancements had no reader at all. They were absent from search, from the faction screen and from the card display, though the data ships them (Stormcast 21, Skaven 20, Sylvaneth 23; Kruleboyz happens to have none, which is why the reporter never missed them).

- `getBrowsableEnhancements(faction)` in `faction.helpers.js` flattens both shapes, tagging each entry with its group label. This is the browsing view; list building keeps `getFactionEnhancements`, which still takes only the 40K array, because the enhancement picker cannot price or validate AoS entries.
- `EnhancementCard` reuses the spell card layout — the data has the same declare/effect shape — with a points/CP cost badge and a phase line.
- An Enhancements list on the AoS faction screen (`/mobile/:faction/enhancements`), the enhancement content type in the desktop panel, and inclusion in global search.
- AoS entries carry `source: "aos-4e"`, which no renderer is keyed on, so the faction's shape now decides the card display.
- `getEnhancementCost` reads a cost from either currency. `Number("")` and `Number(null)` are both `0`, so blanks are rejected before coercion — otherwise an unpriced enhancement renders an empty badge next to "pts" — while an explicit `0` stays a real price.

### Tests

Helper unit tests for both shapes; a `ListAdd` regression test that renders an AoS warscroll; and coverage for search, the enhancement route, the desktop list and the new card. The crash and hardening tests were each confirmed to fail without their fix.

Note: `yarn build` cannot complete in the sandbox — `starcraft-tmg.less` and `aos.less` both `@import` Google Fonts over the network, which the environment's proxy rejects. Pre-existing and unrelated; the new LESS was compiled separately to confirm it is valid.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes (`yarn lint`, `yarn test:ci` — 3205 passed)