### PR TITLE
Edit 11e stratagem restrictions and weapon abilities

### DIFF
--- a/changes/unreleased/11e-editable-values.json
+++ b/changes/unreleased/11e-editable-values.json
@@ -1,0 +1,5 @@
+{
+  "title": "Edit stratagem restrictions and weapon abilities in 11th edition",
+  "body": "Stratagems that carry a restrictions section — like Insane Bravery's \"cannot be used more than once per battle\" — can now be edited: the 11th edition stratagem editor has a Restrictions field next to When, Target and Effect, and it works on stratagems that had no restrictions yet. Weapon abilities such as Overcharge or Conversion now show up under their weapon's profiles on the card and can be added, edited and removed per weapon. Colouring text in the editor now shows on 11th edition cards instead of being dropped. Enhancements get a List eligibility panel for the keywords a unit needs, the keywords that rule it out, and whether non-Characters can take it, and rule parts that never print on the card (quotes and examples) keep their type when the card is edited.",
+  "severity": "info"
+}

--- a/docs/40k-11e-card-editing.md
+++ b/docs/40k-11e-card-editing.md
@@ -30,6 +30,8 @@ how it reads and writes every field.
 
 - [Edit-the-active-language model](#edit-the-active-language-model)
 - [Plain vs language-keyed fields](#plain-vs-language-keyed-fields)
+  - [Fields the datasource omits](#fields-the-datasource-omits)
+  - [Panels beyond the card](#panels-beyond-the-card)
 - [The localisation helpers](#the-localisation-helpers)
 - [Optional show/hide flags](#optional-showhide-flags)
 - [Markup in text fields](#markup-in-text-fields)
@@ -61,19 +63,47 @@ them raw (and some are concatenated into `data-*` attributes):
   stat values `m/t/sv/w/ld/oc`, weapon `range/attacks/skill/strength/ap/damage`,
   `abilities.invul.value`, point `models/cost/keyword`, and all `styling.*`
   numbers and `show*` booleans.
+- Enhancement `keywords[]` / `excludes[]` / `equipableByNonCharacter` — list
+  eligibility is matched against the **English** keyword, so these stay plain.
 
 Everything else is **language-keyed** and edited in place: stat profile `name`;
-weapon profile `name`; `abilities.core[].name` / `faction[].name` /
-`other[].name` / `other[].description`; `abilities.primarch[].name` and its
-nested `abilities.primarch[].abilities[].name` / `.description`;
+weapon profile `name`; weapon `abilities[].name` / `.description`;
+`abilities.core[].name` / `faction[].name` / `other[].name` /
+`other[].description`; `abilities.primarch[].name` and its nested
+`abilities.primarch[].abilities[].name` / `.description`;
 `abilities.damaged.range` / `description`; `composition[]`, `loadout`, `leader`,
 `wargear[]`; unit `keywords[]`; **stratagem**
-`name`/`when`/`target`/`effect`/`detachment`/`type`; **enhancement**
-`name`/`description`/`detachment`; **rule**
+`name`/`when`/`target`/`effect`/`restrictions`/`detachment`/`type`;
+**enhancement** `name`/`description`/`detachment`; **rule**
 `name`/`detachment`/`rules[].title`/`rules[].text`.
 
 > Note the asymmetry: a **unit's** top-level `name` is plain, but
 > **stratagem / enhancement / rule** names are language-keyed.
+
+### Fields the datasource omits
+
+A few language-keyed fields are only present on the cards that use them — a
+stratagem's `restrictions`, a points tier's `faction`/`detachment` restriction.
+`setLocalizedField` returns a plain string when there is nothing to merge into,
+which would store the first value typed in, say, German as a taggless string
+that then shows in every language. Editors for such fields use
+`setLocalizedFieldSeeded`, which starts them as `{ [language]: value }`, and
+drop the field again (via `isLocalizedFieldEmpty`) once it is empty in every
+language, so the card returns to the shape the datasource ships.
+
+### Panels beyond the card
+
+Two editor panels write data that is not printed on the card:
+
+- **Enhancement → List eligibility** — `equipableByNonCharacter` (the
+  "(Upgrade)" entries a non-Character unit may take), plus the `keywords` a unit
+  must have and the `excludes` it must not. This is what
+  `isUnitEnhancementEligible` (`listCategories.helpers.js`) reads in the list
+  builder.
+- **Rule → part type** — the type list includes `quote` and `textItalic`, the
+  rulebook examples `RuleCard` deliberately skips. They are offered (labelled
+  "not shown on card") so an existing part keeps its type instead of silently
+  turning into body text when it is edited.
 
 ## The localisation helpers
 
@@ -116,3 +146,7 @@ use `<k>keyword</k>` for highlighted keywords, `<b>bold</b>`,
 `<ul><li>…</li></ul>` lists, line breaks and `■` bullets (leader text). This is
 the 11e markup described in [warhammer-40k-11e-format.md](warhammer-40k-11e-format.md),
 not the 10e bracket/keyword-dictionary syntax.
+
+The editor's colour picker writes `<span style="color: …">`; the 11e renderer
+keeps that colour (and drops every other style) exactly as the 10e renderer
+does, so colouring text in the editor shows up on the card.

--- a/docs/warhammer-40k-11e-format.md
+++ b/docs/warhammer-40k-11e-format.md
@@ -50,6 +50,9 @@ detachments, rules).
 - [Datasheet column layout](#datasheet-column-layout)
 - [Rich-text markup](#rich-text-markup)
 - [Keyword glossary (tooltips)](#keyword-glossary-tooltips)
+- [Weapons](#weapons)
+- [Stratagems](#stratagems)
+- [Enhancements](#enhancements)
 - [Points, unit sizes and roster surcharge](#points-unit-sizes-and-roster-surcharge)
 - [Wargear options](#wargear-options)
 - [Rule cards](#rule-cards)
@@ -145,7 +148,9 @@ so the component localises both through `localize(...)`.
 `MarkupText`. `normalize11eMarkup` converts `<k>…</k>` → `<span
 class="gdc-keyword">`, normalises `\r` to `\n`, and puts `■` bullets on their own
 line; `MarkupText` then renders it through ReactMarkdown (with `rehype-raw` +
-sanitisation allowing `span[class]`, `strong`, `ul`, `li`). No keyword dictionary
+sanitisation allowing `span[class]`, `span[style]`, `strong`, `ul`, `li`). Of the
+styles only `color` is applied — that is what the shared editor's colour picker
+writes — matching the 10e renderer. No keyword dictionary
 is needed for this **highlighting** because keywords are already explicitly
 tagged in the data. Hover **explanations** for keywords and core abilities come
 from a separate glossary file — see [Keyword glossary](#keyword-glossary-tooltips).
@@ -190,6 +195,39 @@ add `nameLoc`/`descriptionLoc` language maps:
   hover tooltip whose description is localised (`descriptionLoc[lang]`, falling
   back to the English `description`) and rendered with the 11e
   `MarkupText`/`LocalizedMarkup` engine. Unmatched tags render plain.
+
+## Weapons
+
+A weapon is `{ profiles: [...], abilities?: [...] }`. Each profile carries the
+language-keyed `name` plus the plain `range/attacks/skill/strength/ap/damage` and
+`keywords`. The optional `abilities` are named rules that belong to the **whole
+weapon** rather than to one profile (Overcharge on a transmatter inverter,
+Conversion on an SP conversion beamer) — `{ name, description }`, both
+language-keyed. `UnitCard/UnitWeapon.jsx` renders them as a full-width row under
+the weapon's profiles, through the same markup engine as ability text, and
+`UnitCardEditor/UnitWeapon.jsx` edits them per weapon. Weapons that have none
+carry no `abilities` key at all, which the editor restores when the last one is
+deleted.
+
+## Stratagems
+
+Beyond `when` / `target` / `effect`, a stratagem may carry `restrictions` — the
+"cannot be used more than once per battle" style clause — which the card renders
+as a fourth section. Only some stratagems have it (2 of the 11 core stratagems),
+so it is an optional language-keyed field; see
+[the editing doc](40k-11e-card-editing.md#fields-the-datasource-omits) for how
+the editor adds and removes it. `fluff` (flavour text) is carried in the data but
+not rendered, matching the 10e cards.
+
+## Enhancements
+
+Alongside `name`/`description`/`detachment`/`cost`, an enhancement carries the
+fields that decide which units may take it in the list builder: `keywords` (a
+unit must have one of them), `excludes` (it must have none of them) and
+`equipableByNonCharacter`, which marks the "(Upgrade)" entries a non-Character
+unit may take (up to three times). These are plain English strings — matching in
+`listCategories.helpers.js` localises to English — and are edited in the
+enhancement editor's "List eligibility" panel. They are not printed on the card.
 
 ## Points, unit sizes and roster surcharge
 
@@ -267,6 +305,10 @@ the same structure 10e uses (`useDataSourceItems.js`). The only differences are
 that `name`/`text` are language-keyed (resolved/localised by `RuleCard11e`) and
 the card `source` is stamped from the active datasource so it routes to the 11e
 renderer.
+
+Each rule part has a `type`: `text`, `header` and `accordion` render on the card;
+`quote` and `textItalic` are rulebook examples the renderer skips. The editor
+lists all five so a skipped part keeps its type when its card is edited.
 
 ## Faction colours and symbols
 

--- a/src/Components/Warhammer40k-11e/EnhancementEditor.jsx
+++ b/src/Components/Warhammer40k-11e/EnhancementEditor.jsx
@@ -1,6 +1,7 @@
 import { Collapse } from "antd";
 import { EnhancementBasicInfo } from "./EnhancementEditor/EnhancementBasicInfo";
 import { EnhancementCardInfo } from "./EnhancementEditor/EnhancementCardInfo";
+import { EnhancementEligibility } from "./EnhancementEditor/EnhancementEligibility";
 import { EnhancementStylingInfo } from "./EnhancementEditor/EnhancementStylingInfo";
 
 const { Panel } = Collapse;
@@ -16,6 +17,11 @@ export const EnhancementEditor = () => {
       </Panel>
       <Panel header="Detailed information" style={{ width: "100%" }} key="3">
         <EnhancementCardInfo />
+      </Panel>
+      {/* Not printed on the card: this drives which units may take the
+          enhancement in the list builder. */}
+      <Panel header="List eligibility" style={{ width: "100%" }} key="4">
+        <EnhancementEligibility />
       </Panel>
     </Collapse>
   );

--- a/src/Components/Warhammer40k-11e/EnhancementEditor/EnhancementEligibility.jsx
+++ b/src/Components/Warhammer40k-11e/EnhancementEditor/EnhancementEligibility.jsx
@@ -1,0 +1,103 @@
+import { Trash2 } from "lucide-react";
+import { Button, Card, Form, Switch, Typography } from "antd";
+import React from "react";
+import { useCardStorage } from "../../../Hooks/useCardStorage";
+import { localize } from "../../../Helpers/localization.helpers";
+
+// Which units may take an enhancement in the list builder
+// (`isUnitEnhancementEligible` in listCategories.helpers.js):
+//
+// - `equipableByNonCharacter` marks the "(Upgrade)" entries, the only ones a
+//   non-Character unit can take (and which may be taken up to three times).
+// - `keywords` must match one of the unit's keywords or factions.
+// - `excludes` must match none of them.
+//
+// The matcher compares against the **English** keyword, so these entries stay
+// plain strings rather than becoming language-keyed like the enhancement's
+// name/description. An entry that arrives language-keyed from an older card is
+// shown in English and stays that shape until it is edited.
+const EligibilityList = ({ title, field, addLabel, emptyHint }) => {
+  const { activeCard, updateActiveCard } = useCardStorage();
+  const entries = Array.isArray(activeCard[field]) ? activeCard[field] : [];
+
+  const updateEntries = (mutate) => {
+    updateActiveCard(() => {
+      const next = mutate([...entries]);
+      return { ...activeCard, [field]: next };
+    });
+  };
+
+  return (
+    <Card type={"inner"} size={"small"} title={<Typography.Text>{title}</Typography.Text>} style={{ marginBottom: 16 }}>
+      <div className="keywords_container" style={{ paddingBottom: 4, paddingTop: 4 }}>
+        {entries.length === 0 && (
+          <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+            {emptyHint}
+          </Typography.Text>
+        )}
+        {entries.map((entry, index) => (
+          <div className="keyword_container" key={`${field}-${index}`}>
+            <Typography.Text
+              editable={{
+                onChange: (value) =>
+                  updateEntries((next) => {
+                    next[index] = value;
+                    return next;
+                  }),
+              }}>
+              {localize(entry, "en")}
+            </Typography.Text>
+            <Button
+              type="text"
+              size="small"
+              icon={<Trash2 size={14} />}
+              onClick={() =>
+                updateEntries((next) => {
+                  next.splice(index, 1);
+                  return next;
+                })
+              }></Button>
+          </div>
+        ))}
+      </div>
+      <Button
+        type="dashed"
+        style={{ width: "100%" }}
+        onClick={() =>
+          updateEntries((next) => {
+            next.push(`New keyword ${next.length + 1}`);
+            return next;
+          })
+        }>
+        {addLabel}
+      </Button>
+    </Card>
+  );
+};
+
+export function EnhancementEligibility() {
+  const { activeCard, updateActiveCard } = useCardStorage();
+
+  return (
+    <Form size="small">
+      <Form.Item label={"Upgrade (non-Characters can take it)"}>
+        <Switch
+          checked={Boolean(activeCard.equipableByNonCharacter)}
+          onChange={(value) => updateActiveCard({ ...activeCard, equipableByNonCharacter: value })}
+        />
+      </Form.Item>
+      <EligibilityList
+        title="Required keywords"
+        field="keywords"
+        addLabel="Add required keyword"
+        emptyHint="Without a keyword no unit can take this enhancement."
+      />
+      <EligibilityList
+        title="Excluded keywords"
+        field="excludes"
+        addLabel="Add excluded keyword"
+        emptyHint="No unit is excluded."
+      />
+    </Form>
+  );
+}

--- a/src/Components/Warhammer40k-11e/RuleEditor/RuleCardInfo.jsx
+++ b/src/Components/Warhammer40k-11e/RuleEditor/RuleCardInfo.jsx
@@ -14,6 +14,11 @@ const { Text } = Typography;
 // 11th edition rule parts: { order, type, title?:{lang}, text:{lang} }. Type is a
 // plain enum; title and text are language-keyed. Parts are kept sorted by order
 // and the order is renumbered on add / remove / reorder.
+//
+// The source data also carries `quote` and `textItalic` parts (rulebook examples
+// and flavour text) that RuleCard deliberately skips. They are listed here so an
+// existing part keeps its type instead of silently becoming body text the moment
+// it is touched — their labels say they stay off the card.
 export function RuleCardInfo() {
   const { activeCard, updateActiveCard } = useCardStorage();
   const { settings } = useSettingsStorage();
@@ -94,6 +99,8 @@ export function RuleCardInfo() {
                                 <Option value="text">Text</Option>
                                 <Option value="header">Header</Option>
                                 <Option value="accordion">Accordion (bulleted)</Option>
+                                <Option value="quote">Quote (not shown on card)</Option>
+                                <Option value="textItalic">Example (not shown on card)</Option>
                               </Select>
                             </Form.Item>
                           </Col>

--- a/src/Components/Warhammer40k-11e/StratagemEditor/StratagemCardInfo.jsx
+++ b/src/Components/Warhammer40k-11e/StratagemEditor/StratagemCardInfo.jsx
@@ -3,30 +3,44 @@ import React from "react";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
 import { CustomMarkdownEditor } from "../../CustomMarkdownEditor";
-import { isLocalizedFieldEmpty, localize, setLocalizedFieldSeeded } from "../../../Helpers/localization.helpers";
+import {
+  isLocalizedFieldEmpty,
+  localize,
+  setLocalizedField,
+  setLocalizedFieldSeeded,
+} from "../../../Helpers/localization.helpers";
 
 // 11th edition stratagem when / target / effect / restrictions are language-keyed
-// markdown. Only some stratagems carry restrictions (Insane Bravery, Rapid
-// Ingress, …), so that field is seeded as a language-keyed object on first edit
-// and removed again once it is emptied — matching the datasource, which omits it
-// on the stratagems that have none.
+// markdown.
 export function StratagemCardInfo() {
   const { activeCard, updateActiveCard } = useCardStorage();
   const { settings } = useSettingsStorage();
   const lang = settings.language;
 
+  // when / target / effect are on every stratagem: edit the active language in
+  // place and leave the field itself alone, whatever it is cleared to.
   const updateField = (field, value) => {
     updateActiveCard(() => {
+      return { ...activeCard, [field]: setLocalizedField(activeCard[field], lang, value || "") };
+    });
+  };
+
+  // Only some stratagems carry restrictions (Insane Bravery, Rapid Ingress, …),
+  // so the field is seeded as a language-keyed object on first edit and removed
+  // again once it is empty in every language — matching the datasource, which
+  // omits it on the stratagems that have none.
+  const updateRestrictions = (value) => {
+    updateActiveCard(() => {
       const text = value || "";
-      if (!text && activeCard[field] == null) {
+      if (!text && activeCard.restrictions == null) {
         return activeCard;
       }
-      const updated = setLocalizedFieldSeeded(activeCard[field], lang, text);
+      const updated = setLocalizedFieldSeeded(activeCard.restrictions, lang, text);
       if (isLocalizedFieldEmpty(updated)) {
-        const { [field]: _cleared, ...rest } = activeCard;
+        const { restrictions: _cleared, ...rest } = activeCard;
         return rest;
       }
-      return { ...activeCard, [field]: updated };
+      return { ...activeCard, restrictions: updated };
     });
   };
 
@@ -67,7 +81,7 @@ export function StratagemCardInfo() {
           <Col span={24}>
             <CustomMarkdownEditor
               value={localize(activeCard.restrictions, lang)}
-              onChange={(value) => updateField("restrictions", value)}
+              onChange={(value) => updateRestrictions(value)}
             />
           </Col>
         </Row>

--- a/src/Components/Warhammer40k-11e/StratagemEditor/StratagemCardInfo.jsx
+++ b/src/Components/Warhammer40k-11e/StratagemEditor/StratagemCardInfo.jsx
@@ -3,9 +3,13 @@ import React from "react";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
 import { CustomMarkdownEditor } from "../../CustomMarkdownEditor";
-import { localize, setLocalizedField } from "../../../Helpers/localization.helpers";
+import { isLocalizedFieldEmpty, localize, setLocalizedFieldSeeded } from "../../../Helpers/localization.helpers";
 
-// 11th edition stratagem when / target / effect are language-keyed markdown.
+// 11th edition stratagem when / target / effect / restrictions are language-keyed
+// markdown. Only some stratagems carry restrictions (Insane Bravery, Rapid
+// Ingress, …), so that field is seeded as a language-keyed object on first edit
+// and removed again once it is emptied — matching the datasource, which omits it
+// on the stratagems that have none.
 export function StratagemCardInfo() {
   const { activeCard, updateActiveCard } = useCardStorage();
   const { settings } = useSettingsStorage();
@@ -13,7 +17,16 @@ export function StratagemCardInfo() {
 
   const updateField = (field, value) => {
     updateActiveCard(() => {
-      return { ...activeCard, [field]: setLocalizedField(activeCard[field], lang, value || "") };
+      const text = value || "";
+      if (!text && activeCard[field] == null) {
+        return activeCard;
+      }
+      const updated = setLocalizedFieldSeeded(activeCard[field], lang, text);
+      if (isLocalizedFieldEmpty(updated)) {
+        const { [field]: _cleared, ...rest } = activeCard;
+        return rest;
+      }
+      return { ...activeCard, [field]: updated };
     });
   };
 
@@ -45,6 +58,16 @@ export function StratagemCardInfo() {
             <CustomMarkdownEditor
               value={localize(activeCard.effect, lang)}
               onChange={(value) => updateField("effect", value)}
+            />
+          </Col>
+        </Row>
+      </Card>
+      <Card type={"inner"} size={"small"} title={"Restrictions"} bodyStyle={{ padding: 0 }}>
+        <Row justify="space-between" align="middle">
+          <Col span={24}>
+            <CustomMarkdownEditor
+              value={localize(activeCard.restrictions, lang)}
+              onChange={(value) => updateField("restrictions", value)}
             />
           </Col>
         </Row>

--- a/src/Components/Warhammer40k-11e/UnitCard/UnitAbilityDescription.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCard/UnitAbilityDescription.jsx
@@ -19,13 +19,15 @@ import { localize } from "../../../Helpers/localization.helpers";
 // sidesteps the English-only regex dictionary used by the 10e renderer.
 
 // Sanitisation schema: the GitHub default already allows strong/b/ul/li/em; we
-// additionally allow <span class="keyword"> so converted <k> tags can be styled.
+// additionally allow <span class="keyword"> so converted <k> tags can be styled,
+// and <span style="..."> so the editor's colour picker survives sanitisation
+// (only the colour is kept — see the `span` renderer below).
 const schema11e = {
   ...defaultSchema,
   tagNames: [...(defaultSchema.tagNames || []), "span", "br"],
   attributes: {
     ...defaultSchema.attributes,
-    span: [...(defaultSchema.attributes?.span || []), "className"],
+    span: [...(defaultSchema.attributes?.span || []), "className", "style"],
   },
 };
 
@@ -69,6 +71,13 @@ export const MarkupText = ({ content }) => {
             );
           }
           return <span style={{ whiteSpace: "normal" }} {...rest} />;
+        },
+        // The editor's colour picker writes <span style="color: …">, and <k>
+        // keywords arrive here as <span class="gdc-keyword">. Keep the class and
+        // the colour, drop every other style (matching the 10e renderer).
+        span(props) {
+          const { node, style, ...rest } = props;
+          return <span style={style?.color ? { color: style.color } : undefined} {...rest} />;
         },
         br() {
           return <br />;

--- a/src/Components/Warhammer40k-11e/UnitCard/UnitWeapon.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCard/UnitWeapon.jsx
@@ -1,4 +1,5 @@
 import { Grid } from "antd";
+import { MarkupText } from "./UnitAbilityDescription";
 import { UnitWeaponKeywords } from "./UnitWeaponKeyword";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
 import { localize } from "../../../Helpers/localization.helpers";
@@ -7,10 +8,14 @@ import { normalizeKeywords } from "../../../Helpers/weaponProfile.helpers";
 const { useBreakpoint } = Grid;
 
 // 11th edition weapon profiles carry no `active` flag (all are shown) and the
-// profile name is language-keyed.
+// profile name is language-keyed. A weapon can also carry its own abilities
+// (`weapon.abilities`, e.g. Overcharge on a transmatter inverter): named rules
+// that belong to the whole weapon rather than to one profile, so they render as
+// a row underneath the profiles.
 export const UnitWeapon = ({ weapon }) => {
   const screens = useBreakpoint();
   const { settings } = useSettingsStorage();
+  const weaponAbilities = Array.isArray(weapon.abilities) ? weapon.abilities : [];
 
   return (
     <>
@@ -43,6 +48,22 @@ export const UnitWeapon = ({ weapon }) => {
           </div>
         );
       })}
+      {weaponAbilities.length > 0 && (
+        <div className="weapon weapon-abilities">
+          {weaponAbilities.map((ability, index) => {
+            const name = localize(ability.name, settings.language);
+            const description = localize(ability.description, settings.language);
+            return (
+              <div className="weapon-ability" key={`weapon-ability-${index}`}>
+                {name && <span className="name">{name}:</span>}
+                <span className="description">
+                  <MarkupText content={description} />
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </>
   );
 };

--- a/src/Components/Warhammer40k-11e/UnitCardEditor/UnitPoints.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCardEditor/UnitPoints.jsx
@@ -5,7 +5,7 @@ import { useCardStorage } from "../../../Hooks/useCardStorage";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
 import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
 import { reorder } from "../../../Helpers/generic.helpers";
-import { localize, setLocalizedField } from "../../../Helpers/localization.helpers";
+import { localize, setLocalizedField, setLocalizedFieldSeeded } from "../../../Helpers/localization.helpers";
 
 // 11th edition points have no active/primary flags: the first entry is the
 // primary cost and the rest are listed when "Show All Points" is on. Models and
@@ -40,9 +40,7 @@ export function UnitPoints() {
       updatePoint(index, field, null);
       return;
     }
-    const current = points[index]?.[field];
-    const isLocalized = current != null && typeof current === "object" && !Array.isArray(current);
-    updatePoint(index, field, isLocalized ? setLocalizedField(current, language, value) : { [language]: value });
+    updatePoint(index, field, setLocalizedFieldSeeded(points[index]?.[field], language, value));
   };
 
   const updateAdditionalCost = (field, value) => {

--- a/src/Components/Warhammer40k-11e/UnitCardEditor/UnitWeapon.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCardEditor/UnitWeapon.jsx
@@ -1,18 +1,22 @@
 import { Trash2 } from "lucide-react";
-import { Button, Card, Divider, Input, Popconfirm, Space, Typography } from "antd";
+import { Button, Card, Divider, Form, Input, Popconfirm, Space, Typography } from "antd";
 import React from "react";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
+import { CustomMarkdownEditor } from "../../CustomMarkdownEditor";
 import { localize, setLocalizedField } from "../../../Helpers/localization.helpers";
 import { normalizeKeywords } from "../../../Helpers/weaponProfile.helpers";
 
-// 11th edition weapons have profiles only (no weapon-level abilities) and no
-// per-profile `active` flag. The profile name is language-keyed; range/attacks/
-// skill/strength/ap/damage and keywords are plain values.
+// 11th edition weapons have no per-profile `active` flag. The profile name is
+// language-keyed; range/attacks/skill/strength/ap/damage and keywords are plain
+// values. A weapon can also carry `abilities`: named rules that apply to the
+// whole weapon (Overcharge, …) with a language-keyed name and description, shown
+// under the profiles on the card.
 export function UnitWeapon({ weapon, index, type }) {
   const { activeCard, updateActiveCard } = useCardStorage();
   const { settings } = useSettingsStorage();
   const lang = settings.language;
+  const abilities = Array.isArray(weapon?.abilities) ? weapon.abilities : [];
 
   const handleSheetChange = (event, pIndex) => {
     const newWeapons = [...activeCard[type]];
@@ -20,6 +24,24 @@ export function UnitWeapon({ weapon, index, type }) {
     profiles[pIndex] = { ...profiles[pIndex], [event.target.name]: event.target.value };
     newWeapons[index] = { ...newWeapons[index], profiles };
     updateActiveCard({ ...activeCard, [type]: newWeapons });
+  };
+
+  // Weapons without abilities carry no `abilities` key at all in the source
+  // data, so deleting the last one removes the key again rather than leaving an
+  // empty array behind.
+  const updateAbilities = (mutate) => {
+    updateActiveCard(() => {
+      const newWeapons = [...activeCard[type]];
+      const current = Array.isArray(newWeapons[index].abilities) ? newWeapons[index].abilities : [];
+      const next = mutate([...current]);
+      if (next.length === 0) {
+        const { abilities: _emptied, ...rest } = newWeapons[index];
+        newWeapons[index] = rest;
+      } else {
+        newWeapons[index] = { ...newWeapons[index], abilities: next };
+      }
+      return { ...activeCard, [type]: newWeapons };
+    });
   };
 
   return (
@@ -242,6 +264,70 @@ export function UnitWeapon({ weapon, index, type }) {
           })
         }>
         Add profile
+      </Button>
+      {abilities.map((ability, aIndex) => (
+        <Card
+          key={`weapon-ability-${index}-${aIndex}`}
+          type={"inner"}
+          size={"small"}
+          style={{ marginTop: 4 }}
+          bodyStyle={{ padding: 8 }}
+          title={
+            <Typography.Text
+              editable={{
+                onChange: (value) =>
+                  updateAbilities((next) => {
+                    next[aIndex] = { ...next[aIndex], name: setLocalizedField(next[aIndex].name, lang, value) };
+                    return next;
+                  }),
+              }}>
+              {localize(ability.name, lang)}
+            </Typography.Text>
+          }
+          extra={
+            <Space>
+              <Popconfirm
+                title={"Are you sure you want to delete this weapon ability?"}
+                placement="topRight"
+                onConfirm={() =>
+                  updateAbilities((next) => {
+                    next.splice(aIndex, 1);
+                    return next;
+                  })
+                }>
+                <Button type="icon" shape="circle" size="small" icon={<Trash2 size={14} />}></Button>
+              </Popconfirm>
+            </Space>
+          }>
+          <Form size="small">
+            <Form.Item label={"Description"}>
+              <CustomMarkdownEditor
+                value={localize(ability.description, lang)}
+                onChange={(value) =>
+                  updateAbilities((next) => {
+                    next[aIndex] = {
+                      ...next[aIndex],
+                      description: setLocalizedField(next[aIndex].description, lang, value || ""),
+                    };
+                    return next;
+                  })
+                }
+                height={100}
+              />
+            </Form.Item>
+          </Form>
+        </Card>
+      ))}
+      <Button
+        type="dashed"
+        style={{ width: "100%", marginTop: 4, marginBottom: 4, borderColor: "#898989" }}
+        onClick={() =>
+          updateAbilities((next) => {
+            next.push({ name: { [lang]: `Weapon ability ${next.length + 1}` }, description: { [lang]: "" } });
+            return next;
+          })
+        }>
+        Add weapon ability
       </Button>
       <Divider />
     </>

--- a/src/Components/Warhammer40k-11e/__tests__/RulePartsAndEligibility.test.jsx
+++ b/src/Components/Warhammer40k-11e/__tests__/RulePartsAndEligibility.test.jsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+let capturedCard;
+const mockUpdateActiveCard = vi.fn((arg) => {
+  capturedCard = typeof arg === "function" ? arg() : arg;
+});
+const mockActiveCard = { ref: {} };
+
+vi.mock("../../../Hooks/useCardStorage", () => ({
+  useCardStorage: () => ({
+    activeCard: mockActiveCard.ref,
+    updateActiveCard: mockUpdateActiveCard,
+  }),
+}));
+
+vi.mock("../../../Hooks/useSettingsStorage", () => ({
+  useSettingsStorage: () => ({ settings: { language: "de" } }),
+}));
+
+vi.mock("../../CustomMarkdownEditor", () => ({
+  CustomMarkdownEditor: ({ value, onChange }) => (
+    <textarea className="md-editor" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+import { RuleCardInfo } from "../RuleEditor/RuleCardInfo";
+import { EnhancementEligibility } from "../EnhancementEditor/EnhancementEligibility";
+
+// The datasource ships `quote` and `textItalic` parts (rulebook examples) that
+// the card deliberately skips. The editor used to offer text/header/accordion
+// only, so opening the type dropdown on such a part and picking anything turned
+// it into body text with no way back.
+describe("11e rule part types", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedCard = undefined;
+  });
+
+  it("keeps a quote part's own type selected", () => {
+    mockActiveCard.ref = { rules: [{ order: 0, type: "quote", text: { de: "Beispiel" } }] };
+    const { container } = render(<RuleCardInfo />);
+
+    expect(container.querySelector(".ant-select-selection-item").textContent).toBe("Quote (not shown on card)");
+  });
+
+  it("offers the non-rendering types alongside the rendering ones", () => {
+    mockActiveCard.ref = { rules: [{ order: 0, type: "text", text: { de: "Text" } }] };
+    const { container } = render(<RuleCardInfo />);
+
+    fireEvent.mouseDown(container.querySelector(".ant-select-selector"));
+
+    const options = [...document.querySelectorAll(".ant-select-item-option-content")].map((o) => o.textContent);
+    expect(options).toEqual([
+      "Text",
+      "Header",
+      "Accordion (bulleted)",
+      "Quote (not shown on card)",
+      "Example (not shown on card)",
+    ]);
+  });
+});
+
+// `keywords` / `excludes` / `equipableByNonCharacter` decide which units may take
+// an enhancement in the list builder (isUnitEnhancementEligible). They were
+// carried along on every edit but could not be set.
+describe("11e enhancement list eligibility editor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedCard = undefined;
+    mockActiveCard.ref = { name: { en: "Ironskein" }, keywords: ["Kâhl"], excludes: [] };
+  });
+
+  it("shows the required keywords", () => {
+    const { getByText } = render(<EnhancementEligibility />);
+
+    expect(getByText("Kâhl")).toBeInTheDocument();
+  });
+
+  it("adds a keyword as a plain string, since matching is on English", () => {
+    const { getByText } = render(<EnhancementEligibility />);
+
+    fireEvent.click(getByText("Add required keyword"));
+
+    expect(capturedCard.keywords).toEqual(["Kâhl", "New keyword 2"]);
+  });
+
+  it("adds excluded keywords to their own list", () => {
+    const { getByText } = render(<EnhancementEligibility />);
+
+    fireEvent.click(getByText("Add excluded keyword"));
+
+    expect(capturedCard.excludes).toEqual(["New keyword 1"]);
+    expect(capturedCard.keywords).toEqual(["Kâhl"]);
+  });
+
+  it("removes a keyword", () => {
+    const { container } = render(<EnhancementEligibility />);
+
+    const entry = [...container.querySelectorAll(".keyword_container")].find((row) => row.textContent.includes("Kâhl"));
+    fireEvent.click(entry.querySelector("button.ant-btn-text"));
+
+    expect(capturedCard.keywords).toEqual([]);
+  });
+
+  it("marks an enhancement as an Upgrade", () => {
+    const { container } = render(<EnhancementEligibility />);
+
+    fireEvent.click(container.querySelector("button.ant-switch"));
+
+    expect(capturedCard.equipableByNonCharacter).toBe(true);
+  });
+
+  it("reads an existing Upgrade flag", () => {
+    mockActiveCard.ref = { equipableByNonCharacter: true, keywords: [] };
+    const { container } = render(<EnhancementEligibility />);
+
+    expect(container.querySelector("button.ant-switch").className).toContain("ant-switch-checked");
+  });
+});

--- a/src/Components/Warhammer40k-11e/__tests__/StratagemRestrictions.test.jsx
+++ b/src/Components/Warhammer40k-11e/__tests__/StratagemRestrictions.test.jsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+// Some 11e stratagems (Insane Bravery, Rapid Ingress, …) carry a `restrictions`
+// section that the card renders; the editor has to be able to write it, add it
+// to a stratagem that never had one, and take it away again.
+let capturedCard;
+const mockUpdateActiveCard = vi.fn((arg) => {
+  capturedCard = typeof arg === "function" ? arg() : arg;
+});
+const mockActiveCard = { ref: {} };
+
+vi.mock("../../../Hooks/useCardStorage", () => ({
+  useCardStorage: () => ({
+    activeCard: mockActiveCard.ref,
+    updateActiveCard: mockUpdateActiveCard,
+  }),
+}));
+
+// Edit in German so we can assert English siblings survive.
+vi.mock("../../../Hooks/useSettingsStorage", () => ({
+  useSettingsStorage: () => ({ settings: { language: "de" } }),
+}));
+
+// The markdown editor is replaced with a plain textarea, labelled by the card
+// title it sits under so a test can pick the right field.
+vi.mock("../../CustomMarkdownEditor", () => ({
+  CustomMarkdownEditor: ({ value, onChange }) => (
+    <textarea className="md-editor" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+import { StratagemCardInfo } from "../StratagemEditor/StratagemCardInfo";
+import { StratagemCard } from "../StratagemCard";
+
+// The panels render in a fixed order: When, Target, Effect, Restrictions.
+const editorFor = (container, title) => {
+  const panel = [...container.querySelectorAll(".ant-card")].find(
+    (card) => card.querySelector(".ant-card-head-title")?.textContent === title,
+  );
+  return panel.querySelector("textarea.md-editor");
+};
+
+describe("11e stratagem restrictions editor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedCard = undefined;
+  });
+
+  it("shows the restrictions of the active card language", () => {
+    mockActiveCard.ref = {
+      when: { en: "When" },
+      restrictions: { en: "Once per battle.", de: "Einmal pro Schlacht." },
+    };
+    const { container } = render(<StratagemCardInfo />);
+
+    expect(editorFor(container, "Restrictions").value).toBe("Einmal pro Schlacht.");
+  });
+
+  it("merges an edit into the active language and preserves the others", () => {
+    mockActiveCard.ref = { restrictions: { en: "Once per battle.", de: "Alt" } };
+    const { container } = render(<StratagemCardInfo />);
+
+    fireEvent.change(editorFor(container, "Restrictions"), { target: { value: "Einmal pro Schlacht." } });
+
+    expect(capturedCard.restrictions).toEqual({ en: "Once per battle.", de: "Einmal pro Schlacht." });
+  });
+
+  // Without seeding, the first value typed into a stratagem that has no
+  // restrictions would be stored as a bare string and show in every language.
+  it("starts a language-keyed field on a stratagem that had no restrictions", () => {
+    mockActiveCard.ref = { when: { en: "When" } };
+    const { container } = render(<StratagemCardInfo />);
+
+    fireEvent.change(editorFor(container, "Restrictions"), { target: { value: "Einmal pro Schlacht." } });
+
+    expect(capturedCard.restrictions).toEqual({ de: "Einmal pro Schlacht." });
+  });
+
+  it("drops the field once it is empty in every language", () => {
+    mockActiveCard.ref = { when: { en: "When" }, restrictions: { de: "Einmal pro Schlacht." } };
+    const { container } = render(<StratagemCardInfo />);
+
+    fireEvent.change(editorFor(container, "Restrictions"), { target: { value: "" } });
+
+    expect(capturedCard).not.toHaveProperty("restrictions");
+    expect(capturedCard.when).toEqual({ en: "When" });
+  });
+
+  it("keeps the other languages when only the active one is cleared", () => {
+    mockActiveCard.ref = { restrictions: { en: "Once per battle.", de: "Einmal pro Schlacht." } };
+    const { container } = render(<StratagemCardInfo />);
+
+    fireEvent.change(editorFor(container, "Restrictions"), { target: { value: "" } });
+
+    expect(capturedCard.restrictions).toEqual({ en: "Once per battle.", de: "" });
+  });
+
+  it("still edits when / target / effect in place", () => {
+    mockActiveCard.ref = { when: { en: "When", de: "Wann" }, target: { en: "T" }, effect: { en: "E" } };
+    const { container } = render(<StratagemCardInfo />);
+
+    fireEvent.change(editorFor(container, "When"), { target: { value: "Wann genau" } });
+
+    expect(capturedCard.when).toEqual({ en: "When", de: "Wann genau" });
+  });
+
+  it("renders what the editor wrote on the card", () => {
+    const { getByText } = render(
+      <StratagemCard
+        stratagem={{ name: { de: "Wahnsinniger Mut" }, restrictions: { de: "Einmal pro Schlacht." }, phase: [] }}
+      />,
+    );
+
+    expect(getByText("restrictions:")).toBeInTheDocument();
+    expect(getByText("Einmal pro Schlacht.")).toBeInTheDocument();
+  });
+});

--- a/src/Components/Warhammer40k-11e/__tests__/StratagemRestrictions.test.jsx
+++ b/src/Components/Warhammer40k-11e/__tests__/StratagemRestrictions.test.jsx
@@ -120,6 +120,19 @@ describe("11e stratagem restrictions editor", () => {
     expect(capturedCard.when).toEqual({ en: "When", de: "Wann genau" });
   });
 
+  // Dropping an emptied field is for `restrictions`, which the datasource omits
+  // on most stratagems. when/target/effect ship on every stratagem and keep
+  // their key whatever they are cleared to.
+  it("keeps when / target / effect when they are cleared", () => {
+    mockActiveCard.ref = { when: { de: "Wann" }, target: { en: "T" }, effect: { en: "E" } };
+    const { container } = render(<StratagemCardInfo />);
+
+    fireEvent.change(editorFor(container, "When"), { target: { value: "" } });
+
+    expect(capturedCard).toHaveProperty("when");
+    expect(capturedCard.when).toEqual({ de: "" });
+  });
+
   it("renders what the editor wrote on the card", () => {
     const { getByText } = render(
       <StratagemCard

--- a/src/Components/Warhammer40k-11e/__tests__/UnitAbilityDescription.test.jsx
+++ b/src/Components/Warhammer40k-11e/__tests__/UnitAbilityDescription.test.jsx
@@ -57,6 +57,29 @@ describe("MarkupText", () => {
     expect(container.querySelectorAll("br")).toHaveLength(2);
   });
 
+  // The shared markdown editor's colour picker writes <span style="color: …">.
+  // Sanitisation used to strip it, so colouring text in the editor did nothing
+  // on an 11e card.
+  it("keeps the colour a span carries", () => {
+    const { container } = render(<MarkupText content={'<span style="color: #ff0000">Danger</span>'} />);
+
+    // The outer span is the paragraph wrapper; the markup's own span is nested.
+    const coloured = container.querySelector("span > span");
+    expect(coloured.textContent).toBe("Danger");
+    expect(coloured.style.color).toBe("rgb(255, 0, 0)");
+  });
+
+  it("drops every style other than the colour", () => {
+    const { container } = render(
+      <MarkupText content={'<span style="color: #008000; position: fixed; width: 900px">Safe</span>'} />,
+    );
+
+    const coloured = container.querySelector("span > span");
+    expect(coloured.style.color).toBe("rgb(0, 128, 0)");
+    expect(coloured.style.position).toBe("");
+    expect(coloured.style.width).toBe("");
+  });
+
   it("still separates real paragraphs", () => {
     const { container } = render(<MarkupText content={"First paragraph.\n\nSecond paragraph."} />);
     expect(container.querySelector('span[aria-hidden="true"]')).toBeInTheDocument();

--- a/src/Components/Warhammer40k-11e/__tests__/WeaponAbilities.test.jsx
+++ b/src/Components/Warhammer40k-11e/__tests__/WeaponAbilities.test.jsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+// 11e weapons can carry their own abilities next to their profiles (Overcharge
+// on a transmatter inverter, …). They used to be dropped on the floor: neither
+// rendered on the card nor reachable in the editor.
+let capturedCard;
+const mockUpdateActiveCard = vi.fn((arg) => {
+  capturedCard = typeof arg === "function" ? arg() : arg;
+});
+const mockActiveCard = { ref: {} };
+
+vi.mock("../../../Hooks/useCardStorage", () => ({
+  useCardStorage: () => ({
+    activeCard: mockActiveCard.ref,
+    updateActiveCard: mockUpdateActiveCard,
+  }),
+}));
+
+vi.mock("../../../Hooks/useSettingsStorage", () => ({
+  useSettingsStorage: () => ({ settings: { language: "de" } }),
+}));
+
+vi.mock("../../CustomMarkdownEditor", () => ({
+  CustomMarkdownEditor: ({ value, onChange }) => (
+    <textarea className="md-editor" value={value} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+import { UnitWeapon as UnitWeaponCard } from "../UnitCard/UnitWeapon";
+import { UnitWeapon as UnitWeaponEditor } from "../UnitCardEditor/UnitWeapon";
+
+const profile = { name: { en: "Transmatter inverter", de: "Transmaterie-Inverter" }, range: '12"', keywords: [] };
+const weaponWithAbility = {
+  profiles: [profile],
+  abilities: [
+    {
+      name: { en: "Overcharge", de: "Überladung" },
+      description: { en: "Each time this weapon is fired…", de: "Jedes Mal, wenn…" },
+    },
+  ],
+};
+
+describe("weapon abilities on the card", () => {
+  it("renders the ability under the weapon's profiles", () => {
+    const { getByText } = render(<UnitWeaponCard weapon={weaponWithAbility} />);
+
+    expect(getByText("Überladung:")).toBeInTheDocument();
+    expect(getByText("Jedes Mal, wenn…")).toBeInTheDocument();
+  });
+
+  it("renders the ability markup through the 11e engine", () => {
+    const { container } = render(
+      <UnitWeaponCard
+        weapon={{ profiles: [profile], abilities: [{ name: { de: "A" }, description: { de: "<k>Psyker</k> only." } }] }}
+      />,
+    );
+
+    expect(container.querySelector(".gdc-keyword").textContent).toBe("Psyker");
+  });
+
+  it("renders nothing extra for a weapon without abilities", () => {
+    const { container } = render(<UnitWeaponCard weapon={{ profiles: [profile] }} />);
+
+    expect(container.querySelector(".weapon-abilities")).toBeNull();
+  });
+});
+
+describe("weapon abilities in the editor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedCard = undefined;
+    mockActiveCard.ref = { rangedWeapons: [JSON.parse(JSON.stringify(weaponWithAbility))] };
+  });
+
+  it("shows the ability description in the active card language", () => {
+    const { container } = render(
+      <UnitWeaponEditor weapon={mockActiveCard.ref.rangedWeapons[0]} index={0} type="rangedWeapons" />,
+    );
+
+    const editors = [...container.querySelectorAll("textarea.md-editor")];
+    expect(editors).toHaveLength(1);
+    expect(editors[0].value).toBe("Jedes Mal, wenn…");
+  });
+
+  it("merges a description edit into the active language", () => {
+    const { container } = render(
+      <UnitWeaponEditor weapon={mockActiveCard.ref.rangedWeapons[0]} index={0} type="rangedWeapons" />,
+    );
+
+    fireEvent.change(container.querySelector("textarea.md-editor"), { target: { value: "Neu" } });
+
+    expect(capturedCard.rangedWeapons[0].abilities[0].description).toEqual({
+      en: "Each time this weapon is fired…",
+      de: "Neu",
+    });
+  });
+
+  it("adds a language-keyed ability to a weapon that had none", () => {
+    mockActiveCard.ref = { rangedWeapons: [{ profiles: [profile] }] };
+    const { getByText } = render(
+      <UnitWeaponEditor weapon={mockActiveCard.ref.rangedWeapons[0]} index={0} type="rangedWeapons" />,
+    );
+
+    fireEvent.click(getByText("Add weapon ability"));
+
+    expect(capturedCard.rangedWeapons[0].abilities).toEqual([
+      { name: { de: "Weapon ability 1" }, description: { de: "" } },
+    ]);
+  });
+
+  it("removes the abilities key again when the last one is deleted", () => {
+    const { container } = render(
+      <UnitWeaponEditor weapon={mockActiveCard.ref.rangedWeapons[0]} index={0} type="rangedWeapons" />,
+    );
+
+    // The ability card's delete button sits in its header extra.
+    const abilityCard = [...container.querySelectorAll(".ant-card")].find((card) =>
+      card.querySelector(".ant-card-head-title")?.textContent?.includes("Überladung"),
+    );
+    fireEvent.click(abilityCard.querySelector(".ant-card-extra button"));
+    const confirm = [...document.querySelectorAll(".ant-popover button")].find((button) =>
+      ["OK", "Yes"].includes(button.textContent.trim()),
+    );
+    fireEvent.click(confirm);
+
+    expect(capturedCard.rangedWeapons[0]).not.toHaveProperty("abilities");
+    expect(capturedCard.rangedWeapons[0].profiles).toHaveLength(1);
+  });
+});

--- a/src/Helpers/__tests__/localization.helpers.test.js
+++ b/src/Helpers/__tests__/localization.helpers.test.js
@@ -2,7 +2,9 @@ import { describe, it, expect } from "vitest";
 import {
   localize,
   getCardName,
+  isLocalizedFieldEmpty,
   setLocalizedField,
+  setLocalizedFieldSeeded,
   setLocalizedArrayItem,
   SUPPORTED_LANGUAGES,
   LANGUAGE_LABELS,
@@ -73,6 +75,36 @@ describe("setLocalizedField", () => {
 
   it("does not treat arrays as language-keyed objects", () => {
     expect(setLocalizedField(["a", "b"], "de", "X")).toBe("X");
+  });
+});
+
+describe("setLocalizedFieldSeeded", () => {
+  it("starts an absent field as a language-keyed object", () => {
+    expect(setLocalizedFieldSeeded(null, "de", "X")).toEqual({ de: "X" });
+    expect(setLocalizedFieldSeeded(undefined, "de", "X")).toEqual({ de: "X" });
+  });
+
+  it("merges into an existing language-keyed field like setLocalizedField", () => {
+    expect(setLocalizedFieldSeeded({ en: "A" }, "de", "X")).toEqual({ en: "A", de: "X" });
+  });
+
+  it("keeps an existing plain string plain", () => {
+    expect(setLocalizedFieldSeeded("plain", "de", "X")).toBe("X");
+  });
+});
+
+describe("isLocalizedFieldEmpty", () => {
+  it("treats nullish, blank strings and blank language maps as empty", () => {
+    expect(isLocalizedFieldEmpty(null)).toBe(true);
+    expect(isLocalizedFieldEmpty(undefined)).toBe(true);
+    expect(isLocalizedFieldEmpty("   ")).toBe(true);
+    expect(isLocalizedFieldEmpty({})).toBe(true);
+    expect(isLocalizedFieldEmpty({ en: "", de: "  " })).toBe(true);
+  });
+
+  it("is not empty when any language still holds text", () => {
+    expect(isLocalizedFieldEmpty({ en: "A", de: "" })).toBe(false);
+    expect(isLocalizedFieldEmpty("text")).toBe(false);
   });
 });
 

--- a/src/Helpers/localization.helpers.js
+++ b/src/Helpers/localization.helpers.js
@@ -82,6 +82,47 @@ export function setLocalizedField(existing, language = "en", newValue = "") {
 }
 
 /**
+ * Like {@link setLocalizedField}, but starts a **new** field as a language-keyed
+ * object instead of a plain string.
+ *
+ * `setLocalizedField` deliberately returns a bare string when there is nothing
+ * to merge into, so fields the loader already resolved (a unit's `name`) stay
+ * plain. That is wrong for a field the datasource simply omits — a stratagem's
+ * `restrictions`, a points tier's `faction` — because the first value typed in,
+ * say, German would be stored as a taggless string and then show up in every
+ * language. Seeding `{ [language]: value }` keeps such a field multilingual from
+ * its first edit.
+ *
+ * @param {string|Object|null|undefined} existing - The current field value.
+ * @param {string} [language="en"] - The active card language code.
+ * @param {string} [newValue=""] - The value to store for `language`.
+ * @returns {string|Object} The updated field value.
+ */
+export function setLocalizedFieldSeeded(existing, language = "en", newValue = "") {
+  if (existing == null) return { [language]: newValue };
+  return setLocalizedField(existing, language, newValue);
+}
+
+/**
+ * True when a (possibly language-keyed) field holds no text in any language.
+ *
+ * Used by the editor to drop an optional field entirely once the user clears it,
+ * so the card stops rendering its section and the card data keeps the shape the
+ * datasource uses for cards that never had the field.
+ *
+ * @param {string|Object|null|undefined} value - The field value to test.
+ * @returns {boolean}
+ */
+export function isLocalizedFieldEmpty(value) {
+  if (value == null) return true;
+  if (typeof value === "string") return value.trim() === "";
+  if (typeof value === "object") {
+    return Object.values(value).every((entry) => typeof entry !== "string" || entry.trim() === "");
+  }
+  return false;
+}
+
+/**
  * Shape-preserving update of a single entry in an array of localized values
  * (e.g. keywords, unit composition lines, wargear options). Each entry may be a
  * plain string or a language-keyed object; the entry's shape is preserved via

--- a/src/Helpers/localization.helpers.js
+++ b/src/Helpers/localization.helpers.js
@@ -82,8 +82,8 @@ export function setLocalizedField(existing, language = "en", newValue = "") {
 }
 
 /**
- * Like {@link setLocalizedField}, but starts a **new** field as a language-keyed
- * object instead of a plain string.
+ * Like {@link setLocalizedField}, but starts an **absent** field as a
+ * language-keyed object instead of a plain string.
  *
  * `setLocalizedField` deliberately returns a bare string when there is nothing
  * to merge into, so fields the loader already resolved (a unit's `name`) stay
@@ -92,6 +92,11 @@ export function setLocalizedField(existing, language = "en", newValue = "") {
  * say, German would be stored as a taggless string and then show up in every
  * language. Seeding `{ [language]: value }` keeps such a field multilingual from
  * its first edit.
+ *
+ * Only a nullish `existing` is seeded. A field that already holds a plain string
+ * keeps the shape it has (the `setLocalizedField` contract): a plain string here
+ * means a field that is meant to be plain, not a multilingual one waiting to be
+ * converted.
  *
  * @param {string|Object|null|undefined} existing - The current field value.
  * @param {string} [language="en"] - The active card language code.

--- a/src/styles/40k-11e.less
+++ b/src/styles/40k-11e.less
@@ -26,6 +26,26 @@
     }
   }
 
+  // Weapon-level abilities (`weapon.abilities`) render as a full-width row under
+  // the weapon's profiles, so they keep the row striping but break out of the
+  // profile grid. Slightly smaller than a profile line so the stat columns stay
+  // the thing the eye lands on first.
+  .weapon-abilities {
+    .weapon-ability {
+      color: black;
+      font-size: 0.8rem;
+      font-weight: 400;
+      letter-spacing: normal;
+      padding: 2px 4px 2px 0;
+      z-index: 2;
+
+      .name {
+        font-weight: 600;
+        padding-right: 4px;
+      }
+    }
+  }
+
   // Weapon keywords / core abilities that resolve to a keyword-glossary entry
   // get a subtle dotted underline (and a help cursor) to signal the hover
   // tooltip carrying the localised rule text.


### PR DESCRIPTION
## Proposed Changes

11th edition stratagems can carry a `restrictions` section — Insane Bravery's "cannot use this stratagem more than once per battle" — which `StratagemCard` renders but the editor had no field for, so it could not be changed. This adds that field, plus four more places where the 11e editor and the 11e data disagreed about which values exist:

- **Stratagem restrictions.** New Restrictions editor next to When / Target / Effect. The datasource omits the field on stratagems that have none, so a first edit seeds it as a language-keyed object (`setLocalizedFieldSeeded`) instead of a bare string that would show in every language, and clearing it in every language drops the field again (`isLocalizedFieldEmpty`). Both helpers are shared with the points-tier restriction editor, which had this logic inline.
- **Colour picker on 11e cards.** The shared markdown editor writes `<span style="color: …">`; the 11e sanitisation schema stripped it, so colouring text did nothing. `span[style]` is now allowed and only the colour is applied, matching the 10e renderer.
- **Weapon abilities.** A weapon can carry `abilities` (Overcharge, Conversion) next to its profiles. They were rendered nowhere and editable nowhere; they now render as a row under the weapon's profiles and can be added, edited and deleted per weapon (deleting the last one removes the key again).
- **Enhancement list eligibility.** `keywords`, `excludes` and `equipableByNonCharacter` drive `isUnitEnhancementEligible` in the list builder and had no editor. New "List eligibility" panel; entries stay plain strings because matching is on the English keyword.
- **Rule part types.** `quote` and `textItalic` parts exist in the data and are deliberately skipped by `RuleCard`, but the type dropdown only offered text/header/accordion, so touching such a part turned it into body text. Both are now listed, labelled "not shown on card".

Verified in the running app against the live 11e datasource: the Restrictions field edits Insane Bravery live (including a coloured `<span>` and a `<k>` keyword), Brôkhyr Thunderkyn shows its Conversion weapon ability on the card and in the editor, and Ironskein shows its required keywords in the new panel.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes (`yarn lint`, `yarn test:ci` — 3235 tests)

Docs updated: `docs/40k-11e-card-editing.md` (omitted fields, panels beyond the card, colour markup) and `docs/warhammer-40k-11e-format.md` (weapons, stratagems, enhancements, rule part types). Release fragment added in `changes/unreleased/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015PoqQTHu7sCPjNY3r4W1Wo)_