### PR TITLE
Link Starcraft weapon keywords to the datasource glossary

### DIFF
--- a/changes/unreleased/starcraft-weapon-keyword-glossary.json
+++ b/changes/unreleased/starcraft-weapon-keyword-glossary.json
@@ -1,0 +1,5 @@
+{
+  "title": "Starcraft weapon keywords link to the glossary again",
+  "body": "On Starcraft datacards, keywords added to a weapon were printed as raw text and never matched a glossary entry. They now render as proper keyword tags with their tooltips and explanation lines, just like on the other game systems.",
+  "severity": "warning"
+}

--- a/docs/custom datasource/keyword-glossary.md
+++ b/docs/custom datasource/keyword-glossary.md
@@ -150,7 +150,16 @@ AoS and Starcraft TMG render glossary keywords through three system-neutral comp
 |-------------|---------|-----------|
 | `40k-10e` / `40k-11e` | `Ds40kUnitWeapons` → `Ds40kWeaponKeywords` (inline tags) + a `<div class="special">` of `.ability` rows. Uses the 40K-native components rather than the shared ones. | `Ds40kUnitExtra` → `UnitAbilityDescription` (`glossaryOnly`). |
 | `aos` | `DsAosWeapons` → `GlossaryKeywordTags` replaces the plain `weapon-ability-badge` pills (desktop + mobile); `GlossaryExplanationRows` renders below the weapon table. Falls back to plain badges when no glossary is present. | `DsAosAbilities` → `GlossaryText` on `ability.description`, but only when there is an actual abilities-scoped tooltip match (otherwise the normal `MarkdownDisplay` path is kept so formatting survives). |
-| `starcraft-tmg` | `StarcraftWeaponTable` → the keyword column (any column whose `key` is `keyword`/`keywords`) is split with `splitKeywordString` and rendered via `GlossaryKeywordTags`; `GlossaryExplanationRows` renders below the table (desktop + mobile). | `StarcraftAbility` → `GlossaryText` on `ability.description`. |
+| `starcraft-tmg` | `StarcraftWeaponTable` → keywords from a string column (`key` = `keyword`, split with `splitKeywordString`) **and** from the `profile.keywords` array (see below) render via `GlossaryKeywordTags`; `GlossaryExplanationRows` renders below the table (desktop + mobile). | `StarcraftAbility` → `GlossaryText` on `ability.description`. |
+
+### Where Starcraft TMG weapon keywords come from
+
+A TMG weapon type can carry keywords two ways, and both resolve against the glossary:
+
+- **A schema column keyed `keyword`** holding a comma-separated string cell (`Target (Ground), Long Range (18")`) — the shape the built-in Starcraft TMG datasource uses.
+- **`profile.keywords`**, the array the card editors write when the weapon type has `hasKeywords` enabled. `StarcraftWeaponTable` appends a trailing keywords column for it whenever any profile carries a tag, falling back to the parent weapon's `keywords` when a profile has none. The column's header uses the label of a stripped reserved column when the schema has one, otherwise `Keywords`.
+
+A schema column whose `key` is a reserved weapon profile field (`keywords`, `name`, `active`, `upgrade` — see `RESERVED_WEAPON_PROFILE_KEYS`) is dropped before rendering: the data model owns that field, so printing its raw value dumped the keyword array into the cell as `Repeating,testing`. The schema editor blocks those keys, but older and imported datasources can still carry one.
 
 Description text can include newlines and bullet markers (`• `) which the 40K `UnitAbilityDescription` renders verbatim; the shared `GlossaryText` renders plain text plus tooltip spans.
 
@@ -166,4 +175,5 @@ Description text can include newlines and bullet markers (`• `) which the 40K 
 - Create a `blank`-base datasource → glossary starts empty; manually-added entries with `Weapons` selected render correctly.
 - **AoS:** on an `aos` datasource, add a glossary entry scoped to `Weapons`, then add that keyword to a warscroll weapon profile → the keyword tag is styled and (explanation mode) an explanation row renders below the weapon table.
 - **Starcraft TMG:** on a `starcraft-tmg` datasource, add a glossary entry whose name matches a token in a weapon's `Keyword` column (e.g. `Target (Ground)` exact, or `Long Range` prefix) → the column splits into styled tags and explanation rows render below the table.
