### PR TITLE
Restore faction browser grouping for 11th edition

### DIFF
--- a/changes/unreleased/11e-browser-grouping.json
+++ b/changes/unreleased/11e-browser-grouping.json
@@ -1,0 +1,5 @@
+{
+  "title": "Group 11th edition datasheets and stratagems again",
+  "body": "The faction settings for 11th edition were missing, so datasheets could not be grouped into Character / Battleline / Dedicated Transport / Other. They are back, together with the points and double-sided display options, and stratagems can now be split into collapsible sections per detachment.",
+  "severity": "info"
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -27,6 +27,7 @@ description: Table of contents for all Game Datacards documentation files
 |------|-------------|
 | [40k-11e-card-editing.md](40k-11e-card-editing.md) | How the 11th edition card editor edits language-keyed fields in place for the active card language (with per-field English fallback), which fields stay plain, and the optional show/hide flags |
 | [40k-11e-list-building.md](40k-11e-list-building.md) | 11th edition army lists: the list's main faction, battle size and Detachment Points, multi-detachment selection, enhancements and Upgrades, leader/support attachment, and how detachment- and faction-scoped points are resolved and repriced |
+| [faction-browser-grouping.md](faction-browser-grouping.md) | How the faction browser groups datasheets by faction/role and stratagems by detachment across the editor and viewer panels, the separator row shapes, and why keyword matching must be edition-agnostic |
 | [welcome-wizard-v2.md](welcome-wizard-v2.md) | Onboarding wizard (v2.0.0): 9-step flow, game system selection, interactive demos, component architecture |
 | [release-notifications.md](release-notifications.md) | How shipped changes reach users: quiet release notes in the notification bell for fixes (patch bump), the full What's New wizard for notable features (minor bump), and how the issue-to-PR pipeline routes between them |
 | [listforge-direct-read-import.md](listforge-direct-read-import.md) | ListForge/NewRecruit roster import with match and direct-read modes, format mapping reference |

--- a/docs/faction-browser-grouping.md
+++ b/docs/faction-browser-grouping.md
@@ -51,12 +51,19 @@ how to draw.
 | _(none)_ | A card | — |
 | `category` | Faction heading (own or parent faction) | yes, via `settings.mobile.closedFactions` |
 | `allied` | Allied faction heading | yes, via `settings.mobile.closedFactions` |
-| `role` | Role or detachment heading | yes, via `settings.mobile.closedRoles` |
+| `role` | Role or detachment heading | yes, via `settings.mobile.closedRoles` keyed on `roleKey` |
 | `header` | Plain, non-collapsible heading | no |
 
-Cards under a `role` separator carry a matching `role` field, which is what the
-renderers hide against when the section is collapsed, and what the "Add all
+Cards under a `role` separator carry a matching `role` field, which the "Add all
 items to..." context action selects on.
+
+Collapsed sections are tracked in one shared `settings.mobile.closedRoles` list,
+across datasheet roles and stratagem detachments alike. Both can produce a
+section called "Other", so the list stores a namespaced key (`role:Other`,
+`detachment:Other`) rather than the display name, carried on both the separator
+and its cards as `roleKey`. Read it through `getSectionKey(separator)` and
+`getCardSectionKey(card)`, which fall back to the display name for rows built
+without one.
 
 Searching filters the cards, then `dropEmptySections` removes any separator the
 search left with no cards under it.

--- a/docs/faction-browser-grouping.md
+++ b/docs/faction-browser-grouping.md
@@ -1,0 +1,125 @@
+---
+title: Faction Browser Grouping
+description: How the datasheet and stratagem lists in the faction browser are grouped by role, faction and detachment, and why keyword matching has to be edition-agnostic
+category: Features
+tags: [datasheets, stratagems, grouping, 40k-10e, 40k-11e, faction-settings]
+related:
+  - warhammer-40k-11e-format.md
+  - card-data-formats.md
+file_locations:
+  - src/Helpers/browseList.helpers.js
+  - src/Components/LeftPanel/useDataSourceItems.js
+  - src/Helpers/cardstorage.helpers.js
+  - src/Components/FactionSettingsModal.jsx
+---
+
+# Faction Browser Grouping
+
+The faction browser is the searchable card list under the faction picker. It
+appears twice — in the editor's left panel and in the viewer's left panel — and
+both build their rows from the same helpers so a grouping setting behaves the
+same in either place.
+
+## Contents
+
+- [Where the rows come from](#where-the-rows-come-from)
+- [Row shapes](#row-shapes)
+- [Datasheet grouping](#datasheet-grouping)
+- [Stratagem grouping](#stratagem-grouping)
+- [Edition-agnostic keyword matching](#edition-agnostic-keyword-matching)
+- [Settings](#settings)
+
+## Where the rows come from
+
+| Surface | Entry point | Datasheet rows |
+|---------|-------------|----------------|
+| Editor left panel | `useDataSourceItems(contentType, searchText)` | `buildFactionDatasheetList` |
+| Viewer left panel, mobile drawer | `useDataSourceType(searchText)` | `buildFactionDatasheetList` |
+| Mobile faction units screen | `useCombinedDatasheets` | its own grouping |
+
+`buildFactionDatasheetList` runs for every 40k datasource — `40k-10e`,
+`40k-10e-cp` and `40k-11e` — which `is40kBrowseSource` decides. Other systems
+(AoS warscrolls, Necromunda, custom datasources) keep their own branches.
+
+## Row shapes
+
+The list is flat; grouping is expressed with separator rows the renderers know
+how to draw.
+
+| `type` | Meaning | Collapsible |
+|--------|---------|-------------|
+| _(none)_ | A card | — |
+| `category` | Faction heading (own or parent faction) | yes, via `settings.mobile.closedFactions` |
+| `allied` | Allied faction heading | yes, via `settings.mobile.closedFactions` |
+| `role` | Role or detachment heading | yes, via `settings.mobile.closedRoles` |
+| `header` | Plain, non-collapsible heading | no |
+
+Cards under a `role` separator carry a matching `role` field, which is what the
+renderers hide against when the section is collapsed, and what the "Add all
+items to..." context action selects on.
+
+Searching filters the cards, then `dropEmptySections` removes any separator the
+search left with no cards under it.
+
+## Datasheet grouping
+
+Two independent settings shape the datasheet list:
+
+- `groupByFaction` — keeps the faction/parent/allied `category` rows and their
+  order. Off, everything is re-sorted into one alphabetical run.
+- `groupByRole` — replaces the faction sections with four role sections, in the
+  order GW prints them on a roster: **Character**, **Battleline**,
+  **Dedicated Transport**, **Other**. Allied factions are still appended after
+  the role sections, since they are a separate list of their own.
+
+Parent (`combineParentFactions`) and allied (`combineAlliedFactions`) sections
+depend on `is_subfaction` / `parent_keyword` / `allied_factions` in the data.
+The 11th edition datasource ships none of those yet, so those toggles are not
+offered there.
+
+## Stratagem grouping
+
+A 40k faction ships around six stratagems per detachment, so a faction's flat
+list runs to 60+ entries. `groupStratagemsByDetachment` splits the faction
+stratagems into one collapsible `role` section per detachment, in the order the
+datasource lists them; stratagems with no detachment collect in a trailing
+**Other** section. Core stratagems stay flat under the **Basic stratagems**
+header, since they belong to no detachment.
+
+When the list is grouped this way, the per-row detachment subtitle is dropped —
+the section heading already says it.
+
+## Edition-agnostic keyword matching
+
+10th edition stores keywords as plain strings:
+
+```json
+"keywords": ["Infantry", "Character", "Psyker"]
+```
+
+11th edition stores them as language-keyed objects:
+
+```json
+"keywords": [{ "en": "Infantry" }, { "en": "Character", "de": "Charaktermodell" }]
+```
+
+Anything that groups or filters on a keyword must therefore compare against the
+canonical English form rather than test string equality. Use
+`cardHasKeyword(card, "Character")` from `listCategories.helpers.js`; a plain
+`card.keywords.includes("Character")` silently matches nothing on 11e data and
+drops every unit into **Other**.
+
+## Settings
+
+All of these live in the faction settings modal (the gear next to the faction
+picker) and are stored globally, not per faction.
+
+| Setting | Tab | Datasources |
+|---------|-----|-------------|
+| `groupByRole` | Datasheets | 40k-10e, 40k-10e-cp, 40k-11e |
+| `showPointsInListview` | Datasheets | 40k-10e, 40k-10e-cp, 40k-11e |
+| `showCardsAsDoubleSided` | Datasheets | 40k-10e, 40k-10e-cp, 40k-11e |
+| `showLegends`, `combineParentFactions`, `combineAlliedFactions` | Datasheets | 40k-10e |
+| `splitDatasheetsByRole` | Datasheets | datasources without `noDatasheetByRole` |
+| `hideBasicStratagems` | Stratagems | all with stratagems |
+| `groupStratagemsByDetachment` | Stratagems | 40k-10e, 40k-10e-cp, 40k-11e |

--- a/src/Components/FactionSettingsModal.jsx
+++ b/src/Components/FactionSettingsModal.jsx
@@ -8,6 +8,14 @@ import "./FactionSettingsModal.css";
 
 const modalRoot = document.getElementById("modal-root");
 
+// The 40k datasources that share the datasheet display options, and the heading
+// each one shows them under.
+const FORTY_K_OPTION_TITLES = {
+  "40k-11e": "Warhammer 11th edition options",
+  "40k-10e": "Warhammer 10th edition options",
+  "40k-10e-cp": "Combat Patrol options",
+};
+
 const SettingCard = ({ title, checked, onChange }) => (
   <div className="faction-setting-card clickable" onClick={() => onChange(!checked)}>
     <span className="faction-setting-card-title">{title}</span>
@@ -107,78 +115,69 @@ export const FactionSettingsModal = () => {
     </>
   );
 
-  const renderDatasheetsTab = () => (
-    <>
-      {!dataSource.noDatasheetByRole && (
-        <>
-          <p className="faction-section-title">Layout</p>
-          <SettingCard
-            title="Split datasheets by role"
-            checked={settings.splitDatasheetsByRole}
-            onChange={(value) => updateSettings({ ...settings, splitDatasheetsByRole: value })}
-          />
-        </>
-      )}
-      {settings.selectedDataSource === "40k-10e" && (
-        <>
-          <p className="faction-section-title">Warhammer 10th edition options</p>
-          <p className="faction-subsection-title">Datacards</p>
-          <SettingCard
-            title="Add Legends datacards to factions"
-            checked={settings.showLegends}
-            onChange={(value) => updateSettings({ ...settings, showLegends: value })}
-          />
-          <SettingCard
-            title="Add Space Marine cards to subchapter factions"
-            checked={settings.combineParentFactions}
-            onChange={(value) => updateSettings({ ...settings, combineParentFactions: value })}
-          />
-          <SettingCard
-            title="Add allied faction cards to factions"
-            checked={settings.combineAlliedFactions}
-            onChange={(value) => updateSettings({ ...settings, combineAlliedFactions: value })}
-          />
-          <p className="faction-subsection-title">Display</p>
-          <SettingCard
-            title="Show points in listview"
-            checked={settings.showPointsInListview}
-            onChange={(value) => updateSettings({ ...settings, showPointsInListview: value })}
-          />
-          <SettingCard
-            title="Show both sides on one page"
-            checked={settings.showCardsAsDoubleSided || false}
-            onChange={(value) => updateSettings({ ...settings, showCardsAsDoubleSided: value })}
-          />
-          <SettingCard
-            title="Group cards by role"
-            checked={settings.groupByRole}
-            onChange={(value) => updateSettings({ ...settings, groupByRole: value })}
-          />
-        </>
-      )}
-      {settings.selectedDataSource === "40k-10e-cp" && (
-        <>
-          <p className="faction-section-title">Combat Patrol options</p>
-          <p className="faction-subsection-title">Display</p>
-          <SettingCard
-            title="Show points in listview"
-            checked={settings.showPointsInListview}
-            onChange={(value) => updateSettings({ ...settings, showPointsInListview: value })}
-          />
-          <SettingCard
-            title="Show both sides on one page"
-            checked={settings.showCardsAsDoubleSided || false}
-            onChange={(value) => updateSettings({ ...settings, showCardsAsDoubleSided: value })}
-          />
-          <SettingCard
-            title="Group cards by role"
-            checked={settings.groupByRole}
-            onChange={(value) => updateSettings({ ...settings, groupByRole: value })}
-          />
-        </>
-      )}
-    </>
-  );
+  const renderDatasheetsTab = () => {
+    const fortyKTitle = FORTY_K_OPTION_TITLES[settings.selectedDataSource];
+    // Only the 10th edition data ships Legends sheets, sub-chapter parents and
+    // allied factions, so those toggles stay 10e-only. The display options below
+    // work on every 40k edition.
+    const hasDatacardOptions = settings.selectedDataSource === "40k-10e";
+
+    return (
+      <>
+        {!dataSource.noDatasheetByRole && (
+          <>
+            <p className="faction-section-title">Layout</p>
+            <SettingCard
+              title="Split datasheets by role"
+              checked={settings.splitDatasheetsByRole}
+              onChange={(value) => updateSettings({ ...settings, splitDatasheetsByRole: value })}
+            />
+          </>
+        )}
+        {fortyKTitle && (
+          <>
+            <p className="faction-section-title">{fortyKTitle}</p>
+            {hasDatacardOptions && (
+              <>
+                <p className="faction-subsection-title">Datacards</p>
+                <SettingCard
+                  title="Add Legends datacards to factions"
+                  checked={settings.showLegends}
+                  onChange={(value) => updateSettings({ ...settings, showLegends: value })}
+                />
+                <SettingCard
+                  title="Add Space Marine cards to subchapter factions"
+                  checked={settings.combineParentFactions}
+                  onChange={(value) => updateSettings({ ...settings, combineParentFactions: value })}
+                />
+                <SettingCard
+                  title="Add allied faction cards to factions"
+                  checked={settings.combineAlliedFactions}
+                  onChange={(value) => updateSettings({ ...settings, combineAlliedFactions: value })}
+                />
+              </>
+            )}
+            <p className="faction-subsection-title">Display</p>
+            <SettingCard
+              title="Show points in listview"
+              checked={settings.showPointsInListview}
+              onChange={(value) => updateSettings({ ...settings, showPointsInListview: value })}
+            />
+            <SettingCard
+              title="Show both sides on one page"
+              checked={settings.showCardsAsDoubleSided || false}
+              onChange={(value) => updateSettings({ ...settings, showCardsAsDoubleSided: value })}
+            />
+            <SettingCard
+              title="Group cards by role"
+              checked={settings.groupByRole}
+              onChange={(value) => updateSettings({ ...settings, groupByRole: value })}
+            />
+          </>
+        )}
+      </>
+    );
+  };
 
   const renderWarscrollsTab = () => (
     <>
@@ -215,6 +214,16 @@ export const FactionSettingsModal = () => {
         checked={settings.hideBasicStratagems}
         onChange={(value) => updateSettings({ ...settings, hideBasicStratagems: value })}
       />
+      {FORTY_K_OPTION_TITLES[settings.selectedDataSource] && (
+        <>
+          <p className="faction-section-title">Layout</p>
+          <SettingCard
+            title="Group stratagems by detachment"
+            checked={settings.groupStratagemsByDetachment}
+            onChange={(value) => updateSettings({ ...settings, groupStratagemsByDetachment: value })}
+          />
+        </>
+      )}
     </>
   );
 

--- a/src/Components/LeftPanel/DataSourceList.jsx
+++ b/src/Components/LeftPanel/DataSourceList.jsx
@@ -9,6 +9,7 @@ import { useDataSourceStorage } from "../../Hooks/useDataSourceStorage";
 import { confirmDialog } from "../ConfirmChangesModal";
 import { ContextMenu } from "../TreeView/ContextMenu";
 import { buildCategoryMenuItems } from "../../util/menu-helper";
+import { localize } from "../../Helpers/localization.helpers";
 
 export const DataSourceList = ({ isLoading, dataSource, selectedFaction, setSelectedTreeIndex, onAddToCategory }) => {
   const { settings, updateSettings } = useSettingsStorage();
@@ -191,6 +192,17 @@ export const DataSourceList = ({ isLoading, dataSource, selectedFaction, setSele
     }
   };
 
+  const detachmentSubtitle = (card) => {
+    if (card.role) {
+      return null;
+    }
+    const detachment = localize(card.detachment, settings.language);
+    if (!detachment || detachment === "core") {
+      return null;
+    }
+    return <span style={{ fontSize: "0.7rem" }}>{detachment}</span>;
+  };
+
   const renderItem = (card, index) => {
     if (card.type === "header") {
       return (
@@ -292,7 +304,9 @@ export const DataSourceList = ({ isLoading, dataSource, selectedFaction, setSele
           className={card.nonBase ? card.faction_id : ""}>
           <span style={{ flexDirection: "column", display: "flex" }}>
             {card.name}
-            {card.detachment !== "core" && <span style={{ fontSize: "0.7rem" }}>{card.detachment}</span>}
+            {/* The detachment subtitle is redundant once the list is grouped by
+                detachment, and "core" stratagems belong to none. */}
+            {detachmentSubtitle(card)}
           </span>
           {settings.showPointsInListview && card?.points?.length > 0 && (
             <span className="list-cost">

--- a/src/Components/LeftPanel/DataSourceList.jsx
+++ b/src/Components/LeftPanel/DataSourceList.jsx
@@ -10,6 +10,7 @@ import { confirmDialog } from "../ConfirmChangesModal";
 import { ContextMenu } from "../TreeView/ContextMenu";
 import { buildCategoryMenuItems } from "../../util/menu-helper";
 import { localize } from "../../Helpers/localization.helpers";
+import { getCardSectionKey, getSectionKey } from "../../Helpers/browseList.helpers";
 
 export const DataSourceList = ({ isLoading, dataSource, selectedFaction, setSelectedTreeIndex, onAddToCategory }) => {
   const { settings, updateSettings } = useSettingsStorage();
@@ -60,11 +61,12 @@ export const DataSourceList = ({ isLoading, dataSource, selectedFaction, setSele
   };
 
   const handleRoleClick = (card) => {
+    const sectionKey = getSectionKey(card);
     let newClosedRoles = [...(settings?.mobile?.closedRoles || [])];
-    if (newClosedRoles.includes(card.name)) {
-      newClosedRoles.splice(newClosedRoles.indexOf(card.name), 1);
+    if (newClosedRoles.includes(sectionKey)) {
+      newClosedRoles.splice(newClosedRoles.indexOf(sectionKey), 1);
     } else {
-      newClosedRoles.push(card.name);
+      newClosedRoles.push(sectionKey);
     }
     updateSettings({
       ...settings,
@@ -265,7 +267,7 @@ export const DataSourceList = ({ isLoading, dataSource, selectedFaction, setSele
           onClick={() => handleRoleClick(card)}
           onContextMenu={(e) => handleContextMenu(e, card)}>
           <span className="icon">
-            {settings?.mobile?.closedRoles?.includes(card.name) ? (
+            {settings?.mobile?.closedRoles?.includes(getSectionKey(card)) ? (
               <ChevronRight size={14} />
             ) : (
               <ChevronDown size={14} />
@@ -280,7 +282,7 @@ export const DataSourceList = ({ isLoading, dataSource, selectedFaction, setSele
     if (settings?.mobile?.closedFactions?.includes(card.faction_id) && card.allied) {
       return <></>;
     }
-    if (settings?.mobile?.closedRoles?.includes(card.role)) {
+    if (settings?.mobile?.closedRoles?.includes(getCardSectionKey(card))) {
       return <></>;
     }
 

--- a/src/Components/LeftPanel/__tests__/useDataSourceItems.test.jsx
+++ b/src/Components/LeftPanel/__tests__/useDataSourceItems.test.jsx
@@ -84,3 +84,88 @@ describe("useDataSourceItems enhancements section", () => {
     expect(result.current).toEqual([]);
   });
 });
+
+describe("useDataSourceItems stratagem detachment grouping", () => {
+  const detachmentStrat = (name, detachment) => ({ ...strat(name), detachment });
+
+  it("leaves stratagems in one flat list by default", () => {
+    mockState.settings = { selectedDataSource: "40k-11e" };
+    mockState.selectedFaction = {
+      stratagems: [detachmentStrat("Ere We Go", "Blitz Brigade"), detachmentStrat("Wall of Dakka", "Dread Mob")],
+      basicStratagems: [],
+    };
+    const { result } = renderHook(() => useDataSourceItems("stratagems", ""));
+    expect(result.current.some((i) => i.type === "role")).toBe(false);
+  });
+
+  it("splits stratagems into collapsible detachment sections when enabled", () => {
+    mockState.settings = { selectedDataSource: "40k-11e", groupStratagemsByDetachment: true };
+    mockState.selectedFaction = {
+      stratagems: [
+        detachmentStrat("Ere We Go", "Blitz Brigade"),
+        detachmentStrat("Wall of Dakka", "Dread Mob"),
+        detachmentStrat("Ramming Speed", "Blitz Brigade"),
+      ],
+      basicStratagems: [],
+    };
+    const { result } = renderHook(() => useDataSourceItems("stratagems", ""));
+    expect(result.current.map((i) => i.name)).toEqual([
+      "Faction stratagems",
+      "Blitz Brigade",
+      "Ere We Go",
+      "Ramming Speed",
+      "Dread Mob",
+      "Wall of Dakka",
+    ]);
+  });
+
+  it("leaves core stratagems flat under the Basic section", () => {
+    mockState.settings = { selectedDataSource: "40k-11e", groupStratagemsByDetachment: true };
+    mockState.selectedFaction = {
+      stratagems: [detachmentStrat("Ere We Go", "Blitz Brigade")],
+      basicStratagems: [strat("Command Re-roll")],
+    };
+    const { result } = renderHook(() => useDataSourceItems("stratagems", ""));
+    const basicIndex = result.current.findIndex((i) => i.name === "Command Re-roll");
+    expect(result.current[basicIndex].type).toBeUndefined();
+    expect(result.current[basicIndex - 1].name).toBe("Basic stratagems");
+  });
+});
+
+describe("useDataSourceItems datasheets section", () => {
+  // 11e keywords are language-keyed objects, so role grouping has to match on
+  // the canonical English keyword rather than on string equality.
+  const sheet11e = (name, ...keywords) => ({ id: name, name, keywords: keywords.map((k) => ({ en: k })) });
+
+  it("groups an 11e faction's datasheets by role", () => {
+    mockState.settings = { selectedDataSource: "40k-11e", groupByRole: true };
+    mockState.dataSource = { data: [] };
+    mockState.selectedFaction = {
+      id: "orks",
+      name: "Orks",
+      datasheets: [sheet11e("Boyz", "Battleline"), sheet11e("Warboss", "Character"), sheet11e("Stompa", "Titanic")],
+    };
+    const { result } = renderHook(() => useDataSourceItems("datasheets", ""));
+    expect(result.current.map((i) => i.name)).toEqual([
+      "Character",
+      "Warboss",
+      "Battleline",
+      "Boyz",
+      "Dedicated Transport",
+      "Other",
+      "Stompa",
+    ]);
+  });
+
+  it("sorts an 11e faction's datasheets alphabetically when grouping is off", () => {
+    mockState.settings = { selectedDataSource: "40k-11e" };
+    mockState.dataSource = { data: [] };
+    mockState.selectedFaction = {
+      id: "orks",
+      name: "Orks",
+      datasheets: [sheet11e("Warboss", "Character"), sheet11e("Boyz", "Battleline")],
+    };
+    const { result } = renderHook(() => useDataSourceItems("datasheets", ""));
+    expect(result.current.filter((i) => !i.type).map((i) => i.name)).toEqual(["Boyz", "Warboss"]);
+  });
+});

--- a/src/Components/LeftPanel/useDataSourceItems.js
+++ b/src/Components/LeftPanel/useDataSourceItems.js
@@ -1,6 +1,11 @@
 import { useDataSourceStorage } from "../../Hooks/useDataSourceStorage";
 import { useSettingsStorage } from "../../Hooks/useSettingsStorage";
 import { getBrowsableEnhancements } from "../../Helpers/faction.helpers";
+import {
+  buildFactionDatasheetList,
+  groupStratagemsByDetachment,
+  is40kBrowseSource,
+} from "../../Helpers/browseList.helpers";
 
 /**
  * Group warscrolls by their role keywords (Hero, Battleline, Monster, etc.)
@@ -83,107 +88,16 @@ export const useDataSourceItems = (selectedContentType, searchText) => {
     }
 
     if (selectedContentType === "datasheets") {
-      let filteredSheets = [];
-      if (
-        selectedFaction &&
-        (settings.selectedDataSource === "40k-10e" ||
-          settings.selectedDataSource === "40k-10e-cp" ||
-          settings.selectedDataSource === "40k-11e")
-      ) {
+      if (selectedFaction && is40kBrowseSource(settings.selectedDataSource)) {
         try {
-          filteredSheets = [
-            { type: "category", name: selectedFaction.name, id: selectedFaction.id, closed: false },
-            ...selectedFaction?.datasheets?.toSorted((a, b) => a.name.localeCompare(b.name)),
-          ];
-          if (selectedFaction.is_subfaction && settings.combineParentFactions) {
-            let parentFaction = dataSource.data.find((faction) => faction.id === selectedFaction.parent_id);
-
-            let parentDatasheets = parentFaction?.datasheets
-              ?.filter((val) => val.factions.length === 1 && val.factions.includes(selectedFaction.parent_keyword))
-              .map((val) => {
-                return { ...val, nonBase: true };
-              });
-
-            filteredSheets = [
-              ...filteredSheets,
-              { type: "category", name: parentFaction.name, id: parentFaction.id, closed: true },
-              ...parentDatasheets?.toSorted((a, b) => a.name.localeCompare(b.name)),
-            ];
-          }
-
-          if (!settings?.showLegends) {
-            filteredSheets = filteredSheets?.filter((sheet) => !sheet.legends);
-          }
-          if (!settings.groupByFaction) {
-            filteredSheets = filteredSheets?.toSorted((a, b) => a.name.localeCompare(b.name));
-          }
-          if (settings.groupByRole) {
-            const types = ["Battleline", "Character", "Dedicated Transport"];
-            let byRole = [];
-
-            types.map((role) => {
-              byRole = [...byRole, { type: "role", name: role }];
-              byRole = [
-                ...byRole,
-                ...filteredSheets
-                  ?.filter((sheet) => sheet?.keywords?.includes(role))
-                  .map((val) => {
-                    return { ...val, role: role };
-                  }),
-              ];
-            });
-
-            byRole = [
-              ...byRole,
-              { type: "role", name: "Other" },
-              ...filteredSheets
-                ?.filter((sheet) => {
-                  return types.every((t) => !sheet?.keywords?.includes(t));
-                })
-                .map((val) => {
-                  return { ...val, role: "Other" };
-                }),
-            ];
-
-            filteredSheets = byRole;
-          }
-
-          if (
-            selectedFaction.allied_factions &&
-            selectedFaction.allied_factions.length > 0 &&
-            settings.combineAlliedFactions
-          ) {
-            selectedFaction.allied_factions.forEach((alliedFactionId) => {
-              let alliedFaction = dataSource.data.find((faction) => faction.id === alliedFactionId);
-
-              let alliedFactionDatasheets = alliedFaction?.datasheets.map((val) => {
-                return { ...val, nonBase: true, allied: true };
-              });
-
-              filteredSheets = [
-                ...filteredSheets,
-                { type: "allied", name: alliedFaction.name, id: alliedFaction.id, closed: true },
-                ...alliedFactionDatasheets?.toSorted((a, b) => a.name.localeCompare(b.name)),
-              ];
-            });
-          }
-          filteredSheets = searchText
-            ? filteredSheets.filter((sheet) => {
-                if (sheet.type === "category" || sheet.type === "header") {
-                  return true;
-                }
-                return sheet.name.toLowerCase().includes(searchText.toLowerCase());
-              })
-            : filteredSheets;
-
-          return filteredSheets;
+          return buildFactionDatasheetList({ dataSource, selectedFaction, settings, searchText });
         } catch (error) {
           console.error("An error occured", error);
           return [];
         }
       }
 
-      filteredSheets = searchText
+      let filteredSheets = searchText
         ? selectedFaction?.datasheets.filter((sheet) => sheet.name.toLowerCase().includes(searchText.toLowerCase()))
         : selectedFaction?.datasheets;
       if (!settings?.showLegends) {
@@ -206,9 +120,15 @@ export const useDataSourceItems = (selectedContentType, searchText) => {
       const filteredStratagems = selectedFaction?.stratagems?.filter((stratagem) => {
         return !settings?.ignoredSubFactions?.includes(stratagem.subfaction_id);
       });
-      const mainStratagems = searchText
+      const searchedStratagems = searchText
         ? filteredStratagems?.filter((stratagem) => stratagem.name.toLowerCase().includes(searchText.toLowerCase()))
         : filteredStratagems;
+
+      // A faction ships six stratagems per detachment, so the flat list runs to
+      // 60+ entries. Splitting it into collapsible detachment sections is opt-in.
+      const mainStratagems = settings.groupStratagemsByDetachment
+        ? groupStratagemsByDetachment(searchedStratagems, settings.language)
+        : searchedStratagems;
 
       if (settings.hideBasicStratagems || settings?.noStratagemOptions) {
         return mainStratagems;
@@ -219,8 +139,8 @@ export const useDataSourceItems = (selectedContentType, searchText) => {
             )
           : (selectedFaction.basicStratagems ?? []);
 
-        // Datasources without core stratagems (e.g. 11th edition ships none yet)
-        // skip the Basic section entirely instead of rendering an empty header.
+        // Datasources without core stratagems skip the Basic section entirely
+        // instead of rendering an empty header.
         if (!basicStratagems || basicStratagems.length === 0) {
           return [{ type: "header", name: "Faction stratagems" }, ...mainStratagems];
         }

--- a/src/Components/Shared/SharedCardList.jsx
+++ b/src/Components/Shared/SharedCardList.jsx
@@ -5,6 +5,7 @@ const getCardTypeLabel = (card) => {
   const source = card.source || "40k";
 
   switch (source) {
+    case "40k-11e":
     case "40k-10e":
       if (card.cardType === "stratagem") return "Stratagem";
       if (card.cardType === "enhancement") return "Enhancement";

--- a/src/Components/Shared/SharedMobileCardList.jsx
+++ b/src/Components/Shared/SharedMobileCardList.jsx
@@ -5,6 +5,7 @@ const getCardTypeLabel = (card) => {
   const source = card.source || "40k";
 
   switch (source) {
+    case "40k-11e":
     case "40k-10e":
       if (card.cardType === "stratagem") return "Stratagem";
       if (card.cardType === "enhancement") return "Enhancement";

--- a/src/Components/Toolbar/FloatingToolbar.jsx
+++ b/src/Components/Toolbar/FloatingToolbar.jsx
@@ -105,17 +105,18 @@ export const FloatingToolbar = ({
     message.success("Card saved");
   };
 
-  const is40k10e = activeCard?.source === "40k-10e";
+  // Both 40k editions render a two-sided datacard and honour card scaling.
+  const is40k = ["40k-10e", "40k-11e"].includes(activeCard?.source);
   const isAos = activeCard?.source === "aos";
   const isCustomDs = activeCard?.source?.startsWith("custom-");
   const showFrontBackToggle =
-    is40k10e &&
+    is40k &&
     settings.showCardsAsDoubleSided !== true &&
     activeCard?.variant !== "full" &&
     activeCard?.cardType === "DataCard";
 
   // Determine which button groups are visible
-  const showZoom = is40k10e || isAos || isCustomDs;
+  const showZoom = is40k || isAos || isCustomDs;
   const showAddToCategory = !activeCard.isCustom;
   const showSave = activeCard.isCustom && cardUpdated;
 

--- a/src/Components/Viewer/MobileDrawer.jsx
+++ b/src/Components/Viewer/MobileDrawer.jsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useSwipeable } from "react-swipeable";
 import { useDataSourceType } from "../../Helpers/cardstorage.helpers";
+import { getCardSectionKey, getSectionKey } from "../../Helpers/browseList.helpers";
 import { useCardStorage } from "../../Hooks/useCardStorage";
 import { useDataSourceStorage } from "../../Hooks/useDataSourceStorage";
 import { useSettingsStorage } from "../../Hooks/useSettingsStorage";
@@ -171,11 +172,12 @@ export const MobileDrawer = ({ open, setOpen }) => {
                   key={`list-role-${index}`}
                   className={`list-category`}
                   onClick={() => {
+                    const sectionKey = getSectionKey(card);
                     let newClosedRoles = [...(settings?.mobile?.closedRoles || [])];
-                    if (newClosedRoles.includes(card.name)) {
-                      newClosedRoles.splice(newClosedRoles.indexOf(card.name), 1);
+                    if (newClosedRoles.includes(sectionKey)) {
+                      newClosedRoles.splice(newClosedRoles.indexOf(sectionKey), 1);
                     } else {
-                      newClosedRoles.push(card.name);
+                      newClosedRoles.push(sectionKey);
                     }
                     updateSettings({
                       ...settings,
@@ -183,7 +185,7 @@ export const MobileDrawer = ({ open, setOpen }) => {
                     });
                   }}>
                   <span className="icon">
-                    {settings?.mobile?.closedRoles?.includes(card.name) ? (
+                    {settings?.mobile?.closedRoles?.includes(getSectionKey(card)) ? (
                       <ChevronRight size={14} />
                     ) : (
                       <ChevronDown size={14} />
@@ -198,7 +200,7 @@ export const MobileDrawer = ({ open, setOpen }) => {
             if (settings?.mobile?.closedFactions?.includes(card.faction_id) && card.allied) {
               return <></>;
             }
-            if (settings?.mobile?.closedRoles?.includes(card.role)) {
+            if (settings?.mobile?.closedRoles?.includes(getCardSectionKey(card))) {
               return <></>;
             }
             return (

--- a/src/Components/Viewer/ViewerLeftPanel/ViewerUnitList.jsx
+++ b/src/Components/Viewer/ViewerLeftPanel/ViewerUnitList.jsx
@@ -2,6 +2,7 @@ import { ChevronDown, ChevronRight } from "lucide-react";
 import { List } from "antd";
 import classNames from "classnames";
 import { useDataSourceType } from "../../../Helpers/cardstorage.helpers";
+import { groupStratagemsByDetachment } from "../../../Helpers/browseList.helpers";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
 import { useDataSourceStorage } from "../../../Hooks/useDataSourceStorage";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
@@ -86,19 +87,33 @@ export const ViewerUnitList = ({ searchText, selectedContentType }) => {
       return !settings?.ignoredSubFactions?.includes(stratagem.subfaction_id);
     });
 
-    const mainStratagems = searchText
+    const searchedStratagems = searchText
       ? filteredStratagems?.filter((stratagem) => stratagem.name.toLowerCase().includes(searchText.toLowerCase()))
       : filteredStratagems;
 
-    const basicStratagems = searchText
-      ? selectedFaction.basicStratagems?.filter((stratagem) =>
-          stratagem.name.toLowerCase().includes(searchText.toLowerCase()),
-        )
-      : selectedFaction.basicStratagems;
+    // A faction ships six stratagems per detachment, so the flat list runs to
+    // 60+ entries. Splitting it into collapsible detachment sections is opt-in.
+    const mainStratagems = settings.groupStratagemsByDetachment
+      ? groupStratagemsByDetachment(searchedStratagems, settings.language)
+      : searchedStratagems;
+
+    const basicStratagems = settings.hideBasicStratagems
+      ? []
+      : searchText
+        ? selectedFaction.basicStratagems?.filter((stratagem) =>
+            stratagem.name.toLowerCase().includes(searchText.toLowerCase()),
+          )
+        : selectedFaction.basicStratagems;
 
     unitList = [
-      { type: "header", name: "Basic stratagems" },
-      ...(basicStratagems || []).map((s) => ({ ...s, faction_id: selectedFaction.id })),
+      // Datasources without core stratagems skip the Basic section entirely
+      // instead of rendering an empty header.
+      ...(basicStratagems?.length > 0
+        ? [
+            { type: "header", name: "Basic stratagems" },
+            ...basicStratagems.map((s) => ({ ...s, faction_id: selectedFaction.id })),
+          ]
+        : []),
       { type: "header", name: "Faction stratagems" },
       ...(mainStratagems || []),
     ];

--- a/src/Components/Viewer/ViewerLeftPanel/ViewerUnitList.jsx
+++ b/src/Components/Viewer/ViewerLeftPanel/ViewerUnitList.jsx
@@ -2,7 +2,7 @@ import { ChevronDown, ChevronRight } from "lucide-react";
 import { List } from "antd";
 import classNames from "classnames";
 import { useDataSourceType } from "../../../Helpers/cardstorage.helpers";
-import { groupStratagemsByDetachment } from "../../../Helpers/browseList.helpers";
+import { getCardSectionKey, getSectionKey, groupStratagemsByDetachment } from "../../../Helpers/browseList.helpers";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
 import { useDataSourceStorage } from "../../../Hooks/useDataSourceStorage";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
@@ -283,11 +283,12 @@ export const ViewerUnitList = ({ searchText, selectedContentType }) => {
   };
 
   const handleRoleClick = (card) => {
+    const sectionKey = getSectionKey(card);
     let newClosedRoles = [...(settings?.mobile?.closedRoles || [])];
-    if (newClosedRoles.includes(card.name)) {
-      newClosedRoles.splice(newClosedRoles.indexOf(card.name), 1);
+    if (newClosedRoles.includes(sectionKey)) {
+      newClosedRoles.splice(newClosedRoles.indexOf(sectionKey), 1);
     } else {
-      newClosedRoles.push(card.name);
+      newClosedRoles.push(sectionKey);
     }
     updateSettings({
       ...settings,
@@ -366,7 +367,7 @@ export const ViewerUnitList = ({ searchText, selectedContentType }) => {
 
     // Role item
     if (card.type === "role") {
-      const isClosed = settings?.mobile?.closedRoles?.includes(card.name);
+      const isClosed = settings?.mobile?.closedRoles?.includes(getSectionKey(card));
       return (
         <List.Item key={`list-role-${index}`} className="list-category" onClick={() => handleRoleClick(card)}>
           <span className="icon">{isClosed ? <ChevronRight size={14} /> : <ChevronDown size={14} />}</span>
@@ -379,7 +380,7 @@ export const ViewerUnitList = ({ searchText, selectedContentType }) => {
     if (settings?.mobile?.closedFactions?.includes(card.faction_id) && card.allied) {
       return null;
     }
-    if (settings?.mobile?.closedRoles?.includes(card.role)) {
+    if (settings?.mobile?.closedRoles?.includes(getCardSectionKey(card))) {
       return null;
     }
 

--- a/src/Components/__tests__/FactionSettingsModal.test.jsx
+++ b/src/Components/__tests__/FactionSettingsModal.test.jsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// FactionSettingsModal resolves its portal target at import time, so the root
+// has to exist before the module is evaluated.
+vi.hoisted(() => {
+  const root = document.createElement("div");
+  root.setAttribute("id", "modal-root");
+  document.body.appendChild(root);
+});
+
+const mockState = {
+  dataSource: {},
+  selectedFaction: {},
+  settings: {},
+  updateSettings: vi.fn(),
+};
+
+vi.mock("../../Hooks/useDataSourceStorage", () => ({
+  useDataSourceStorage: () => ({ dataSource: mockState.dataSource, selectedFaction: mockState.selectedFaction }),
+}));
+vi.mock("../../Hooks/useSettingsStorage", () => ({
+  useSettingsStorage: () => ({ settings: mockState.settings, updateSettings: mockState.updateSettings }),
+}));
+
+import { FactionSettingsModal } from "../FactionSettingsModal";
+
+// The 11e datasource sets noDatasheetByRole/noSubfactionOptions, so the
+// datasheets tab opens by default and shows no "Split datasheets by role" card.
+const ELEVENTH_EDITION_DATASOURCE = {
+  noDatasheetOptions: false,
+  noDatasheetByRole: true,
+  noStratagemOptions: false,
+  noSubfactionOptions: true,
+  noSecondaryOptions: true,
+};
+
+const openModal = () => fireEvent.click(document.querySelector(".faction-settings-trigger"));
+
+describe("FactionSettingsModal", () => {
+  beforeEach(() => {
+    mockState.updateSettings = vi.fn();
+    mockState.selectedFaction = { id: "orks", name: "Orks" };
+  });
+
+  it("offers the 40k display options on the 11th edition datasource", () => {
+    mockState.dataSource = ELEVENTH_EDITION_DATASOURCE;
+    mockState.settings = { selectedDataSource: "40k-11e" };
+
+    render(<FactionSettingsModal />);
+    openModal();
+
+    expect(screen.getByText("Warhammer 11th edition options")).toBeInTheDocument();
+    expect(screen.getByText("Group cards by role")).toBeInTheDocument();
+    expect(screen.getByText("Show points in listview")).toBeInTheDocument();
+    expect(screen.getByText("Show both sides on one page")).toBeInTheDocument();
+  });
+
+  it("hides the Legends and allied toggles on 11e, whose data ships neither", () => {
+    mockState.dataSource = ELEVENTH_EDITION_DATASOURCE;
+    mockState.settings = { selectedDataSource: "40k-11e" };
+
+    render(<FactionSettingsModal />);
+    openModal();
+
+    expect(screen.queryByText("Add Legends datacards to factions")).not.toBeInTheDocument();
+    expect(screen.queryByText("Add allied faction cards to factions")).not.toBeInTheDocument();
+  });
+
+  it("keeps the 10th edition datacard toggles", () => {
+    mockState.dataSource = { ...ELEVENTH_EDITION_DATASOURCE };
+    mockState.settings = { selectedDataSource: "40k-10e" };
+
+    render(<FactionSettingsModal />);
+    openModal();
+
+    expect(screen.getByText("Warhammer 10th edition options")).toBeInTheDocument();
+    expect(screen.getByText("Add Legends datacards to factions")).toBeInTheDocument();
+  });
+
+  it("toggles group-by-role through updateSettings", () => {
+    mockState.dataSource = ELEVENTH_EDITION_DATASOURCE;
+    mockState.settings = { selectedDataSource: "40k-11e" };
+
+    render(<FactionSettingsModal />);
+    openModal();
+    fireEvent.click(screen.getByText("Group cards by role"));
+
+    expect(mockState.updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ selectedDataSource: "40k-11e", groupByRole: true }),
+    );
+  });
+
+  it("offers detachment grouping on the stratagems tab", () => {
+    mockState.dataSource = ELEVENTH_EDITION_DATASOURCE;
+    mockState.settings = { selectedDataSource: "40k-11e" };
+
+    render(<FactionSettingsModal />);
+    openModal();
+    fireEvent.click(screen.getByText("Stratagems"));
+
+    fireEvent.click(screen.getByText("Group stratagems by detachment"));
+    expect(mockState.updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ groupStratagemsByDetachment: true }),
+    );
+  });
+
+  it("does not offer the 40k options on Age of Sigmar", () => {
+    mockState.dataSource = { noDatasheetOptions: true, noSubfactionOptions: true, noStratagemOptions: true };
+    mockState.settings = { selectedDataSource: "aos" };
+
+    render(<FactionSettingsModal />);
+    openModal();
+
+    expect(screen.queryByText("Group cards by role")).not.toBeInTheDocument();
+    expect(screen.getByText("Show Legends warscrolls")).toBeInTheDocument();
+  });
+});

--- a/src/Helpers/__tests__/browseList.helpers.test.js
+++ b/src/Helpers/__tests__/browseList.helpers.test.js
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   buildFactionDatasheetList,
+  getCardSectionKey,
+  getSectionKey,
   groupSheetsByRole,
   groupStratagemsByDetachment,
   is40kBrowseSource,
@@ -166,5 +168,33 @@ describe("buildFactionDatasheetList", () => {
     expect(rows[allied].name).toBe("Agents of the Imperium");
     expect(rows[allied + 1].name).toBe("Inquisitor");
     expect(rows[allied + 1].allied).toBe(true);
+  });
+});
+
+// Role sections and detachment sections share one `settings.mobile.closedRoles`
+// list, and both have an "Other" bucket, so their collapse keys must not collide.
+describe("section collapse keys", () => {
+  const otherSheet = groupSheetsByRole([sheet11e("Stompa", "Titanic")]).filter((row) => row.name === "Other");
+  const otherStrats = groupStratagemsByDetachment([{ id: "s", name: "Command Re-roll", detachment: "" }]);
+
+  it("namespaces a role section apart from a detachment section of the same name", () => {
+    const roleSeparator = otherSheet.find((row) => row.type === "role");
+    const detachmentSeparator = otherStrats.find((row) => row.type === "role");
+    expect(getSectionKey(roleSeparator)).not.toBe(getSectionKey(detachmentSeparator));
+  });
+
+  it("gives a card the same key as the separator it sits under", () => {
+    const [separator, card] = groupSheetsByRole([sheet11e("Warboss", "Character")]);
+    expect(getCardSectionKey(card)).toBe(getSectionKey(separator));
+
+    const [stratSeparator, strat] = groupStratagemsByDetachment([
+      { id: "s", name: "Ere We Go", detachment: "Blitz Brigade" },
+    ]);
+    expect(getCardSectionKey(strat)).toBe(getSectionKey(stratSeparator));
+  });
+
+  it("falls back to the display name for rows built without a key", () => {
+    expect(getSectionKey({ type: "role", name: "Heroes" })).toBe("Heroes");
+    expect(getCardSectionKey({ name: "Warboss", role: "Character" })).toBe("Character");
   });
 });

--- a/src/Helpers/__tests__/browseList.helpers.test.js
+++ b/src/Helpers/__tests__/browseList.helpers.test.js
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildFactionDatasheetList,
+  groupSheetsByRole,
+  groupStratagemsByDetachment,
+  is40kBrowseSource,
+} from "../browseList.helpers";
+
+// 10th edition keywords are plain strings, 11th edition keywords are
+// language-keyed objects. Both must group.
+const sheet10e = (name, ...keywords) => ({ id: name, name, keywords });
+const sheet11e = (name, ...keywords) => ({ id: name, name, keywords: keywords.map((k) => ({ en: k, de: `${k}-de` })) });
+
+const names = (rows) => rows.map((row) => row.name);
+const separators = (rows) => rows.filter((row) => row.type === "role").map((row) => row.name);
+
+describe("is40kBrowseSource", () => {
+  it("covers every 40k edition that browses datasheets", () => {
+    expect(["40k-10e", "40k-10e-cp", "40k-11e"].every(is40kBrowseSource)).toBe(true);
+  });
+
+  it("excludes the other datasources", () => {
+    expect(["aos", "40k", "basic", "necromunda", "custom-1234", undefined].some(is40kBrowseSource)).toBe(false);
+  });
+});
+
+describe("groupSheetsByRole", () => {
+  it("splits 10e string keywords into role sections", () => {
+    const rows = groupSheetsByRole([
+      sheet10e("Warboss", "Infantry", "Character"),
+      sheet10e("Boyz", "Infantry", "Battleline"),
+      sheet10e("Trukk", "Vehicle", "Dedicated Transport"),
+      sheet10e("Stompa", "Vehicle", "Titanic"),
+    ]);
+
+    expect(names(rows)).toEqual([
+      "Character",
+      "Warboss",
+      "Battleline",
+      "Boyz",
+      "Dedicated Transport",
+      "Trukk",
+      "Other",
+      "Stompa",
+    ]);
+  });
+
+  it("splits 11e language-keyed keywords into the same role sections", () => {
+    const rows = groupSheetsByRole([
+      sheet11e("Warboss", "Infantry", "Character"),
+      sheet11e("Boyz", "Infantry", "Battleline"),
+      sheet11e("Stompa", "Vehicle", "Titanic"),
+    ]);
+
+    expect(names(rows)).toEqual([
+      "Character",
+      "Warboss",
+      "Battleline",
+      "Boyz",
+      "Dedicated Transport",
+      "Other",
+      "Stompa",
+    ]);
+  });
+
+  it("tags each sheet with its role so the list can collapse the section", () => {
+    const rows = groupSheetsByRole([sheet11e("Warboss", "Character")]);
+    expect(rows.find((row) => row.name === "Warboss").role).toBe("Character");
+  });
+
+  it("drops structural rows, which carry no keywords", () => {
+    const rows = groupSheetsByRole([{ type: "category", name: "Orks", id: "orks" }, sheet11e("Boyz", "Battleline")]);
+    expect(rows.some((row) => row.type === "category")).toBe(false);
+  });
+});
+
+describe("groupStratagemsByDetachment", () => {
+  const strat = (name, detachment) => ({ id: name, name, detachment });
+
+  it("keeps the datasource's detachment order and groups each one", () => {
+    const rows = groupStratagemsByDetachment([
+      strat("Ere We Go", "Blitz Brigade"),
+      strat("Unbridled Carnage", "Kult of Speed"),
+      strat("Ramming Speed", "Blitz Brigade"),
+    ]);
+
+    expect(names(rows)).toEqual(["Blitz Brigade", "Ere We Go", "Ramming Speed", "Kult of Speed", "Unbridled Carnage"]);
+    expect(rows.find((row) => row.name === "Ere We Go").role).toBe("Blitz Brigade");
+  });
+
+  it("resolves language-keyed detachment names for the chosen language", () => {
+    const rows = groupStratagemsByDetachment([strat("Ere We Go", { en: "Blitz Brigade", de: "Blitzbrigade" })], "de");
+    expect(separators(rows)).toEqual(["Blitzbrigade"]);
+  });
+
+  it("sorts stratagems without a detachment into a trailing Other section", () => {
+    const rows = groupStratagemsByDetachment([strat("Command Re-roll", ""), strat("Ere We Go", "Blitz Brigade")]);
+    expect(separators(rows)).toEqual(["Blitz Brigade", "Other"]);
+  });
+
+  it("returns nothing for a faction with no stratagems", () => {
+    expect(groupStratagemsByDetachment(undefined)).toEqual([]);
+  });
+});
+
+describe("buildFactionDatasheetList", () => {
+  const faction = {
+    id: "orks",
+    name: "Orks",
+    datasheets: [sheet11e("Boyz", "Battleline"), sheet11e("Warboss", "Character"), sheet11e("Stompa", "Titanic")],
+  };
+  const dataSource = { data: [faction] };
+
+  it("sorts alphabetically when no grouping is on", () => {
+    const rows = buildFactionDatasheetList({ dataSource, selectedFaction: faction, settings: {} });
+    expect(rows.filter((row) => !row.type).map((row) => row.name)).toEqual(["Boyz", "Stompa", "Warboss"]);
+  });
+
+  it("groups an 11e faction by role", () => {
+    const rows = buildFactionDatasheetList({
+      dataSource,
+      selectedFaction: faction,
+      settings: { groupByRole: true },
+    });
+    expect(separators(rows)).toEqual(["Character", "Battleline", "Dedicated Transport", "Other"]);
+    expect(rows.find((row) => row.name === "Boyz").role).toBe("Battleline");
+  });
+
+  it("drops role sections a search has emptied", () => {
+    const rows = buildFactionDatasheetList({
+      dataSource,
+      selectedFaction: faction,
+      settings: { groupByRole: true },
+      searchText: "boyz",
+    });
+    expect(names(rows)).toEqual(["Battleline", "Boyz"]);
+  });
+
+  it("hides Legends sheets unless the setting asks for them", () => {
+    const legendsFaction = { ...faction, datasheets: [...faction.datasheets, { name: "Old Boss", legends: true }] };
+    const rows = buildFactionDatasheetList({
+      dataSource,
+      selectedFaction: legendsFaction,
+      settings: {},
+    });
+    expect(rows.some((row) => row.name === "Old Boss")).toBe(false);
+
+    const withLegends = buildFactionDatasheetList({
+      dataSource,
+      selectedFaction: legendsFaction,
+      settings: { showLegends: true },
+    });
+    expect(withLegends.some((row) => row.name === "Old Boss")).toBe(true);
+  });
+
+  it("appends allied faction sections after the faction's own sheets", () => {
+    const allies = { id: "agents", name: "Agents of the Imperium", datasheets: [sheet11e("Inquisitor", "Character")] };
+    const rows = buildFactionDatasheetList({
+      dataSource: { data: [faction, allies] },
+      selectedFaction: { ...faction, allied_factions: ["agents"] },
+      settings: { combineAlliedFactions: true },
+    });
+
+    const allied = rows.findIndex((row) => row.type === "allied");
+    expect(allied).toBeGreaterThan(-1);
+    expect(rows[allied].name).toBe("Agents of the Imperium");
+    expect(rows[allied + 1].name).toBe("Inquisitor");
+    expect(rows[allied + 1].allied).toBe(true);
+  });
+});

--- a/src/Helpers/__tests__/customDatasource.helpers.test.js
+++ b/src/Helpers/__tests__/customDatasource.helpers.test.js
@@ -38,7 +38,7 @@ describe("VALID_DISPLAY_FORMATS", () => {
   });
 
   it("includes all expected formats", () => {
-    expect(VALID_DISPLAY_FORMATS).toEqual(["40k-10e", "40k", "basic", "necromunda", "aos", "custom"]);
+    expect(VALID_DISPLAY_FORMATS).toEqual(["40k-11e", "40k-10e", "40k", "basic", "necromunda", "aos", "custom"]);
   });
 });
 

--- a/src/Helpers/browseList.helpers.js
+++ b/src/Helpers/browseList.helpers.js
@@ -34,21 +34,28 @@ export const OTHER_ROLE = "Other";
  *
  * @param {Array} sheets - datasheets, possibly mixed with structural rows
  * @returns {Array} rows of `{ type: "role", name }` separators followed by their
- *   datasheets, each tagged with `role` so the list can collapse the section
+ *   datasheets, each tagged with `role` and `roleKey` so the list can collapse
+ *   the section
  */
 export const groupSheetsByRole = (sheets) => {
   const cards = (sheets || []).filter((sheet) => !sheet?.type);
   const rows = [];
 
+  const section = (role) => {
+    const roleKey = `role:${role}`;
+    rows.push({ type: "role", name: role, roleKey });
+    return roleKey;
+  };
+
   DATASHEET_ROLES.forEach((role) => {
-    rows.push({ type: "role", name: role });
-    cards.filter((sheet) => cardHasKeyword(sheet, role)).forEach((sheet) => rows.push({ ...sheet, role }));
+    const roleKey = section(role);
+    cards.filter((sheet) => cardHasKeyword(sheet, role)).forEach((sheet) => rows.push({ ...sheet, role, roleKey }));
   });
 
-  rows.push({ type: "role", name: OTHER_ROLE });
+  const otherKey = section(OTHER_ROLE);
   cards
     .filter((sheet) => DATASHEET_ROLES.every((role) => !cardHasKeyword(sheet, role)))
-    .forEach((sheet) => rows.push({ ...sheet, role: OTHER_ROLE }));
+    .forEach((sheet) => rows.push({ ...sheet, role: OTHER_ROLE, roleKey: otherKey }));
 
   return rows;
 };
@@ -62,7 +69,8 @@ export const groupSheetsByRole = (sheets) => {
  * @param {string} [language] - card language, for datasources whose detachment
  *   names are language-keyed objects
  * @returns {Array} rows of `{ type: "role", name }` separators followed by their
- *   stratagems, each tagged with `role` so the list can collapse the section
+ *   stratagems, each tagged with `role` and `roleKey` so the list can collapse
+ *   the section
  */
 export const groupStratagemsByDetachment = (stratagems, language = "en") => {
   const sections = new Map();
@@ -72,7 +80,7 @@ export const groupStratagemsByDetachment = (stratagems, language = "en") => {
     if (!sections.has(name)) {
       sections.set(name, []);
     }
-    sections.get(name).push({ ...stratagem, role: name });
+    sections.get(name).push({ ...stratagem, role: name, roleKey: `detachment:${name}` });
   });
 
   // A nameless detachment sorts last, whatever order the data listed it in.
@@ -81,7 +89,7 @@ export const groupStratagemsByDetachment = (stratagems, language = "en") => {
     names.push(OTHER_ROLE);
   }
 
-  return names.flatMap((name) => [{ type: "role", name }, ...sections.get(name)]);
+  return names.flatMap((name) => [{ type: "role", name, roleKey: `detachment:${name}` }, ...sections.get(name)]);
 };
 
 const isCardRow = (row) => Boolean(row) && !row.type;
@@ -94,6 +102,22 @@ const isCardRow = (row) => Boolean(row) && !row.type;
  * @returns {Array} the same rows minus the separators that head no cards
  */
 const dropEmptySections = (rows) => rows.filter((row, index) => isCardRow(row) || isCardRow(rows[index + 1]));
+
+/**
+ * Collapse-state key for a section separator row. Datasheet roles and stratagem
+ * detachments share one `settings.mobile.closedRoles` list, and both can be
+ * called "Other", so the key is namespaced rather than the bare display name.
+ *
+ * @param {Object} row - a `{ type: "role" }` separator row
+ */
+export const getSectionKey = (row) => row?.roleKey ?? row?.name;
+
+/**
+ * Collapse-state key for a card row, matching the separator it sits under.
+ *
+ * @param {Object} card - a card row
+ */
+export const getCardSectionKey = (card) => card?.roleKey ?? card?.role;
 
 /**
  * Build a 40K faction's datasheet list: the faction's own sheets plus any parent

--- a/src/Helpers/browseList.helpers.js
+++ b/src/Helpers/browseList.helpers.js
@@ -78,9 +78,10 @@ export const groupStratagemsByDetachment = (stratagems, language = "en") => {
   (stratagems || []).forEach((stratagem) => {
     const name = localize(stratagem?.detachment, language) || OTHER_ROLE;
     if (!sections.has(name)) {
-      sections.set(name, []);
+      sections.set(name, { roleKey: `detachment:${name}`, rows: [] });
     }
-    sections.get(name).push({ ...stratagem, role: name, roleKey: `detachment:${name}` });
+    const section = sections.get(name);
+    section.rows.push({ ...stratagem, role: name, roleKey: section.roleKey });
   });
 
   // A nameless detachment sorts last, whatever order the data listed it in.
@@ -89,7 +90,10 @@ export const groupStratagemsByDetachment = (stratagems, language = "en") => {
     names.push(OTHER_ROLE);
   }
 
-  return names.flatMap((name) => [{ type: "role", name, roleKey: `detachment:${name}` }, ...sections.get(name)]);
+  return names.flatMap((name) => {
+    const { roleKey, rows } = sections.get(name);
+    return [{ type: "role", name, roleKey }, ...rows];
+  });
 };
 
 const isCardRow = (row) => Boolean(row) && !row.type;

--- a/src/Helpers/browseList.helpers.js
+++ b/src/Helpers/browseList.helpers.js
@@ -1,0 +1,170 @@
+import { cardHasKeyword } from "./listCategories.helpers";
+import { localize } from "./localization.helpers";
+
+// ===========================================
+// Faction browser list building (40K)
+// ===========================================
+// Shared by the desktop editor's left panel (useDataSourceItems) and the
+// viewer/mobile drawer (useDataSourceType), so both browsers group a faction's
+// cards the same way.
+
+/** 40K datasources whose factions browse as datasheets + stratagems. */
+export const BROWSE_40K_SOURCES = ["40k-10e", "40k-10e-cp", "40k-11e"];
+
+/**
+ * True for the 40K datasources that use the faction/role grouped browser.
+ * @param {string} source - a datasource id (settings.selectedDataSource)
+ */
+export const is40kBrowseSource = (source) => BROWSE_40K_SOURCES.includes(source);
+
+/**
+ * Role sections, in the order GW prints them on an army roster. Matched against
+ * the canonical English keyword, so 10e string keywords and 11e language-keyed
+ * object keywords both group (see cardHasKeyword).
+ */
+export const DATASHEET_ROLES = ["Character", "Battleline", "Dedicated Transport"];
+
+/** Section holding everything that carries none of the role keywords. */
+export const OTHER_ROLE = "Other";
+
+/**
+ * Split datasheets into collapsible role sections: Character, Battleline,
+ * Dedicated Transport, Other. Structural rows (faction/allied separators) carry
+ * no keywords and are dropped — roles replace them as the grouping.
+ *
+ * @param {Array} sheets - datasheets, possibly mixed with structural rows
+ * @returns {Array} rows of `{ type: "role", name }` separators followed by their
+ *   datasheets, each tagged with `role` so the list can collapse the section
+ */
+export const groupSheetsByRole = (sheets) => {
+  const cards = (sheets || []).filter((sheet) => !sheet?.type);
+  const rows = [];
+
+  DATASHEET_ROLES.forEach((role) => {
+    rows.push({ type: "role", name: role });
+    cards.filter((sheet) => cardHasKeyword(sheet, role)).forEach((sheet) => rows.push({ ...sheet, role }));
+  });
+
+  rows.push({ type: "role", name: OTHER_ROLE });
+  cards
+    .filter((sheet) => DATASHEET_ROLES.every((role) => !cardHasKeyword(sheet, role)))
+    .forEach((sheet) => rows.push({ ...sheet, role: OTHER_ROLE }));
+
+  return rows;
+};
+
+/**
+ * Split stratagems into collapsible sections per detachment, in the order the
+ * datasource lists them. A faction ships six stratagems per detachment, so an
+ * 11e faction browses as one 60+ item pile without this.
+ *
+ * @param {Array} stratagems - a faction's stratagems
+ * @param {string} [language] - card language, for datasources whose detachment
+ *   names are language-keyed objects
+ * @returns {Array} rows of `{ type: "role", name }` separators followed by their
+ *   stratagems, each tagged with `role` so the list can collapse the section
+ */
+export const groupStratagemsByDetachment = (stratagems, language = "en") => {
+  const sections = new Map();
+
+  (stratagems || []).forEach((stratagem) => {
+    const name = localize(stratagem?.detachment, language) || OTHER_ROLE;
+    if (!sections.has(name)) {
+      sections.set(name, []);
+    }
+    sections.get(name).push({ ...stratagem, role: name });
+  });
+
+  // A nameless detachment sorts last, whatever order the data listed it in.
+  const names = [...sections.keys()].filter((name) => name !== OTHER_ROLE);
+  if (sections.has(OTHER_ROLE)) {
+    names.push(OTHER_ROLE);
+  }
+
+  return names.flatMap((name) => [{ type: "role", name }, ...sections.get(name)]);
+};
+
+const isCardRow = (row) => Boolean(row) && !row.type;
+
+/**
+ * Drop separator rows a search has emptied, so filtering never leaves a role or
+ * faction heading with nothing under it.
+ *
+ * @param {Array} rows - browser rows, separators mixed with cards
+ * @returns {Array} the same rows minus the separators that head no cards
+ */
+const dropEmptySections = (rows) => rows.filter((row, index) => isCardRow(row) || isCardRow(rows[index + 1]));
+
+/**
+ * Build a 40K faction's datasheet list: the faction's own sheets plus any parent
+ * and allied sheets the settings ask for, grouped by faction or by role, and
+ * filtered by the search box.
+ *
+ * @param {Object} params
+ * @param {Object} params.dataSource - the loaded datasource
+ * @param {Object} params.selectedFaction - the faction being browsed
+ * @param {Object} params.settings - user settings
+ * @param {string} [params.searchText] - search box contents
+ * @returns {Array} rows for the browser list
+ */
+export const buildFactionDatasheetList = ({ dataSource, selectedFaction, settings, searchText }) => {
+  let filteredSheets = [
+    { type: "category", name: selectedFaction.name, id: selectedFaction.id, closed: false },
+    ...selectedFaction?.datasheets?.toSorted((a, b) => a.name.localeCompare(b.name)),
+  ];
+
+  if (selectedFaction.is_subfaction && settings.combineParentFactions) {
+    const parentFaction = dataSource.data.find((faction) => faction.id === selectedFaction.parent_id);
+
+    const parentDatasheets = parentFaction?.datasheets
+      ?.filter((val) => val.factions.length === 1 && val.factions.includes(selectedFaction.parent_keyword))
+      .map((val) => {
+        return { ...val, nonBase: true };
+      });
+
+    filteredSheets = [
+      ...filteredSheets,
+      { type: "category", name: parentFaction.name, id: parentFaction.id, closed: true },
+      ...parentDatasheets?.toSorted((a, b) => a.name.localeCompare(b.name)),
+    ];
+  }
+
+  if (!settings?.showLegends) {
+    filteredSheets = filteredSheets?.filter((sheet) => !sheet.legends);
+  }
+  if (!settings.groupByFaction) {
+    filteredSheets = filteredSheets?.toSorted((a, b) => a.name.localeCompare(b.name));
+  }
+  if (settings.groupByRole) {
+    filteredSheets = groupSheetsByRole(filteredSheets);
+  }
+
+  if (selectedFaction.allied_factions && selectedFaction.allied_factions.length > 0 && settings.combineAlliedFactions) {
+    selectedFaction.allied_factions.forEach((alliedFactionId) => {
+      const alliedFaction = dataSource.data.find((faction) => faction.id === alliedFactionId);
+
+      const alliedFactionDatasheets = alliedFaction?.datasheets.map((val) => {
+        return { ...val, nonBase: true, allied: true };
+      });
+
+      filteredSheets = [
+        ...filteredSheets,
+        { type: "allied", name: alliedFaction.name, id: alliedFaction.id, closed: true },
+        ...alliedFactionDatasheets?.toSorted((a, b) => a.name.localeCompare(b.name)),
+      ];
+    });
+  }
+
+  if (!searchText) {
+    return filteredSheets;
+  }
+
+  const matches = filteredSheets.filter((sheet) => {
+    if (sheet.type) {
+      return true;
+    }
+    return sheet.name.toLowerCase().includes(searchText.toLowerCase());
+  });
+
+  return dropEmptySections(matches);
+};

--- a/src/Helpers/cardstorage.helpers.js
+++ b/src/Helpers/cardstorage.helpers.js
@@ -2,6 +2,7 @@ import { compare } from "compare-versions";
 import { v4 as uuidv4 } from "uuid";
 import { useDataSourceStorage } from "../Hooks/useDataSourceStorage";
 import { useSettingsStorage } from "../Hooks/useSettingsStorage";
+import { buildFactionDatasheetList, is40kBrowseSource } from "./browseList.helpers";
 
 const defaultCategories = {
   version: import.meta.env.VITE_VERSION,
@@ -18,102 +19,17 @@ export const useDataSourceType = (searchText) => {
   const { settings } = useSettingsStorage();
   const { dataSource, selectedFaction } = useDataSourceStorage();
 
-  let filteredSheets = [];
-  if (selectedFaction && (settings.selectedDataSource === "40k-10e" || settings.selectedDataSource === "40k-10e-cp")) {
+  if (selectedFaction && is40kBrowseSource(settings.selectedDataSource)) {
     try {
-      filteredSheets = [
-        { type: "category", name: selectedFaction.name, id: selectedFaction.id, closed: false },
-        ...selectedFaction?.datasheets?.toSorted((a, b) => a.name.localeCompare(b.name)),
-      ];
-      if (selectedFaction.is_subfaction && settings.combineParentFactions) {
-        let parentFaction = dataSource.data.find((faction) => faction.id === selectedFaction.parent_id);
-
-        let parentDatasheets = parentFaction?.datasheets
-          ?.filter((val) => val.factions.length === 1 && val.factions.includes(selectedFaction.parent_keyword))
-          .map((val) => {
-            return { ...val, nonBase: true };
-          });
-
-        filteredSheets = [
-          ...filteredSheets,
-          { type: "category", name: parentFaction.name, id: parentFaction.id, closed: true },
-          ...parentDatasheets?.toSorted((a, b) => a.name.localeCompare(b.name)),
-        ];
-      }
-
-      if (!settings?.showLegends) {
-        filteredSheets = filteredSheets?.filter((sheet) => !sheet.legends);
-      }
-      if (!settings.groupByFaction) {
-        filteredSheets = filteredSheets?.toSorted((a, b) => a.name.localeCompare(b.name));
-      }
-      if (settings.groupByRole) {
-        const types = ["Battleline", "Character", "Dedicated Transport"];
-        let byRole = [];
-
-        types.map((role) => {
-          byRole = [...byRole, { type: "role", name: role }];
-          byRole = [
-            ...byRole,
-            ...filteredSheets
-              ?.filter((sheet) => sheet?.keywords?.includes(role))
-              .map((val) => {
-                return { ...val, role: role };
-              }),
-          ];
-        });
-
-        byRole = [
-          ...byRole,
-          { type: "role", name: "Other" },
-          ...filteredSheets
-            ?.filter((sheet) => {
-              return types.every((t) => !sheet?.keywords?.includes(t));
-            })
-            .map((val) => {
-              return { ...val, role: "Other" };
-            }),
-        ];
-
-        filteredSheets = byRole;
-      }
-
-      if (
-        selectedFaction.allied_factions &&
-        selectedFaction.allied_factions.length > 0 &&
-        settings.combineAlliedFactions
-      ) {
-        selectedFaction.allied_factions.forEach((alliedFactionId) => {
-          let alliedFaction = dataSource.data.find((faction) => faction.id === alliedFactionId);
-
-          let alliedFactionDatasheets = alliedFaction?.datasheets.map((val) => {
-            return { ...val, nonBase: true, allied: true };
-          });
-
-          filteredSheets = [
-            ...filteredSheets,
-            { type: "allied", name: alliedFaction.name, id: alliedFaction.id, closed: true },
-            ...alliedFactionDatasheets?.toSorted((a, b) => a.name.localeCompare(b.name)),
-          ];
-        });
-      }
-      filteredSheets = searchText
-        ? filteredSheets.filter((sheet) => {
-            if (sheet.type === "category" || sheet.type === "header") {
-              return true;
-            }
-            return sheet.name.toLowerCase().includes(searchText.toLowerCase());
-          })
-        : filteredSheets;
-
-      return filteredSheets;
+      return buildFactionDatasheetList({ dataSource, selectedFaction, settings, searchText });
     } catch (error) {
       console.error("An error occured", error);
       return [];
     }
-  } //
-  if (selectedFaction && settings.selectedDataSource !== "40k-10e" && settings.selectedDataSource !== "40k-10e-cp") {
-    filteredSheets = searchText
+  }
+
+  if (selectedFaction) {
+    let filteredSheets = searchText
       ? selectedFaction?.datasheets?.filter((sheet) => sheet.name.toLowerCase().includes(searchText.toLowerCase()))
       : selectedFaction?.datasheets;
     if (!settings?.showLegends) {

--- a/src/Helpers/customDatasource.helpers.js
+++ b/src/Helpers/customDatasource.helpers.js
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import { validateSchema, getDefaultValueForType, stripReservedWeaponColumns } from "./customSchema.helpers";
 
 // Valid display formats that map to existing card renderers
-export const VALID_DISPLAY_FORMATS = ["40k-10e", "40k", "basic", "necromunda", "aos", "custom"];
+export const VALID_DISPLAY_FORMATS = ["40k-11e", "40k-10e", "40k", "basic", "necromunda", "aos", "custom"];
 
 // Validation limits for security
 const MAX_NAME_LENGTH = 200;

--- a/src/Hooks/useViewerNavigation.jsx
+++ b/src/Hooks/useViewerNavigation.jsx
@@ -135,7 +135,12 @@ export function useViewerNavigation() {
       if (foundEnhancement) {
         // AoS enhancements carry their own `source` ("aos-4e"), which no renderer
         // is keyed on — the faction's shape decides which card display to use.
-        const enhancementSource = foundFaction?.warscrolls ? "aos" : foundFaction?.datasheets ? "40k-10e" : "40k";
+        // 40k factions keep their own source so 11e cards reach the 11e renderer.
+        const enhancementSource = foundFaction?.warscrolls
+          ? "aos"
+          : foundFaction?.datasheets
+            ? (foundFaction.source ?? "40k-10e")
+            : "40k";
         setActiveCard({
           ...foundEnhancement,
           id: `enhancement-${foundEnhancement.name}`, // Add unique id for changeActiveCard comparison
@@ -183,7 +188,7 @@ export function useViewerNavigation() {
           id: `rule-${foundRule.name}`, // Add unique id for changeActiveCard comparison
           cardType: "rule",
           faction_id: foundFaction?.id,
-          source: foundFaction?.datasheets ? "40k-10e" : "40k",
+          source: foundFaction?.datasheets ? (foundFaction.source ?? "40k-10e") : "40k",
         });
       } else {
         setActiveCard();

--- a/src/Hooks/useViewerNavigation.jsx
+++ b/src/Hooks/useViewerNavigation.jsx
@@ -135,11 +135,12 @@ export function useViewerNavigation() {
       if (foundEnhancement) {
         // AoS enhancements carry their own `source` ("aos-4e"), which no renderer
         // is keyed on — the faction's shape decides which card display to use.
-        // 40k factions keep their own source so 11e cards reach the 11e renderer.
+        // 40k cards keep their own source so 11e enhancements reach the 11e
+        // renderer, falling back to the faction's for data that omits it.
         const enhancementSource = foundFaction?.warscrolls
           ? "aos"
           : foundFaction?.datasheets
-            ? (foundFaction.source ?? "40k-10e")
+            ? (foundEnhancement.source ?? foundFaction.source ?? "40k-10e")
             : "40k";
         setActiveCard({
           ...foundEnhancement,
@@ -188,7 +189,9 @@ export function useViewerNavigation() {
           id: `rule-${foundRule.name}`, // Add unique id for changeActiveCard comparison
           cardType: "rule",
           faction_id: foundFaction?.id,
-          source: foundFaction?.datasheets ? (foundFaction.source ?? "40k-10e") : "40k",
+          // Same as enhancements: the rule's own source routes 11e rules to the
+          // 11e renderer, with the faction's as a fallback.
+          source: foundFaction?.datasheets ? (foundRule.source ?? foundFaction.source ?? "40k-10e") : "40k",
         });
       } else {
         setActiveCard();

--- a/src/Pages/ImageExport.jsx
+++ b/src/Pages/ImageExport.jsx
@@ -175,7 +175,7 @@ export const ImageExport = () => {
                             <div ref={(el) => (cardsFrontRef.current[index] = el)}>
                               <CardRenderer card={card} cardScaling={100} printSide="front" backgrounds={backgrounds} />
                             </div>
-                            {card?.source === "40k-10e" &&
+                            {["40k-10e", "40k-11e"].includes(card?.source) &&
                               settings.showCardsAsDoubleSided !== true &&
                               card?.cardType === "DataCard" &&
                               card?.variant !== "full" && (


### PR DESCRIPTION
## Proposed Changes

Reported on Discord: since the 11th edition update, faction datasheets can no longer be sorted into Character / Battleline / the rest, and stratagems come out as one undifferentiated pile.

Two separate causes:

1. **The setting was never shown.** `FactionSettingsModal` only rendered its 40k display options for `40k-10e` and `40k-10e-cp`, so on `40k-11e` the Datasheets tab — the tab that opens by default — was completely empty. No "Group cards by role", no "Show points in listview", no "Show both sides on one page".
2. **The grouping was broken anyway.** It bucketed sheets with `sheet.keywords.includes("Character")`. 10e keywords are plain strings, but 11e ships them as language-keyed objects (`{ en: "Character", de: "Charaktermodell" }`), so nothing matched and every unit fell into "Other".

The datasheet list was also duplicated between `useDataSourceItems` (editor panel) and `useDataSourceType` (viewer panel / mobile drawer), and the second copy never learned about 11e at all — so the viewer's list stayed flat there too.

### What changed

- New `src/Helpers/browseList.helpers.js` holds the shared list building. Both panels call `buildFactionDatasheetList`, so a grouping setting behaves identically in the editor and the viewer.
- Role matching goes through `cardHasKeyword`, which compares against the canonical English keyword and therefore works on both editions.
- Role sections are ordered Character, Battleline, Dedicated Transport, Other — the roster order, and the order mobile already used (desktop previously led with Battleline).
- Searching a grouped list drops the sections the search empties, instead of leaving bare headings behind.
- The faction settings modal shares one 40k options block across `40k-11e`, `40k-10e` and `40k-10e-cp`. Legends / parent chapter / allied toggles stay 10e-only, since the 11e data ships no `legends`, `is_subfaction`, `parent_keyword` or `allied_factions` fields for them to act on.

### Stratagems

A 40k faction ships around six stratagems per detachment — Orks has 66 across 13 detachments — so the flat list is unusable. Added an opt-in **Group stratagems by detachment** setting (Stratagems tab) that splits them into collapsible sections, in datasource order, with core stratagems left flat under "Basic stratagems". The per-row detachment subtitle is dropped when the list is grouped, since the heading already says it.

### Other 11e gaps found while auditing

| Where | Was |
|-------|-----|
| `FloatingToolbar` | Zoom and front/back flip gated to `40k-10e`; 11e cards got neither, although the 11e renderer honours both |
| `ImageExport` | Card back never exported for 11e |
| `useViewerNavigation` | Enhancement and rule URLs forced `source: "40k-10e"`, routing 11e cards to the 10e renderer |
| `SharedCardList`, `SharedMobileCardList` | 11e cards labelled "Card" instead of Datasheet / Stratagem / Enhancement / Rule |
| `ViewerUnitList` | "Basic stratagems" heading rendered even with none, and `hideBasicStratagems` was ignored |
| `VALID_DISPLAY_FORMATS` | Missing `40k-11e` |

Not addressed, worth a separate look: the GW app and ListForge importers/exporters are still 10e-only, since both formats map onto 10e data.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes

`yarn lint` clean, `yarn test:ci` 3270 passed / 204 files, `yarn build` succeeds. 32 new tests cover the helpers, the two hook paths and the settings modal.

Verified against the live 11e datasource in a browser: Orks datasheets group into Character (21) / Battleline (2) / Dedicated Transport (1) / Other, stratagems collapse per detachment, and search prunes empty sections.

Docs: new `docs/faction-browser-grouping.md`, indexed under Features. Release fragment in `changes/unreleased/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FywbEDK24Rna8wPw5JJkQ3)_