+- **Starcraft TMG (keyword arrays):** on a weapon type with `hasKeywords` enabled, add a keyword to a weapon profile in the card editor and a glossary entry with the same name scoped to `Weapons` → a `Keywords` column appears with styled tags and the explanation row renders below the table.
 - **Abilities (AoS / TMG):** add an entry scoped to `Abilities` with display mode `Hover tooltip`, reference its name in an ability description → the name gets a dotted underline + hover tooltip in the rendered card.

--- a/src/Components/DatasourceEditor/cards/starcraft/StarcraftWeaponTable.jsx
+++ b/src/Components/DatasourceEditor/cards/starcraft/StarcraftWeaponTable.jsx
@@ -113,8 +113,11 @@ export const StarcraftWeaponTable = ({ weapons, weaponTypeDef, isLast, isMobile,
 
   if (!rows.length) return null;
 
-  // The profile keyword array only gets a column when the weapon type declares
-  // keywords and something actually carries one.
+  // The profile keyword array only gets a column when the weapon type allows
+  // keywords and something actually carries one. `!== false` rather than
+  // `=== true` on purpose: keywords default to on when the field is unset, the
+  // same reading `CustomCardWeapons` and the premium weapons editor use, so a
+  // schema predating the field still renders the keywords its cards hold.
   const showProfileKeywords = weaponTypeDef?.hasKeywords !== false && rows.some((row) => row.keywords.length > 0);
   const renderedColumns = showProfileKeywords
     ? [...columns, { key: PROFILE_KEYWORDS_KEY, label: reservedKeywordColumn?.label || "Keywords", type: "string" }]

--- a/src/Components/DatasourceEditor/cards/starcraft/StarcraftWeaponTable.jsx
+++ b/src/Components/DatasourceEditor/cards/starcraft/StarcraftWeaponTable.jsx
@@ -1,10 +1,30 @@
 import React from "react";
+import { isReservedWeaponProfileKey, normalizeKeywords } from "../../../../Helpers/weaponProfile.helpers";
 import {
   GlossaryExplanationRows,
   GlossaryKeywordTags,
   getKeywordExplanations,
   splitKeywordString,
 } from "../shared/GlossaryKeywords";
+
+/**
+ * Column key of the synthesised keywords column. It is not a schema column:
+ * weapon keywords live on the profile itself (`profile.keywords`), so the
+ * column exists only to give those tags a header and a cell to render in.
+ */
+const PROFILE_KEYWORDS_KEY = "__profileKeywords";
+
+const isKeywordColumnKey = (key) => /^keywords?$/i.test(key || "");
+
+/**
+ * The keyword tags a weapon profile carries, normalised to an array (saved
+ * cards can hold a bare string here). Falls back to the parent weapon's own
+ * keywords when the profile has none.
+ */
+const profileKeywords = (profile, weapon) => {
+  const own = normalizeKeywords(profile?.keywords);
+  return own.length > 0 ? own : normalizeKeywords(weapon?.keywords);
+};
 
 /**
  * Renders the weapon list for a single Starcraft TMG phase (Assault or Combat).
@@ -20,19 +40,33 @@ import {
  * cards: each weapon gets a name banner and a stat grid with column labels
  * inline, so the data stays scannable on a narrow screen.
  *
- * When a `glossary` is supplied, the keyword column (a comma-separated string
- * cell whose key is `keyword`/`keywords`) renders glossary-styled tags with
+ * Keywords reach the table through two routes, and both resolve against the
+ * datasource glossary:
+ * - a schema column keyed `keyword` holding a comma-separated string cell
+ * - `profile.keywords`, the array the card editors write when the weapon type
+ *   has `hasKeywords` enabled — rendered in a trailing "Keywords" column
+ *
+ * When a `glossary` is supplied those tags get their glossary styling and
  * hover tooltips, and matching explanation-mode entries render as explanation
  * rows below the table.
  */
 export const StarcraftWeaponTable = ({ weapons, weaponTypeDef, isLast, isMobile, glossary }) => {
-  const columns = weaponTypeDef?.columns || [];
+  const schemaColumns = weaponTypeDef?.columns || [];
   const relation = weaponTypeDef?.profileRelation || "parent-child";
   const indentSubProfiles = relation === "parent-child";
   if (!weapons?.length) return null;
 
   const hasGlossary = Array.isArray(glossary) && glossary.length > 0;
-  const isKeywordColumn = (col) => /^keywords?$/i.test(col?.key || "");
+
+  // A column keyed after a reserved profile field (`keywords`, `name`, …) is
+  // not a real column — the data model owns that field, and the card editors
+  // never write a plain cell value to it. Rendering it would dump the raw
+  // value (an array of keywords stringifies to "Repeating,testing"), so drop
+  // it here and let the synthesised keywords column below do the work.
+  const columns = schemaColumns.filter((col) => !isReservedWeaponProfileKey(col?.key));
+  const reservedKeywordColumn = schemaColumns.find(
+    (col) => isReservedWeaponProfileKey(col?.key) && isKeywordColumnKey(col?.key),
+  );
 
   const cellValue = (source, field) => {
     if (!source) return "-";
@@ -60,6 +94,9 @@ export const StarcraftWeaponTable = ({ weapons, weaponTypeDef, isLast, isMobile,
             indent: pIdx > 0 && indentSubProfiles,
             upgrade: Boolean(profile.upgrade || (pIdx === 0 && weapon.upgrade)),
             data: profile,
+            // Saved cards can carry the keywords on the weapon rather than on
+            // each profile, so the profile value falls back to the parent's.
+            keywords: profileKeywords(profile, weapon),
           });
         });
     } else {
@@ -69,44 +106,63 @@ export const StarcraftWeaponTable = ({ weapons, weaponTypeDef, isLast, isMobile,
         indent: false,
         upgrade: Boolean(weapon.upgrade),
         data: weapon,
+        keywords: profileKeywords(weapon, weapon),
       });
     }
   });
 
   if (!rows.length) return null;
 
-  // Parse each keyword cell once (TMG stores keywords as a comma-separated
-  // string column): row data object → { [colKey]: tags }. Both the
-  // explanation rows and the per-cell render read from this.
-  const keywordColumns = columns.filter(isKeywordColumn);
+  // The profile keyword array only gets a column when the weapon type declares
+  // keywords and something actually carries one.
+  const showProfileKeywords = weaponTypeDef?.hasKeywords !== false && rows.some((row) => row.keywords.length > 0);
+  const renderedColumns = showProfileKeywords
+    ? [...columns, { key: PROFILE_KEYWORDS_KEY, label: reservedKeywordColumn?.label || "Keywords", type: "string" }]
+    : columns;
+
+  const isKeywordColumn = (col) => col?.key === PROFILE_KEYWORDS_KEY || isKeywordColumnKey(col?.key);
+
+  // Resolve each row's keyword tags once: row key → { [colKey]: tags }. Both
+  // the explanation rows and the per-cell render read from this.
+  const keywordColumns = renderedColumns.filter(isKeywordColumn);
   const keywordTagsByRow = new Map();
-  if (hasGlossary) {
-    rows.forEach((row) => {
-      const byCol = {};
-      keywordColumns.forEach((col) => {
-        byCol[col.key] = splitKeywordString(row.data?.[col.key]);
-      });
-      keywordTagsByRow.set(row.data, byCol);
+  rows.forEach((row) => {
+    const byCol = {};
+    keywordColumns.forEach((col) => {
+      byCol[col.key] = col.key === PROFILE_KEYWORDS_KEY ? row.keywords : splitKeywordString(row.data?.[col.key]);
     });
-  }
+    keywordTagsByRow.set(row.key, byCol);
+  });
+
+  const keywordTags = (row, col) => keywordTagsByRow.get(row.key)?.[col.key] || [];
 
   const explanationEntries = hasGlossary
     ? getKeywordExplanations(
-        rows.flatMap((row) => keywordColumns.flatMap((col) => keywordTagsByRow.get(row.data)[col.key])),
+        rows.flatMap((row) => keywordColumns.flatMap((col) => keywordTags(row, col))),
         glossary,
         "weapons",
       )
     : [];
 
+  // Plain-text value of a cell, used for the mobile wide/compact split and as
+  // the fallback whenever a keyword cell has no glossary to resolve against.
+  const columnText = (row, col) => {
+    if (col.key === PROFILE_KEYWORDS_KEY) {
+      const tags = keywordTags(row, col);
+      return tags.length > 0 ? tags.join(", ") : "-";
+    }
+    return cellValue(row.data, col);
+  };
+
   // Keyword columns render as glossary-styled tags; every other column stays plain text.
-  const renderCell = (data, col) => {
+  const renderCell = (row, col) => {
     if (hasGlossary && isKeywordColumn(col)) {
-      const tags = keywordTagsByRow.get(data)?.[col.key] || [];
+      const tags = keywordTags(row, col);
       if (tags.length > 0) {
         return <GlossaryKeywordTags keywords={tags} glossary={glossary} scope="weapons" />;
       }
     }
-    return cellValue(data, col);
+    return columnText(row, col);
   };
 
   if (isMobile) {
@@ -118,11 +174,11 @@ export const StarcraftWeaponTable = ({ weapons, weaponTypeDef, isLast, isMobile,
     const WIDE_THRESHOLD = 12;
     const isWideColumn = (col) =>
       rows.some((row) => {
-        const value = cellValue(row.data, col);
+        const value = columnText(row, col);
         return typeof value === "string" && value !== "-" && value.length > WIDE_THRESHOLD;
       });
-    const compactColumns = columns.filter((col) => !isWideColumn(col));
-    const wideColumns = columns.filter((col) => isWideColumn(col));
+    const compactColumns = renderedColumns.filter((col) => !isWideColumn(col));
+    const wideColumns = renderedColumns.filter((col) => isWideColumn(col));
 
     return (
       <div className={`sc-weapon-cards${isLast ? " is-last" : ""}`}>
@@ -142,18 +198,17 @@ export const StarcraftWeaponTable = ({ weapons, weaponTypeDef, isLast, isMobile,
                 {compactColumns.map((col) => (
                   <div key={col.key} className="sc-weapon-card-stat">
                     <span className="sc-weapon-card-stat-label">{col.label}</span>
-                    <span className="sc-weapon-card-stat-value">{renderCell(row.data, col)}</span>
+                    <span className="sc-weapon-card-stat-value">{renderCell(row, col)}</span>
                   </div>
                 ))}
               </div>
             )}
             {wideColumns.map((col) => {
-              const value = cellValue(row.data, col);
-              if (value === "-") return null;
+              if (columnText(row, col) === "-") return null;
               return (
                 <div key={col.key} className="sc-weapon-card-wide">
                   <span className="sc-weapon-card-wide-label">{col.label}</span>
-                  <span className="sc-weapon-card-wide-value">{renderCell(row.data, col)}</span>
+                  <span className="sc-weapon-card-wide-value">{renderCell(row, col)}</span>
                 </div>
               );
             })}
@@ -184,7 +239,7 @@ export const StarcraftWeaponTable = ({ weapons, weaponTypeDef, isLast, isMobile,
         <thead>
           <tr>
             <th>Name</th>
-            {columns.map((col) => (
+            {renderedColumns.map((col) => (
               <th key={col.key}>{col.label}</th>
             ))}
           </tr>
@@ -193,8 +248,8 @@ export const StarcraftWeaponTable = ({ weapons, weaponTypeDef, isLast, isMobile,
           {rows.map((row) => (
             <tr key={row.key} className={row.indent ? "sc-weapon-profile" : "sc-weapon-row"}>
               {renderNameCell(row.name, { indent: row.indent, upgrade: row.upgrade })}
-              {columns.map((col) => (
-                <td key={col.key}>{renderCell(row.data, col)}</td>
+              {renderedColumns.map((col) => (
+                <td key={col.key}>{renderCell(row, col)}</td>
               ))}
             </tr>
           ))}

--- a/src/Components/DatasourceEditor/cards/starcraft/__tests__/StarcraftWeaponTable.glossary.test.jsx
+++ b/src/Components/DatasourceEditor/cards/starcraft/__tests__/StarcraftWeaponTable.glossary.test.jsx
@@ -71,3 +71,116 @@ describe("StarcraftWeaponTable keyword glossary", () => {
     expect(screen.getByText('Target (Ground), Long Range (18")')).toBeInTheDocument();
   });
 });
+
+// Weapon types with `hasKeywords` store their keywords as an array on the
+// profile (`profile.keywords`) instead of in a schema column — the shape the
+// card editors write. Those tags have to resolve against the glossary too.
+describe("StarcraftWeaponTable profile keyword arrays", () => {
+  const keywordArrayTypeDef = {
+    key: "assault",
+    label: "Assault",
+    hasKeywords: true,
+    hasProfiles: true,
+    columns: [
+      { key: "rng", label: "RNG", type: "string" },
+      { key: "dmg", label: "DMG", type: "string" },
+    ],
+  };
+
+  const arrayWeapons = [
+    {
+      name: "Tendril Strike",
+      profiles: [{ name: "Tendril Strike", active: true, rng: "2", dmg: "1", keywords: ["Repeating", "Long Range"] }],
+    },
+  ];
+
+  it("renders profile keywords as glossary tags in a keywords column", () => {
+    const { container } = render(
+      <StarcraftWeaponTable weapons={arrayWeapons} weaponTypeDef={keywordArrayTypeDef} glossary={glossary} />,
+    );
+    const headers = [...container.querySelectorAll("th")].map((th) => th.textContent);
+    expect(headers).toContain("Keywords");
+    // Both tags render, and the glossary-matched one carries its tooltip.
+    expect(container.querySelectorAll(".ds-kw-tag")).toHaveLength(2);
+    expect(container.querySelector("[data-tooltip-content]").getAttribute("data-tooltip-content")).toMatch(
+      /Adds range/i,
+    );
+    // The raw array must never reach the cell as a stringified value.
+    expect(screen.queryByText("Repeating,Long Range")).toBeNull();
+  });
+
+  it("renders explanation rows for profile keywords", () => {
+    const explanationGlossary = [
+      {
+        key: "repeating",
+        name: "Repeating",
+        description: "Roll the attack dice twice.",
+        matchType: "exact",
+        appliesTo: ["weapons"],
+        displayMode: "explanation",
+      },
+    ];
+    render(
+      <StarcraftWeaponTable
+        weapons={arrayWeapons}
+        weaponTypeDef={keywordArrayTypeDef}
+        glossary={explanationGlossary}
+      />,
+    );
+    expect(screen.getByTestId("ds-kw-explanations")).toBeInTheDocument();
+    expect(screen.getByText(/Roll the attack dice twice/i)).toBeInTheDocument();
+  });
+
+  it("falls back to the parent weapon's keywords when the profile has none", () => {
+    const weaponLevel = [
+      {
+        name: "Tendril Strike",
+        keywords: ["Repeating"],
+        profiles: [{ name: "Tendril Strike", active: true, rng: "2", dmg: "1" }],
+      },
+    ];
+    const { container } = render(
+      <StarcraftWeaponTable weapons={weaponLevel} weaponTypeDef={keywordArrayTypeDef} glossary={glossary} />,
+    );
+    expect(container.querySelectorAll(".ds-kw-tag")).toHaveLength(1);
+  });
+
+  it("lists profile keywords as plain text when no glossary is supplied", () => {
+    const { container } = render(<StarcraftWeaponTable weapons={arrayWeapons} weaponTypeDef={keywordArrayTypeDef} />);
+    expect(container.querySelector(".ds-kw-tag")).toBeNull();
+    expect(screen.getByText("Repeating, Long Range")).toBeInTheDocument();
+  });
+
+  it("drops a schema column keyed after the reserved keywords field", () => {
+    // Older/imported schemas can carry a column keyed `keywords`; rendering it
+    // dumped the raw array into the cell ("Repeating,Long Range").
+    const withReservedColumn = {
+      ...keywordArrayTypeDef,
+      columns: [...keywordArrayTypeDef.columns, { key: "keywords", label: "Keyword tags", type: "string" }],
+    };
+    const { container } = render(
+      <StarcraftWeaponTable weapons={arrayWeapons} weaponTypeDef={withReservedColumn} glossary={glossary} />,
+    );
+    const headers = [...container.querySelectorAll("th")].map((th) => th.textContent);
+    // Only one keyword column, carrying the schema column's label.
+    expect(headers.filter((h) => /keyword/i.test(h))).toEqual(["Keyword tags"]);
+    expect(screen.queryByText("Repeating,Long Range")).toBeNull();
+    expect(container.querySelectorAll(".ds-kw-tag")).toHaveLength(2);
+  });
+
+  it("omits the keywords column when no profile carries a keyword", () => {
+    const bare = [{ name: "Tendril Strike", profiles: [{ name: "Tendril Strike", active: true, rng: "2", dmg: "1" }] }];
+    const { container } = render(
+      <StarcraftWeaponTable weapons={bare} weaponTypeDef={keywordArrayTypeDef} glossary={glossary} />,
+    );
+    const headers = [...container.querySelectorAll("th")].map((th) => th.textContent);
+    expect(headers).toEqual(["Name", "RNG", "DMG"]);
+  });
+
+  it("renders profile keywords on the mobile card layout", () => {
+    const { container } = render(
+      <StarcraftWeaponTable weapons={arrayWeapons} weaponTypeDef={keywordArrayTypeDef} glossary={glossary} isMobile />,
+    );
+    expect(container.querySelectorAll(".ds-kw-tag")).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Problem

On a `starcraft-tmg` datasource, keywords added to a weapon never linked to the keyword glossary: no styled tags, no tooltips, no explanation rows. The keyword cell printed the raw value instead, e.g. `Repeating,testing`.

`StarcraftWeaponTable` only understood one keyword shape — a schema column keyed `keyword`/`keywords` holding a comma-separated string. Weapon types with `hasKeywords` enabled store keywords as an array on the profile (`profile.keywords`), which the card editors write and the AoS renderer already handles. That array fell through to the plain-text cell path, where `String(["Repeating", "testing"])` produced the observed output.

A second issue compounded it: a schema column keyed `keywords` is a reserved weapon profile field. The schema editor blocks those keys and the card editors skip them, but older/imported datasources still carry one, and the Starcraft renderer printed it — which is where the raw array became visible in the first place.

## Changes

- `StarcraftWeaponTable` resolves `profile.keywords` against the glossary and renders it in a trailing keywords column (desktop table and mobile cards), falling back to the parent weapon's `keywords` when a profile has none — matching `DsAosWeapons`.
- The column only appears when the weapon type declares keywords and something actually carries one; its header reuses a stripped reserved column's label when the schema has one, otherwise `Keywords`.
- Columns keyed after a reserved weapon profile field (`name`, `active`, `keywords`, `upgrade`) are dropped before rendering, so the raw array can no longer reach a cell.
- Without a glossary, profile keywords render as plain comma-separated text; existing string-column behaviour is unchanged.

## Tests

Seven new cases in `StarcraftWeaponTable.glossary.test.jsx` cover the array path: glossary tags and tooltips, explanation rows, the weapon-level fallback, the no-glossary plain-text path, the stripped reserved column, the column being omitted when no keywords exist, and the mobile layout. Full suite passes (3212 tests), lint clean.

## Docs

`docs/custom datasource/keyword-glossary.md` documents both keyword routes for Starcraft TMG and the reserved-key stripping, plus a verification checklist entry.


---
_Generated by [Claude Code](https://claude.ai/code/session_012Aop9buwoX9VWXpsEnh9Ge)_