### PR TITLE
Mobile: 11th edition card editing, cloud category sharing, and a CI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,14 @@ on:
     paths-ignore:
       - "**/*.md"
 
+# A branch with an open PR fires this workflow twice — once for the push and once
+# for the pull_request — and both resolved to the same group, so whichever
+# started second cancelled the other. Only the pull_request run executes `test`,
+# so when the push run won the race the PR went green having run no tests at all.
+# Keying the group on the event as well lets the two runs stand alongside each
+# other, while a second push to the same branch still cancels its own predecessor.
 concurrency:
-  group: "${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}"
+  group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.ref || github.ref_name }}"
   cancel-in-progress: true
 
 jobs:

--- a/changes/unreleased/mobile-11e-card-editing.json
+++ b/changes/unreleased/mobile-11e-card-editing.json
@@ -1,0 +1,5 @@
+{
+  "title": "Edit 11th edition cards on mobile",
+  "body": "Cards you add to an 11th edition list on mobile now have an Edit button, like 10th edition and Age of Sigmar cards already did. The mobile editor covers the whole card — stats, points and their detachment or faction restrictions, weapons and their profiles, weapon abilities, core, faction and other abilities, Primarch abilities, the damaged profile, invulnerable save, wargear options, unit composition, loadout, leader, transport and keywords — as well as stratagems, enhancements and rules. Edits are written in the card language you picked in Settings and leave the other languages untouched, so a card you edit in German still reads correctly in English.",
+  "severity": "info"
+}

--- a/changes/unreleased/mobile-cloud-category-sharing.json
+++ b/changes/unreleased/mobile-cloud-category-sharing.json
@@ -1,0 +1,5 @@
+{
+  "title": "Share cloud categories from your phone",
+  "body": "The \"...\" menu in the mobile list overview now offers Share List for cloud categories, not just local lists, so you can hand out a link to a synced category from your phone. Sharing a list that cannot be shared now tells you why instead of doing nothing.",
+  "severity": "success"
+}

--- a/docs/40k-11e-card-editing.md
+++ b/docs/40k-11e-card-editing.md
@@ -6,6 +6,7 @@ tags: [40k-11e, editor, multi-language, i18n, localization]
 related:
   - warhammer-40k-11e-format.md
   - card-data-formats.md
+  - mobile-card-editor.md
 file_locations:
   - src/Components/Warhammer40k-11e/CardEditor.jsx
   - src/Components/Warhammer40k-11e/UnitCardEditor.jsx
@@ -25,6 +26,11 @@ enhancement and rule editors). The editor is wired in `src/App.jsx` and routed b
 The data format differs from 10e (see
 [warhammer-40k-11e-format.md](warhammer-40k-11e-format.md)), so the editor adapts
 how it reads and writes every field.
+
+11e cards in a list are editable on mobile too. The mobile editor follows the
+same edit-the-active-language model but reaches it differently — it edits a
+projection of the card rather than resolving each field in each input; see
+[mobile-card-editor.md](mobile-card-editor.md).
 
 ## Table of contents
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -37,6 +37,7 @@ description: Table of contents for all Game Datacards documentation files
 
 | File | Description |
 |------|-------------|
+| [mobile-card-editor.md](mobile-card-editor.md) | Mobile card editor: how sections are resolved per base system, and how multi-language (40k-11e) cards are projected into the active card language and merged back without touching the other languages |
 | [draggable-tree-component.md](draggable-tree-component.md) | TreeViewDemo drag-and-drop component used in the Welcome Wizard workspace step |
 
 ## Infrastructure

--- a/docs/mobile-card-editor.md
+++ b/docs/mobile-card-editor.md
@@ -1,0 +1,170 @@
+---
+title: Mobile card editor
+description: How the mobile card editor resolves a card into editor sections, and how it edits multi-language (40k-11e) cards by projecting them into the active card language and folding each change back without touching the other languages.
+category: Components
+tags: [mobile, editor, 40k-11e, multi-language, i18n, localization]
+related:
+  - 40k-11e-card-editing.md
+  - warhammer-40k-11e-format.md
+  - card-data-formats.md
+file_locations:
+  - src/Components/Viewer/MobileEditor/MobileCardEditor.jsx
+  - src/Components/Viewer/MobileEditor/editorSchemaResolvers.js
+  - src/Components/Viewer/MobileEditor/localizedCard.js
+  - src/Components/Viewer/MobileEditor/sections/
+  - src/Components/Viewer/MobileEditor/weapons/
+  - src/Components/Viewer/MobileEditor/shared/nameObjects.js
+  - src/Pages/ViewerMobile.jsx
+---
+
+# Mobile card editor
+
+The mobile viewer edits cards that live in a list or a cloud category. Tapping
+**Edit** on such a card opens `MobileCardEditor`, a full-screen sheet of
+collapsible sections, and every change is written straight back to the stored
+card through `useMobileList().updateCardData`.
+
+Cards browsed from the datasource are not editable — only a card that was added
+to a list or a cloud category has somewhere to save to. `ViewerMobile` decides
+this from the router state it was navigated with (`listCard` / `cloudCard`).
+
+## Table of contents
+
+- [Section resolution](#section-resolution)
+- [Editing multi-language cards](#editing-multi-language-cards)
+  - [Why a projection](#why-a-projection)
+  - [The `__i18n` sidecar](#the-__i18n-sidecar)
+  - [Untouched fields stay untouched](#untouched-fields-stay-untouched)
+  - [What the spec covers](#what-the-spec-covers)
+- [Shape differences between editions](#shape-differences-between-editions)
+
+## Section resolution
+
+`resolveEditorSections(card, gameSystem, schema)` turns a card into an array of
+section descriptors — `{ key, label, type, config }` — and `MobileCardEditor`
+renders each one with the component registered for its `type`. Weapons are the
+exception: their section is a summary row that drills down into a weapon list and
+then a profile editor.
+
+There is one resolver per base system (`40k-10e`, `40k-11e`, `aos`, custom
+schemas, plus a generic fallback). A resolver only emits a section when the card
+actually has that data, so a stratagem gets a Details section and a unit gets
+stats, weapons and abilities.
+
+The section components are shared across all systems. Where a system's data
+differs in **shape** rather than in kind, the resolver says so in the section's
+`config` instead of the component branching on the game system — see
+[Shape differences between editions](#shape-differences-between-editions).
+
+## Editing multi-language cards
+
+11th edition (`40k-11e`) stores every displayable string as a language-keyed
+object: `{ en: "Leader", de: "Anführer", … }`. See
+[40k-11e-card-editing.md](40k-11e-card-editing.md) for the format and for how the
+desktop editor handles it.
+
+The mobile editor edits **one language at a time** — the card language picked in
+mobile Settings (`settings.language`) — exactly like the desktop editor. It gets
+there differently, though: rather than teaching every section component to read
+through `localize` and write through `setLocalizedField`, the editor works on a
+*projection* of the card, in `src/Components/Viewer/MobileEditor/localizedCard.js`:
+
+```
+projectCard(card, spec, language)   ->  every localized field resolved to a plain
+                                        string in the active language
+mergeCard(view, spec, language)     ->  that view folded back into language-keyed
+                                        shape, other languages untouched
+```
+
+`MobileCardEditor` projects the card once when it opens, hands the projection to
+the sections, and merges on every save and on close. `getLocalizationSpec`
+returns `null` for every single-language source, and then both calls are
+pass-throughs — 10e, AoS and custom datasources take exactly the path they did
+before.
+
+### Why a projection
+
+The sections all read and write plain strings. Feeding them a language-keyed
+object directly would render `[object Object]` and, worse, save a plain string
+over the whole language map — which is why 11e cards used to have no Edit button
+on mobile at all.
+
+### The `__i18n` sidecar
+
+A merge cannot simply walk the view and the original card side by side: sections
+add, remove and reorder array items, so the *n*th entry of the edited view is not
+necessarily the *n*th entry of the card. Merging by index would fold one
+keyword's text into another keyword's translations.
+
+So the projection carries each field's original language map along with it, in an
+`__i18n` key on the object that owns the field:
+
+```js
+// card                                  // projection (language: "de")
+{ name: { en: "Bolt rifle",              { name: "Boltgewehr",
+          de: "Boltgewehr" },              range: "24",
+  range: "24" }                            __i18n: { name: { en: …, de: … } } }
+```
+
+Sections copy objects wholesale when they edit them (`{ ...item, name: value }`),
+so the sidecar travels with its entry through deletions and reorders. On merge,
+each field is written back with `setLocalizedFieldSeeded(sidecar, language,
+value)`; an item that has no sidecar is one the user just added, and is seeded as
+`{ [language]: value }` so it is multilingual from its first edit.
+
+Arrays whose *entries* are themselves localized strings (unit `keywords`,
+`composition`, `wargear`) have no object to hang a sidecar on, so they project as
+`{ name }` objects instead — a shape `StringListSection` already accepts, and
+that `nameObjects.js` converts to and from plain chips for the keyword editor.
+
+The merge strips every `__i18n` key, so nothing ever reaches storage.
+
+### Untouched fields stay untouched
+
+Language coverage in the 11e data is uneven: a field that only has English
+projects as its English fallback. Writing that back would stamp a copy of the
+English text into the active language on every save, for every field the user
+never opened. So a field whose edited text still equals its projection is
+restored exactly as it came in, and only genuinely changed fields are written.
+
+Two related rules keep the saved card in the shape the datasource ships:
+
+- A field the datasource omits (a stratagem's `restrictions`, a new ability's
+  `description`) stays omitted until it actually has text.
+- A points tier's `detachment` / `faction` restriction clears back to `null`,
+  which is what the points helpers test for.
+
+### What the spec covers
+
+The spec lists which fields are language-keyed, per 11e card type. Anything not
+in it passes through both directions untouched, which is how the plain fields
+stay plain — a unit's `name` and `subname`, `factions[]`, weapon keywords and
+numeric stats, `abilities.invul.value`, and an enhancement's `keywords` /
+`excludes` (matched in English by the list builder).
+
+The spec mirrors the field table in
+[40k-11e-card-editing.md](40k-11e-card-editing.md#plain-vs-language-keyed-fields);
+the one deliberate difference is that top-level `name` is absent for **every**
+card type, because the datasource loader (`get40k11eData`) already resolves it to
+a plain string before a card is ever stored.
+
+## Shape differences between editions
+
+11e is close to 10e but not identical, and the differences are passed to the
+shared sections as config rather than branched on inside them:
+
+| Difference | Config |
+|---|---|
+| No `active` flag on stat profiles, weapons or weapon profiles | `newProfileDefaults`, `newWeaponDefaults`, `hasActiveFlag` |
+| Core / faction abilities are `{ name }` objects, not bare strings | `itemShape: "object"` on the ability category |
+| Unit keywords are objects too (they are language-keyed) | `keywordsAreObjects` |
+| No per-ability `showAbility` / `showDescription` flags | `newAbilityDefaults`, `hasShowToggle` |
+| Invulnerable save is a bare value with no info line | `valueOnly` |
+| Points are tiers with detachment / faction restrictions and a per-copy surcharge | `hasActive`, `hasRestrictions`, `hasAdditionalCost` |
+| Weapons can carry their own named abilities (Overcharge, …) | `hasWeaponAbilities` |
+
+Wargear is the one place the editor picks between two fields: a card's structured
+`wargearOptions` groups win when it has any, and the free-form `wargear`
+sentences are edited only when it has none — the same rule the card renderer and
+the desktop panel follow, so the editor always edits the wargear that reaches the
+card.

--- a/src/Components/Viewer/ListCreator/ListOverview.css
+++ b/src/Components/Viewer/ListCreator/ListOverview.css
@@ -550,6 +550,16 @@
   font-size: 14px;
 }
 
+/* Share failure message */
+.list-share-error {
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--bs-danger-bg);
+  color: var(--bs-danger, #dc3545);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
 /* Spinner */
 .list-share-spinner {
   animation: listShareSpin 1s linear infinite;

--- a/src/Components/Viewer/ListCreator/ListOverview.jsx
+++ b/src/Components/Viewer/ListCreator/ListOverview.jsx
@@ -83,6 +83,7 @@ const ListHeader = ({
   onListSelectorClick,
   onCopyToClipboard,
   onShareList,
+  canShare,
   isCloudCategory,
   isSynced,
   gameSystem,
@@ -119,7 +120,7 @@ const ListHeader = ({
                   <FileText size={16} />
                   <span>Copy List</span>
                 </button>
-                {!isCloudCategory && (
+                {canShare && (
                   <button
                     className="list-overview-more-item"
                     onClick={() => {
@@ -239,6 +240,7 @@ const ListShareSheet = ({ isVisible, onClose, category }) => {
   const { isAuthenticated } = useAuth();
 
   const [shareResult, setShareResult] = useState(null);
+  const [shareError, setShareError] = useState(null);
   const [existingShare, setExistingShare] = useState(null);
   const [isPublic, setIsPublic] = useState(true);
   const [copied, setCopied] = useState(false);
@@ -256,6 +258,7 @@ const ListShareSheet = ({ isVisible, onClose, category }) => {
   const handleClose = () => {
     onClose();
     setShareResult(null);
+    setShareError(null);
     setExistingShare(null);
     setIsPublic(true);
     setCopied(false);
@@ -263,6 +266,7 @@ const ListShareSheet = ({ isVisible, onClose, category }) => {
 
   const handleShare = async () => {
     if (!category) return;
+    setShareError(null);
     let result;
     if (isAuthenticated) {
       result = await shareOwned(category, isPublic);
@@ -271,14 +275,19 @@ const ListShareSheet = ({ isVisible, onClose, category }) => {
     }
     if (result.success) {
       setShareResult(result.shareId);
+    } else {
+      setShareError(result.error || "Could not share this list");
     }
   };
 
   const handleUpdate = async () => {
     if (!category || !existingShare?.share_id) return;
+    setShareError(null);
     const result = await updateShare(existingShare.share_id, category);
     if (result.success) {
       setShareResult(existingShare.share_id);
+    } else {
+      setShareError(result.error || "Could not update this share");
     }
   };
 
@@ -316,6 +325,9 @@ const ListShareSheet = ({ isVisible, onClose, category }) => {
             </button>
           </div>
         )}
+
+        {/* Share failure (e.g. the sharing hook's 100 card limit) */}
+        {shareError && <div className="list-share-error">{shareError}</div>}
 
         {/* Share result */}
         {shareUrl && (
@@ -502,6 +514,12 @@ export const ListOverview = ({ isVisible, setIsVisible }) => {
     ? { surcharge: 0, total: 0 }
     : computeCategoryPoints(currentCards);
 
+  // The category the share sheet operates on. A cloud category shares the very
+  // object the overview renders, so the link always contains what is on screen;
+  // it carries the same uuid as its local mirror, so an existing share is still
+  // found and can be updated. Local lists keep sharing the selected list.
+  const shareCategory = isCloudCategory ? selectedCloudCategory : currentList;
+
   const isEmpty = currentCards.length === 0;
 
   return (
@@ -562,6 +580,7 @@ export const ListOverview = ({ isVisible, setIsVisible }) => {
                 onListSelectorClick={() => setIsListSelectorVisible(true)}
                 onCopyToClipboard={handleCopyToClipboard}
                 onShareList={() => setIsShareSheetVisible(true)}
+                canShare={!!shareCategory}
                 isCloudCategory={isCloudCategory}
                 isSynced={!isCloudCategory && !!currentList?.syncEnabled}
                 gameSystem={isCloudCategory ? selectedCloudCategory.gameSystem : null}
@@ -683,11 +702,11 @@ export const ListOverview = ({ isVisible, setIsVisible }) => {
         card={editingCard}
       />
 
-      {!isCloudCategory && currentList && (
+      {shareCategory && (
         <ListShareSheet
           isVisible={isShareSheetVisible}
           onClose={() => setIsShareSheetVisible(false)}
-          category={currentList}
+          category={shareCategory}
         />
       )}
     </>

--- a/src/Components/Viewer/ListCreator/__tests__/ListOverview.test.jsx
+++ b/src/Components/Viewer/ListCreator/__tests__/ListOverview.test.jsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ListOverview } from "../ListOverview";
+
+// The list overview shares either the selected local list or, when a cloud
+// category is open, that cloud category. These tests pin down which object ends
+// up in the share sheet, because sharing the wrong one would publish a
+// completely different army list.
+
+const localList = {
+  uuid: "local-1",
+  name: "My Local List",
+  cards: [{ uuid: "card-local", name: "Local Marine", cardType: "datasheet", keywords: [], faction_id: "faction-1" }],
+};
+
+const cloudCategory = {
+  uuid: "cloud-1",
+  name: "My Cloud Category",
+  type: "category",
+  gameSystem: "40k",
+  cloudId: 42,
+  cardCount: 2,
+  cards: [
+    { uuid: "card-cloud-1", name: "Cloud Marine", cardType: "datasheet", keywords: [] },
+    { uuid: "card-cloud-2", name: "Cloud Terminator", cardType: "datasheet", keywords: [] },
+  ],
+};
+
+let mobileListState;
+let cloudCategories;
+let isAuthenticated;
+let shareAnonymousResult;
+
+const shareAnonymous = vi.fn(() => Promise.resolve(shareAnonymousResult));
+const shareOwned = vi.fn(() => Promise.resolve({ success: true, shareId: "owned-share" }));
+const updateShare = vi.fn(() => Promise.resolve({ success: true }));
+const getExistingShare = vi.fn(() => Promise.resolve(null));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: "/mobile", state: {} }),
+}));
+
+vi.mock("../../useMobileList", () => ({
+  useMobileList: () => mobileListState,
+}));
+
+vi.mock("../../../../Hooks/useDataSourceStorage", () => ({
+  useDataSourceStorage: () => ({
+    dataSource: { data: [{ id: "faction-1", name: "Space Marines", detachments: [] }] },
+    selectedFaction: { id: "faction-1", name: "Space Marines" },
+  }),
+}));
+
+vi.mock("../../../../Hooks/useSettingsStorage", () => ({
+  useSettingsStorage: () => ({ settings: { selectedDataSource: "40k-10e" }, updateSettings: vi.fn() }),
+}));
+
+vi.mock("../../../../Premium", () => ({
+  useCloudCategories: () => ({ categories: cloudCategories }),
+  useAuth: () => ({ isAuthenticated }),
+  ListSyncButton: () => null,
+}));
+
+vi.mock("../../../../Hooks/useCategorySharing", () => ({
+  useCategorySharing: () => ({
+    shareAnonymous,
+    shareOwned,
+    updateShare,
+    getExistingShare,
+    isSharing: false,
+  }),
+}));
+
+// Sibling sheets are not under test and pull in their own storage hooks.
+vi.mock("../ListSelector", () => ({ ListSelector: () => null }));
+vi.mock("../ListEditCard", () => ({ ListEditCard: () => null }));
+vi.mock("../../Mobile/ArmyRosterSheet", () => ({ ArmyRosterSheet: () => null }));
+vi.mock("../../MobileImporter", () => ({
+  MobileGwImporter: () => null,
+  MobileListForgeImporter: () => null,
+}));
+
+const openMoreMenu = (container) => {
+  fireEvent.click(container.querySelector(".list-overview-more-button"));
+};
+
+describe("ListOverview sharing", () => {
+  let modalRoot;
+
+  beforeEach(() => {
+    modalRoot = document.createElement("div");
+    modalRoot.setAttribute("id", "modal-root");
+    document.body.appendChild(modalRoot);
+
+    mobileListState = {
+      lists: [localList],
+      selectedList: 0,
+      removeDatacard: vi.fn(),
+      selectedCloudCategoryId: null,
+      setListDetachments: vi.fn(),
+      setListBattleSize: vi.fn(),
+    };
+    cloudCategories = [cloudCategory];
+    isAuthenticated = false;
+    shareAnonymousResult = { success: true, shareId: "anon-share" };
+
+    shareAnonymous.mockClear();
+    shareOwned.mockClear();
+    updateShare.mockClear();
+    getExistingShare.mockClear();
+  });
+
+  afterEach(() => {
+    document.body.removeChild(modalRoot);
+    document.body.style.overflow = "";
+  });
+
+  const renderOverview = () => render(<ListOverview isVisible={true} setIsVisible={vi.fn()} />);
+
+  it("offers Share List for a local list", () => {
+    renderOverview();
+    openMoreMenu(document.body);
+    expect(screen.getByText("Share List")).toBeTruthy();
+    expect(screen.getByText("Copy List")).toBeTruthy();
+  });
+
+  it("offers Share List for a cloud category", () => {
+    mobileListState.selectedCloudCategoryId = "cloud-1";
+    renderOverview();
+    openMoreMenu(document.body);
+    expect(screen.getByText("Share List")).toBeTruthy();
+  });
+
+  it("shares the cloud category, not the selected local list", async () => {
+    mobileListState.selectedCloudCategoryId = "cloud-1";
+    renderOverview();
+    openMoreMenu(document.body);
+    fireEvent.click(screen.getByText("Share List"));
+
+    // The sheet describes the cloud category (2 cards), not the local list (1 card)
+    expect(document.querySelector(".list-share-name").textContent).toBe("My Cloud Category");
+    expect(document.querySelector(".list-share-meta").textContent).toBe("2 cards");
+
+    fireEvent.click(screen.getByText("Generate Link"));
+    await waitFor(() => expect(shareAnonymous).toHaveBeenCalledTimes(1));
+    expect(shareAnonymous.mock.calls[0][0]).toBe(cloudCategory);
+    expect(shareAnonymous.mock.calls[0][0].uuid).toBe("cloud-1");
+  });
+
+  it("looks up an existing share by the cloud category uuid when authenticated", async () => {
+    isAuthenticated = true;
+    mobileListState.selectedCloudCategoryId = "cloud-1";
+    renderOverview();
+    openMoreMenu(document.body);
+    fireEvent.click(screen.getByText("Share List"));
+
+    await waitFor(() => expect(getExistingShare).toHaveBeenCalledWith("cloud-1"));
+
+    fireEvent.click(await screen.findByText("Share"));
+    await waitFor(() => expect(shareOwned).toHaveBeenCalledTimes(1));
+    expect(shareOwned.mock.calls[0][0]).toBe(cloudCategory);
+  });
+
+  it("still shares the selected local list when no cloud category is open", async () => {
+    renderOverview();
+    openMoreMenu(document.body);
+    fireEvent.click(screen.getByText("Share List"));
+
+    expect(document.querySelector(".list-share-name").textContent).toBe("My Local List");
+    expect(document.querySelector(".list-share-meta").textContent).toBe("1 card");
+
+    fireEvent.click(screen.getByText("Generate Link"));
+    await waitFor(() => expect(shareAnonymous).toHaveBeenCalledTimes(1));
+    expect(shareAnonymous.mock.calls[0][0]).toBe(localList);
+  });
+
+  it("hides Share List when there is no list or cloud category to share", () => {
+    mobileListState.lists = [];
+    renderOverview();
+    openMoreMenu(document.body);
+    expect(screen.queryByText("Share List")).toBeNull();
+    expect(screen.getByText("Copy List")).toBeTruthy();
+  });
+
+  it("surfaces a share failure such as the card limit", async () => {
+    shareAnonymousResult = { success: false, error: "Maximum 100 cards per share" };
+    mobileListState.selectedCloudCategoryId = "cloud-1";
+    renderOverview();
+    openMoreMenu(document.body);
+    fireEvent.click(screen.getByText("Share List"));
+    fireEvent.click(screen.getByText("Generate Link"));
+
+    expect(await screen.findByText("Maximum 100 cards per share")).toBeTruthy();
+  });
+});

--- a/src/Components/Viewer/MobileEditor/MobileCardEditor.jsx
+++ b/src/Components/Viewer/MobileEditor/MobileCardEditor.jsx
@@ -18,8 +18,10 @@ import {
   ScrollText,
 } from "lucide-react";
 import { useMobileList } from "../useMobileList";
+import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
 import { useCardEditorState } from "./useCardEditorState";
 import { resolveEditorSections } from "./editorSchemaResolvers";
+import { getLocalizationSpec, mergeCard, projectCard } from "./localizedCard";
 import { NameSection } from "./sections/NameSection";
 import { StatsSection } from "./sections/StatsSection";
 import { WeaponsSection } from "./sections/WeaponsSection";
@@ -36,6 +38,7 @@ import { DamagedSection } from "./sections/DamagedSection";
 import { StringListSection } from "./sections/StringListSection";
 import { TextFieldSection } from "./sections/TextFieldSection";
 import { LeaderInfoSection } from "./sections/LeaderInfoSection";
+import { WargearOptionsSection } from "./sections/WargearOptionsSection";
 import { DrillDownView } from "./shared/DrillDownView";
 import { WeaponListView } from "./weapons/WeaponListView";
 import { WeaponProfileEditor } from "./weapons/WeaponProfileEditor";
@@ -59,6 +62,7 @@ const SECTION_COMPONENTS = {
   stringList: StringListSection,
   textField: TextFieldSection,
   leaderInfo: LeaderInfoSection,
+  wargearOptions: WargearOptionsSection,
 };
 
 const SECTION_ICONS = {
@@ -77,20 +81,38 @@ const SECTION_ICONS = {
   stringList: Wrench,
   textField: ScrollText,
   leaderInfo: Users,
+  wargearOptions: Wrench,
 };
 
 export const MobileCardEditor = ({ isOpen, onClose, card, cardUuid, gameSystem, schema, factionColours }) => {
   const [drillDown, setDrillDown] = useState(null);
   const { updateCardData } = useMobileList();
+  const { settings } = useSettingsStorage();
+
+  // Multi-language datasources (40k-11e) store every displayable string as a
+  // language-keyed object. The sections below all read and write plain strings,
+  // so the editor works on a projection of the card in the active card language
+  // and folds each change back in, leaving the other languages untouched.
+  const language = settings?.language || "en";
+  const localizationSpec = useMemo(() => getLocalizationSpec(card, gameSystem), [card, gameSystem]);
+  const editableCard = useMemo(
+    () => (localizationSpec ? projectCard(card, localizationSpec, language) : card),
+    [card, localizationSpec, language],
+  );
+
+  const toStoredCard = useCallback(
+    (edited) => (localizationSpec ? mergeCard(edited, localizationSpec, language) : edited),
+    [localizationSpec, language],
+  );
 
   const handleSave = useCallback(
     (updatedCard) => {
-      updateCardData?.(cardUuid, updatedCard);
+      updateCardData?.(cardUuid, toStoredCard(updatedCard));
     },
-    [updateCardData, cardUuid],
+    [updateCardData, cardUuid, toStoredCard],
   );
 
-  const { localCard, updateField, updateFields, replaceCard } = useCardEditorState(card, handleSave);
+  const { localCard, updateField, updateFields, replaceCard } = useCardEditorState(editableCard, handleSave);
 
   const sections = useMemo(() => resolveEditorSections(localCard, gameSystem, schema), [localCard, gameSystem, schema]);
 
@@ -110,7 +132,7 @@ export const MobileCardEditor = ({ isOpen, onClose, card, cardUuid, gameSystem, 
 
   const handleClose = () => {
     setDrillDown(null);
-    onClose(localCard);
+    onClose(toStoredCard(localCard));
   };
 
   const bannerColour = factionColours?.banner || "#1a1d2e";

--- a/src/Components/Viewer/MobileEditor/__tests__/MobileCardEditor11e.test.jsx
+++ b/src/Components/Viewer/MobileEditor/__tests__/MobileCardEditor11e.test.jsx
@@ -1,0 +1,186 @@
+import React from "react";
+import { render, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const updateCardData = vi.fn();
+const settings = { language: "de", selectedDataSource: "40k-11e" };
+
+vi.mock("../../useMobileList", () => ({
+  useMobileList: () => ({ updateCardData }),
+}));
+
+vi.mock("../../../../Hooks/useSettingsStorage", () => ({
+  useSettingsStorage: () => ({ settings }),
+}));
+
+import { MobileCardEditor } from "../MobileCardEditor";
+
+// A card as the 11e datasource ships it: the top-level name resolved to a plain
+// string by the loader, every body field language-keyed.
+const card11e = () => ({
+  uuid: "card-1",
+  source: "40k-11e",
+  cardType: "DataCard",
+  name: "Intercessor Squad",
+  stats: [{ name: { en: "Intercessor", de: "Intercessor DE" }, m: '6"', t: "4", sv: "3+", w: "2", ld: "6+", oc: "2" }],
+  abilities: {
+    core: [{ name: { en: 'Scouts 6"', de: 'Späher 6"' } }],
+    faction: [],
+    other: [{ name: { en: "Combat Squads", de: "Kampftrupps" }, description: { en: "Split", de: "Teilen" } }],
+    wargear: [],
+    special: [],
+    invul: { value: "4+" },
+  },
+  rangedWeapons: [
+    {
+      profiles: [{ name: { en: "Bolt rifle", de: "Boltgewehr" }, range: "24", attacks: "2", keywords: ["Assault"] }],
+      abilities: [{ name: { en: "Overcharge", de: "Überladen" }, description: { en: "Boom", de: "Bumm" } }],
+    },
+  ],
+  keywords: [{ en: "Infantry", de: "Infanterie" }],
+  factions: ["Adeptus Astartes"],
+  loadout: { en: "Equipped with a bolt rifle", de: "Mit einem Boltgewehr" },
+});
+
+const renderEditor = (card, onClose = vi.fn()) => {
+  const modalRoot = document.createElement("div");
+  modalRoot.setAttribute("id", "modal-root");
+  document.body.appendChild(modalRoot);
+  const utils = render(
+    <MobileCardEditor
+      isOpen
+      onClose={onClose}
+      card={card}
+      cardUuid={card.uuid}
+      gameSystem="40k-11e"
+      schema={null}
+      factionColours={{ banner: "#000", header: "#111" }}
+    />,
+  );
+  return { ...utils, onClose };
+};
+
+const lastSavedCard = () => updateCardData.mock.calls.at(-1)[1];
+
+describe("MobileCardEditor with a 40k-11e card", () => {
+  beforeEach(() => {
+    updateCardData.mockClear();
+    document.body.innerHTML = "";
+  });
+
+  it("shows the localized text for the active card language", () => {
+    const { getByDisplayValue } = renderEditor(card11e());
+
+    expect(getByDisplayValue("Intercessor Squad")).toBeTruthy();
+    expect(getByDisplayValue("Mit einem Boltgewehr")).toBeTruthy();
+  });
+
+  it("writes an edit into the active language and keeps the others", () => {
+    const { getByDisplayValue } = renderEditor(card11e());
+
+    const loadout = getByDisplayValue("Mit einem Boltgewehr");
+    act(() => {
+      fireEvent.change(loadout, { target: { value: "Mit einem Plasmagewehr" } });
+      fireEvent.blur(loadout);
+    });
+
+    const saved = lastSavedCard();
+    expect(saved.loadout).toEqual({ en: "Equipped with a bolt rifle", de: "Mit einem Plasmagewehr" });
+  });
+
+  it("keeps a unit's name a plain string", () => {
+    const { getByDisplayValue } = renderEditor(card11e());
+
+    const name = getByDisplayValue("Intercessor Squad");
+    act(() => {
+      fireEvent.change(name, { target: { value: "Assault Squad" } });
+      fireEvent.blur(name);
+    });
+
+    expect(lastSavedCard().name).toBe("Assault Squad");
+  });
+
+  it("never saves the language sidecar onto the card", () => {
+    const { getByDisplayValue } = renderEditor(card11e());
+
+    const loadout = getByDisplayValue("Mit einem Boltgewehr");
+    act(() => {
+      fireEvent.change(loadout, { target: { value: "Geändert" } });
+      fireEvent.blur(loadout);
+    });
+
+    expect(JSON.stringify(lastSavedCard())).not.toContain("__i18n");
+  });
+
+  it("hands the merged card back on close", () => {
+    const onClose = vi.fn();
+    const { getByDisplayValue, container } = renderEditor(card11e(), onClose);
+
+    const loadout = getByDisplayValue("Mit einem Boltgewehr");
+    act(() => {
+      fireEvent.change(loadout, { target: { value: "Geändert" } });
+      fireEvent.blur(loadout);
+    });
+    fireEvent.click(document.querySelector(".mobile-editor-back"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    const closed = onClose.mock.calls[0][0];
+    expect(closed.loadout).toEqual({ en: "Equipped with a bolt rifle", de: "Geändert" });
+    expect(container).toBeTruthy();
+  });
+
+  it("edits a weapon profile through the drill-down", () => {
+    const { getByText, getByDisplayValue } = renderEditor(card11e());
+
+    fireEvent.click(getByText("Ranged Weapons"));
+    fireEvent.click(getByText("Boltgewehr"));
+
+    const profileName = getByDisplayValue("Boltgewehr");
+    act(() => {
+      fireEvent.change(profileName, { target: { value: "Schweres Boltgewehr" } });
+      fireEvent.blur(profileName);
+    });
+
+    const saved = lastSavedCard();
+    expect(saved.rangedWeapons[0].profiles[0].name).toEqual({ en: "Bolt rifle", de: "Schweres Boltgewehr" });
+    expect(saved.rangedWeapons[0].profiles[0].keywords).toEqual(["Assault"]);
+  });
+
+  it("edits a weapon ability, which 11e weapons carry and 10e ones do not", () => {
+    const { getByText, getByDisplayValue } = renderEditor(card11e());
+
+    fireEvent.click(getByText("Ranged Weapons"));
+    fireEvent.click(getByText("Boltgewehr"));
+
+    expect(getByText("Weapon Abilities")).toBeTruthy();
+    const description = getByDisplayValue("Bumm");
+    act(() => {
+      fireEvent.change(description, { target: { value: "Grosser Knall" } });
+      fireEvent.blur(description);
+    });
+
+    expect(lastSavedCard().rangedWeapons[0].abilities[0].description).toEqual({
+      en: "Boom",
+      de: "Grosser Knall",
+    });
+  });
+
+  it("does not offer the per-profile Active toggle that 11e has no field for", () => {
+    const { getByText, queryByText } = renderEditor(card11e());
+
+    fireEvent.click(getByText("Ranged Weapons"));
+    fireEvent.click(getByText("Boltgewehr"));
+
+    expect(queryByText("Active")).toBeNull();
+  });
+
+  it("leaves untouched fields exactly as the datasource shipped them", () => {
+    const original = card11e();
+    const onClose = vi.fn();
+    renderEditor(original, onClose);
+
+    fireEvent.click(document.querySelector(".mobile-editor-back"));
+
+    expect(onClose.mock.calls[0][0]).toEqual(original);
+  });
+});

--- a/src/Components/Viewer/MobileEditor/__tests__/editorSchemaResolvers.test.js
+++ b/src/Components/Viewer/MobileEditor/__tests__/editorSchemaResolvers.test.js
@@ -557,6 +557,15 @@ describe("editorSchemaResolvers 40k-11e", () => {
     expect(ruleTypes).toContain("rulesList");
   });
 
+  it("resolves a rule card the viewer stamped as a rule", () => {
+    // ViewerUnitList stamps cardType "rule"; the resolver must not fall through
+    // to the unit sections for it.
+    const rule = { source: "40k-11e", cardType: "rule", ruleType: "army", rules: [{ order: 0, type: "text" }] };
+    const keys = resolveEditorSections(rule, "40k-11e", null).map((s) => s.key);
+
+    expect(keys).toEqual(["name", "fields", "rules"]);
+  });
+
   it("keeps enhancement eligibility keywords on the plain-string path", () => {
     const enhancement = { source: "40k-11e", cardType: "enhancement", description: "D", cost: "10" };
     const eligibility = resolveEditorSections(enhancement, "40k-11e", null).find((s) => s.key === "eligibility");

--- a/src/Components/Viewer/MobileEditor/__tests__/editorSchemaResolvers.test.js
+++ b/src/Components/Viewer/MobileEditor/__tests__/editorSchemaResolvers.test.js
@@ -437,3 +437,131 @@ describe("editorSchemaResolvers", () => {
     });
   });
 });
+
+// 11th edition cards reach the resolver as a language projection (see
+// localizedCard.js), so every localized field is already a plain string here.
+describe("editorSchemaResolvers 40k-11e", () => {
+  const unitCard = {
+    name: "Intercessor Squad",
+    source: "40k-11e",
+    cardType: "DataCard",
+    stats: [{ name: "Intercessor", m: '6"', t: "4", sv: "3+", w: "2", ld: "6+", oc: "2" }],
+    rangedWeapons: [{ profiles: [{ name: "Bolt rifle", range: "24", attacks: "2" }] }],
+    meleeWeapons: [{ profiles: [{ name: "Close combat weapon", range: "Melee" }] }],
+    abilities: {
+      core: [{ name: 'Scouts 6"' }],
+      faction: [{ name: "Oath of Moment" }],
+      other: [{ name: "Combat Squads", description: "Split" }],
+      primarch: [{ name: "Rites of Battle", abilities: [{ name: "Tactical Precision", description: "Re-roll" }] }],
+      damaged: { range: "1-3 wounds", description: "Hurts" },
+      invul: { value: "4+" },
+    },
+    keywords: [{ name: "Infantry" }],
+    factions: ["Adeptus Astartes"],
+    composition: [{ name: "5 Intercessors" }],
+    loadout: "Equipped with a bolt rifle",
+    leader: "Can lead Assault Squads",
+    transport: "Capacity 6",
+    points: [{ models: "5", cost: "80", keyword: "" }],
+  };
+
+  const sectionFor = (card, key) => resolveEditorSections(card, "40k-11e", null).find((s) => s.key === key);
+
+  it("resolves the full set of unit sections", () => {
+    const keys = resolveEditorSections(unitCard, "40k-11e", null).map((s) => s.key);
+
+    expect(keys).toEqual([
+      "name",
+      "stats",
+      "points",
+      "weapons",
+      "abilities",
+      "primarch",
+      "damaged",
+      "invul",
+      "composition",
+      "loadout",
+      "leader",
+      "transport",
+      "keywords",
+    ]);
+  });
+
+  it("tells the sections about the shapes 11e does not share with 10e", () => {
+    expect(sectionFor(unitCard, "stats").config.newProfileDefaults).not.toHaveProperty("active");
+    expect(sectionFor(unitCard, "invul").config.valueOnly).toBe(true);
+    expect(sectionFor(unitCard, "damaged").config.hasShowToggle).toBe(false);
+    expect(sectionFor(unitCard, "primarch").config.hasShowToggle).toBe(false);
+    expect(sectionFor(unitCard, "keywords").config.keywordsAreObjects).toBe(true);
+    expect(sectionFor(unitCard, "keywords").config.factionKeywordsAreObjects).toBeUndefined();
+
+    const weaponType = sectionFor(unitCard, "weapons").config.types[0];
+    expect(weaponType.hasActiveFlag).toBe(false);
+    expect(weaponType.hasWeaponAbilities).toBe(true);
+    expect(weaponType.newProfileDefaults).toEqual({});
+  });
+
+  it("resolves points as restricted tiers rather than a scalar", () => {
+    const config = sectionFor(unitCard, "points").config;
+    expect(config.hasActive).toBe(false);
+    expect(config.hasRestrictions).toBe(true);
+    expect(config.hasAdditionalCost).toBe(true);
+  });
+
+  it("marks core and faction abilities as name objects", () => {
+    const categories = sectionFor(unitCard, "abilities").config.categories;
+    const byKey = Object.fromEntries(categories.map((c) => [c.key, c]));
+
+    expect(byKey.core.itemShape).toBe("object");
+    expect(byKey.faction.itemShape).toBe("object");
+    expect(byKey.other.itemShape).toBeUndefined();
+    expect(sectionFor(unitCard, "abilities").config.newAbilityDefaults).toEqual({});
+  });
+
+  it("edits the structured wargear groups when a card has them", () => {
+    const withGroups = { ...unitCard, wargearOptions: [{ instruction: "Replace", options: [] }], wargear: ["Text"] };
+    const keys = resolveEditorSections(withGroups, "40k-11e", null).map((s) => s.key);
+
+    expect(keys).toContain("wargearOptions");
+    expect(keys).not.toContain("wargear");
+  });
+
+  it("falls back to the free-form wargear sentences when there are no groups", () => {
+    const withText = { ...unitCard, wargear: ["Any model may take a plasma pistol"] };
+    const section = sectionFor(withText, "wargear");
+
+    expect(section.type).toBe("stringList");
+    expect(section.config.dataPath).toBe("wargear");
+  });
+
+  it("resolves stratagem, enhancement and rule cards", () => {
+    const stratagem = { source: "40k-11e", cardType: "stratagem", when: "W", effect: "E" };
+    const stratagemFields = resolveEditorSections(stratagem, "40k-11e", null).find((s) => s.type === "fields");
+    expect(stratagemFields.config.fields.map((f) => f.key)).toEqual([
+      "type",
+      "detachment",
+      "cost",
+      "turn",
+      "when",
+      "target",
+      "effect",
+      "restrictions",
+    ]);
+
+    const enhancement = { source: "40k-11e", cardType: "enhancement", description: "D", cost: "10" };
+    const enhancementKeys = resolveEditorSections(enhancement, "40k-11e", null).map((s) => s.key);
+    expect(enhancementKeys).toEqual(["name", "fields", "eligibility"]);
+
+    const rule = { source: "40k-11e", rules: [{ order: 0, type: "text", text: "Body" }] };
+    const ruleTypes = resolveEditorSections(rule, "40k-11e", null).map((s) => s.type);
+    expect(ruleTypes).toContain("rulesList");
+  });
+
+  it("keeps enhancement eligibility keywords on the plain-string path", () => {
+    const enhancement = { source: "40k-11e", cardType: "enhancement", description: "D", cost: "10" };
+    const eligibility = resolveEditorSections(enhancement, "40k-11e", null).find((s) => s.key === "eligibility");
+
+    expect(eligibility.config.keywordsAreObjects).toBeUndefined();
+    expect(eligibility.config.factionKeywordsPath).toBe("excludes");
+  });
+});

--- a/src/Components/Viewer/MobileEditor/__tests__/localizedCard.test.js
+++ b/src/Components/Viewer/MobileEditor/__tests__/localizedCard.test.js
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "vitest";
+import { getLocalizationSpec, I18N_KEY, mergeCard, projectCard } from "../localizedCard";
+
+// A trimmed 11e unit carrying one of every localized shape the spec covers.
+const unit11e = () => ({
+  uuid: "unit-1",
+  source: "40k-11e",
+  cardType: "DataCard",
+  name: "Intercessor Squad",
+  subname: "Battleline",
+  stats: [{ name: { en: "Intercessor", de: "Intercessor DE" }, m: '6"', t: "4", sv: "3+", w: "2", ld: "6+", oc: "2" }],
+  rangedWeapons: [
+    {
+      profiles: [{ name: { en: "Bolt rifle", de: "Boltgewehr" }, range: "24", attacks: "2", keywords: ["Assault"] }],
+      abilities: [{ name: { en: "Overcharge", de: "Überladen" }, description: { en: "Boom", de: "Bumm" } }],
+    },
+  ],
+  meleeWeapons: [{ profiles: [{ name: { en: "Close combat weapon", de: "Nahkampfwaffe" }, range: "Melee" }] }],
+  abilities: {
+    core: [{ name: { en: 'Scouts 6"', de: 'Späher 6"' } }],
+    faction: [{ name: { en: "Oath of Moment", de: "Eid des Augenblicks" } }],
+    other: [{ name: { en: "Combat Squads", de: "Kampftrupps" }, description: { en: "Split", de: "Teilen" } }],
+    primarch: [
+      {
+        name: { en: "Rites of Battle", de: "Riten der Schlacht" },
+        abilities: [{ name: { en: "Tactical Precision", de: "Präzision" }, description: { en: "Re-roll", de: "Neu" } }],
+      },
+    ],
+    damaged: { range: { en: "1-3 wounds", de: "1-3 LP" }, description: { en: "Hurts", de: "Schmerzt" } },
+    invul: { value: "4+" },
+  },
+  keywords: [
+    { en: "Infantry", de: "Infanterie" },
+    { en: "Imperium", de: "Imperium" },
+  ],
+  factions: ["Adeptus Astartes"],
+  composition: [{ en: "5 Intercessors", de: "5 Intercessors DE" }],
+  wargearOptions: [
+    {
+      instruction: { en: "Replace the bolt rifle", de: "Ersetze das Boltgewehr" },
+      options: [{ name: { en: "Plasma incinerator", de: "Plasmabrenner" }, cost: "5" }],
+    },
+  ],
+  loadout: { en: "Equipped with a bolt rifle", de: "Ausgerüstet mit Boltgewehr" },
+  transport: { en: "Capacity 6", de: "Kapazität 6" },
+  leader: { en: "Can lead Assault Squads", de: "Kann Sturmtrupps führen" },
+  points: [
+    { models: "5", cost: "80", keyword: { en: "", de: "" }, detachment: null, faction: null },
+    { models: "10", cost: "160", keyword: { en: "" }, detachment: { en: "Gladius Task Force" }, faction: null },
+  ],
+});
+
+const project = (card, language = "de") => projectCard(card, getLocalizationSpec(card, "40k-11e"), language);
+const merge = (card, view, language = "de") => mergeCard(view, getLocalizationSpec(card, "40k-11e"), language);
+
+describe("getLocalizationSpec", () => {
+  it("returns no spec for single-language sources", () => {
+    expect(getLocalizationSpec({ source: "40k-10e", stats: [] }, "40k-10e")).toBeNull();
+    expect(getLocalizationSpec({ source: "aos" }, "aos")).toBeNull();
+    expect(getLocalizationSpec({ source: "my-custom-ds" }, "my-custom-ds")).toBeNull();
+  });
+
+  it("returns a spec for 11e cards, falling back to the game system", () => {
+    expect(getLocalizationSpec({ cardType: "DataCard" }, "40k-11e")).not.toBeNull();
+    expect(getLocalizationSpec({ source: "40k-11e", cardType: "stratagem" }, "aos")).not.toBeNull();
+  });
+
+  it("picks the spec by card type", () => {
+    const stratagem = { source: "40k-11e", cardType: "stratagem", when: { en: "W" }, effect: { en: "E" } };
+    const view = projectCard(stratagem, getLocalizationSpec(stratagem, "40k-11e"), "en");
+    expect(view.when).toBe("W");
+  });
+
+  it("falls back to the card shape when cardType is missing", () => {
+    const rule = { source: "40k-11e", rules: [{ order: 0, type: "text", text: { en: "Body", de: "Körper" } }] };
+    const view = projectCard(rule, getLocalizationSpec(rule, "40k-11e"), "de");
+    expect(view.rules[0].text).toBe("Körper");
+  });
+});
+
+describe("projectCard", () => {
+  const view = project(unit11e());
+
+  it("resolves localized fields to the active language", () => {
+    expect(view.stats[0].name).toBe("Intercessor DE");
+    expect(view.rangedWeapons[0].profiles[0].name).toBe("Boltgewehr");
+    expect(view.rangedWeapons[0].abilities[0].description).toBe("Bumm");
+    expect(view.abilities.other[0].name).toBe("Kampftrupps");
+    expect(view.abilities.primarch[0].abilities[0].description).toBe("Neu");
+    expect(view.abilities.damaged.range).toBe("1-3 LP");
+    expect(view.loadout).toBe("Ausgerüstet mit Boltgewehr");
+    expect(view.wargearOptions[0].options[0].name).toBe("Plasmabrenner");
+  });
+
+  it("leaves plain fields untouched", () => {
+    expect(view.name).toBe("Intercessor Squad");
+    expect(view.subname).toBe("Battleline");
+    expect(view.stats[0].sv).toBe("3+");
+    expect(view.abilities.invul.value).toBe("4+");
+    expect(view.factions).toEqual(["Adeptus Astartes"]);
+    expect(view.rangedWeapons[0].profiles[0].keywords).toEqual(["Assault"]);
+    expect(view.wargearOptions[0].options[0].cost).toBe("5");
+  });
+
+  it("projects arrays of localized strings as name objects", () => {
+    expect(view.keywords.map((k) => k.name)).toEqual(["Infanterie", "Imperium"]);
+    expect(view.composition[0].name).toBe("5 Intercessors DE");
+  });
+
+  it("falls back to English when the active language is missing", () => {
+    const card = unit11e();
+    card.loadout = { en: "Only English" };
+    expect(project(card).loadout).toBe("Only English");
+  });
+});
+
+describe("mergeCard", () => {
+  it("round-trips an untouched card back to its original shape", () => {
+    const card = unit11e();
+    expect(merge(card, project(card))).toEqual(card);
+  });
+
+  it("writes only the active language and keeps the others", () => {
+    const card = unit11e();
+    const view = project(card);
+    view.loadout = "Neuer Text";
+    view.stats[0].name = "Neuer Name";
+
+    const merged = merge(card, view);
+    expect(merged.loadout).toEqual({ en: "Equipped with a bolt rifle", de: "Neuer Text" });
+    expect(merged.stats[0].name).toEqual({ en: "Intercessor", de: "Neuer Name" });
+  });
+
+  it("strips the language sidecar from every level", () => {
+    const card = unit11e();
+    const merged = merge(card, project(card));
+    const json = JSON.stringify(merged);
+    expect(json).not.toContain(I18N_KEY);
+  });
+
+  it("keeps each entry's translations when an array item is removed", () => {
+    const card = unit11e();
+    const view = project(card);
+    // Drop the first keyword, exactly as the chip editor does.
+    view.keywords = view.keywords.slice(1);
+
+    const merged = merge(card, view);
+    expect(merged.keywords).toEqual([{ en: "Imperium", de: "Imperium" }]);
+  });
+
+  it("keeps each profile's translations when a weapon is removed", () => {
+    const card = unit11e();
+    card.rangedWeapons.push({ profiles: [{ name: { en: "Grenade", de: "Granate" }, range: "8" }] });
+    const view = project(card);
+    view.rangedWeapons = view.rangedWeapons.slice(1);
+
+    const merged = merge(card, view);
+    expect(merged.rangedWeapons).toHaveLength(1);
+    expect(merged.rangedWeapons[0].profiles[0].name).toEqual({ en: "Grenade", de: "Granate" });
+  });
+
+  it("seeds a newly added entry as a language-keyed object", () => {
+    const card = unit11e();
+    const view = project(card);
+    view.keywords = [...view.keywords, { name: "Neues Schlüsselwort" }];
+    view.composition = [...view.composition, ""];
+    view.stats = [...view.stats, { name: "Zweites Profil", m: '8"' }];
+
+    const merged = merge(card, view);
+    expect(merged.keywords[2]).toEqual({ de: "Neues Schlüsselwort" });
+    expect(merged.composition[1]).toEqual({ de: "" });
+    expect(merged.stats[1].name).toEqual({ de: "Zweites Profil" });
+  });
+
+  it("keeps a plain-string field plain", () => {
+    const card = unit11e();
+    card.loadout = "Already resolved";
+    const view = project(card);
+    view.loadout = "Edited";
+    expect(merge(card, view).loadout).toBe("Edited");
+  });
+
+  it("omits a field the datasource never had until it has text", () => {
+    const stratagem = {
+      source: "40k-11e",
+      cardType: "stratagem",
+      name: "Insane Bravery",
+      when: { en: "Battle-shock step", de: "Schlachtschock" },
+      effect: { en: "Auto-pass", de: "Automatisch" },
+    };
+    const spec = getLocalizationSpec(stratagem, "40k-11e");
+    const view = projectCard(stratagem, spec, "de");
+
+    view.restrictions = "";
+    expect(mergeCard(view, spec, "de")).not.toHaveProperty("restrictions");
+
+    view.restrictions = "Einmal pro Schlacht";
+    expect(mergeCard(view, spec, "de").restrictions).toEqual({ de: "Einmal pro Schlacht" });
+  });
+
+  it("keeps other languages when a field that has text is cleared", () => {
+    const card = unit11e();
+    const view = project(card);
+    view.loadout = "";
+    expect(merge(card, view).loadout).toEqual({ en: "Equipped with a bolt rifle", de: "" });
+  });
+
+  it("clears a points tier restriction back to null", () => {
+    const card = unit11e();
+    const view = project(card);
+    expect(view.points[1].detachment).toBe("Gladius Task Force");
+
+    view.points[1].detachment = "";
+    const merged = merge(card, view);
+    expect(merged.points[1].detachment).toBeNull();
+    expect(merged.points[0].detachment).toBeNull();
+  });
+
+  it("merges a points tier restriction into the active language", () => {
+    const card = unit11e();
+    const view = project(card);
+    view.points[1].detachment = "Gladius DE";
+    expect(merge(card, view).points[1].detachment).toEqual({ en: "Gladius Task Force", de: "Gladius DE" });
+  });
+
+  it("leaves the enhancement eligibility keywords as plain strings", () => {
+    const enhancement = {
+      source: "40k-11e",
+      cardType: "enhancement",
+      name: "Artificer Armour",
+      cost: "10",
+      description: { en: "Improve save", de: "Rettung" },
+      keywords: ["Infantry"],
+      excludes: ["Named Character"],
+    };
+    const spec = getLocalizationSpec(enhancement, "40k-11e");
+    const view = projectCard(enhancement, spec, "de");
+
+    expect(view.keywords).toEqual(["Infantry"]);
+    view.keywords = ["Infantry", "Biker"];
+    expect(mergeCard(view, spec, "de").keywords).toEqual(["Infantry", "Biker"]);
+  });
+});

--- a/src/Components/Viewer/MobileEditor/__tests__/localizedCard.test.js
+++ b/src/Components/Viewer/MobileEditor/__tests__/localizedCard.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getLocalizationSpec, I18N_KEY, mergeCard, projectCard } from "../localizedCard";
+import { classify11eCard, getLocalizationSpec, I18N_KEY, mergeCard, projectCard } from "../localizedCard";
 
 // A trimmed 11e unit carrying one of every localized shape the spec covers.
 const unit11e = () => ({
@@ -71,10 +71,52 @@ describe("getLocalizationSpec", () => {
     expect(view.when).toBe("W");
   });
 
+  it("uses the rule spec for a card the viewer stamped as a rule", () => {
+    // ViewerUnitList turns army and detachment rules into cards with
+    // cardType "rule"; the loader never stamps that one.
+    const rule = {
+      source: "40k-11e",
+      cardType: "rule",
+      ruleType: "detachment",
+      name: "Gladius Task Force",
+      detachment: { en: "Gladius Task Force", de: "Gladius DE" },
+      rules: [{ order: 0, type: "text", text: { en: "Body", de: "Körper" } }],
+    };
+    const spec = getLocalizationSpec(rule, "40k-11e");
+    const view = projectCard(rule, spec, "de");
+
+    expect(view.detachment).toBe("Gladius DE");
+    expect(view.rules[0].text).toBe("Körper");
+
+    view.rules[0].text = "Neuer Körper";
+    expect(mergeCard(view, spec, "de").rules[0].text).toEqual({ en: "Body", de: "Neuer Körper" });
+  });
+
   it("falls back to the card shape when cardType is missing", () => {
     const rule = { source: "40k-11e", rules: [{ order: 0, type: "text", text: { en: "Body", de: "Körper" } }] };
     const view = projectCard(rule, getLocalizationSpec(rule, "40k-11e"), "de");
     expect(view.rules[0].text).toBe("Körper");
+  });
+});
+
+describe("classify11eCard", () => {
+  it("trusts the stamped card type over the card's shape", () => {
+    // A rule card carries `rules`; a datasheet carries `stats`. Both are
+    // classified by what they say they are.
+    expect(classify11eCard({ cardType: "rule", rules: [] })).toBe("rule");
+    expect(classify11eCard({ cardType: "DataCard", stats: [] })).toBe("unit");
+    expect(classify11eCard({ cardType: "stratagem" })).toBe("stratagem");
+    expect(classify11eCard({ cardType: "enhancement" })).toBe("enhancement");
+  });
+
+  it("falls back to the card shape for cards stored before cardType existed", () => {
+    expect(classify11eCard({ stats: [] })).toBe("unit");
+    expect(classify11eCard({ rangedWeapons: [] })).toBe("unit");
+    expect(classify11eCard({ when: { en: "W" } })).toBe("stratagem");
+    expect(classify11eCard({ rules: [] })).toBe("rule");
+    expect(classify11eCard({ description: { en: "D" } })).toBe("enhancement");
+    expect(classify11eCard({})).toBe("unit");
+    expect(classify11eCard(undefined)).toBe("unit");
   });
 });
 

--- a/src/Components/Viewer/MobileEditor/__tests__/nameObjects.test.js
+++ b/src/Components/Viewer/MobileEditor/__tests__/nameObjects.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { alignNameObjects, nameObjectLabel } from "../shared/nameObjects";
+
+describe("nameObjectLabel", () => {
+  it("reads both the object and the bare-string shape", () => {
+    expect(nameObjectLabel({ name: "Scouts" })).toBe("Scouts");
+    expect(nameObjectLabel("Scouts")).toBe("Scouts");
+    expect(nameObjectLabel(undefined)).toBe("");
+  });
+});
+
+describe("alignNameObjects", () => {
+  // The language map each entry carries is what must survive a chip edit.
+  const items = [
+    { name: "Infantry", __i18n: { name: { en: "Infantry", de: "Infanterie" } } },
+    { name: "Imperium", __i18n: { name: { en: "Imperium", de: "Imperium" } } },
+    { name: "Grenades", __i18n: { name: { en: "Grenades", de: "Granaten" } } },
+  ];
+
+  it("keeps the original entries when nothing changed", () => {
+    expect(alignNameObjects(items, ["Infantry", "Imperium", "Grenades"])).toEqual(items);
+  });
+
+  it("keeps the surviving entries when one is removed", () => {
+    expect(alignNameObjects(items, ["Infantry", "Grenades"])).toEqual([items[0], items[2]]);
+  });
+
+  it("adds a new entry for a chip that did not exist", () => {
+    const result = alignNameObjects(items, ["Infantry", "Imperium", "Grenades", "Character"]);
+
+    expect(result.slice(0, 3)).toEqual(items);
+    expect(result[3]).toEqual({ name: "Character" });
+  });
+
+  it("consumes duplicates one at a time", () => {
+    const dupes = [{ name: "Core" }, { name: "Core" }];
+    expect(alignNameObjects(dupes, ["Core"])).toEqual([{ name: "Core" }]);
+  });
+});

--- a/src/Components/Viewer/MobileEditor/editorSchemaResolvers.js
+++ b/src/Components/Viewer/MobileEditor/editorSchemaResolvers.js
@@ -62,6 +62,8 @@ export function resolveEditorSections(card, gameSystem, schema) {
   switch (source) {
     case "40k-10e":
       return resolve40k10eSections(card);
+    case "40k-11e":
+      return resolve40k11eSections(card);
     case "aos":
       return resolveAosSections(card);
     default:
@@ -317,6 +319,273 @@ function resolve40kRuleSections() {
       type: "rulesList",
       config: {},
     },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// 40k-11e
+//
+// The 11th edition data is close to 10th but not identical, and the editor is
+// fed a language projection of the card (see localizedCard.js) so every
+// localized field arrives here as a plain string. The differences that the
+// sections need to know about are passed as config rather than branched on
+// inside the components:
+//
+//   - no per-profile / per-weapon / per-ability `active` and `show*` flags
+//   - core and faction abilities are `{ name }` objects, not bare strings
+//   - keywords are objects too (they are language-keyed in the source)
+//   - points are tiers with detachment / faction restrictions
+//   - weapons can carry their own named abilities (Overcharge, ...)
+// ---------------------------------------------------------------------------
+
+// 11e stat lines carry no `active` flag; the card renders every profile.
+const NEW_STAT_PROFILE_11E = { showName: true };
+
+const WEAPON_TYPE_11E = {
+  columns: WEAPON_COLUMNS_40K_10E,
+  hasKeywords: true,
+  hasActiveFlag: false,
+  hasWeaponAbilities: true,
+  newWeaponDefaults: {},
+  newProfileDefaults: {},
+};
+
+function resolve40k11eSections(card) {
+  switch (card.cardType) {
+    case "stratagem":
+      return resolve11eStratagemSections();
+    case "enhancement":
+      return resolve11eEnhancementSections();
+    case "DataCard":
+      return resolve11eUnitSections(card);
+    default:
+      break;
+  }
+
+  const isUnit = Array.isArray(card.stats) || card.rangedWeapons || card.meleeWeapons;
+  if (isUnit) return resolve11eUnitSections(card);
+  if (card.when !== undefined || card.effect !== undefined) return resolve11eStratagemSections();
+  if (Array.isArray(card.rules)) return resolve11eRuleSections();
+  if (card.description !== undefined) return resolve11eEnhancementSections();
+  return resolve11eUnitSections(card);
+}
+
+function resolve11eUnitSections(card) {
+  const sections = [{ key: "name", label: "Name", type: "name", config: {} }];
+
+  if (Array.isArray(card.stats)) {
+    sections.push({
+      key: "stats",
+      label: "Stats",
+      type: "stats",
+      config: {
+        fields: STATS_40K_10E,
+        allowMultipleProfiles: true,
+        dataPath: "stats",
+        newProfileDefaults: NEW_STAT_PROFILE_11E,
+      },
+    });
+  }
+
+  if (Array.isArray(card.points)) {
+    sections.push({
+      key: "points",
+      label: "Points",
+      type: "points",
+      config: {
+        format: "tiers",
+        hasActive: false,
+        hasRestrictions: true,
+        hasAdditionalCost: true,
+      },
+    });
+  }
+
+  const weaponTypes = [];
+  if (card.rangedWeapons) {
+    weaponTypes.push({ key: "rangedWeapons", label: "Ranged Weapons", ...WEAPON_TYPE_11E });
+  }
+  if (card.meleeWeapons) {
+    weaponTypes.push({ key: "meleeWeapons", label: "Melee Weapons", ...WEAPON_TYPE_11E });
+  }
+  if (weaponTypes.length > 0) {
+    sections.push({
+      key: "weapons",
+      label: "Weapons",
+      type: "weapons",
+      config: { types: weaponTypes, format: "40k" },
+    });
+  }
+
+  sections.push({
+    key: "abilities",
+    label: "Abilities",
+    type: "abilities",
+    config: {
+      format: "40k",
+      newAbilityDefaults: {},
+      categories: [
+        { key: "core", label: "Core Abilities", format: "name-only", itemShape: "object" },
+        { key: "faction", label: "Faction Abilities", format: "name-only", itemShape: "object" },
+        { key: "other", label: "Other Abilities", format: "name-description" },
+        { key: "wargear", label: "Wargear Abilities", format: "name-description" },
+        { key: "special", label: "Special Abilities", format: "name-description" },
+      ],
+    },
+  });
+
+  if (card.abilities?.primarch?.length) {
+    sections.push({
+      key: "primarch",
+      label: "Primarch Abilities",
+      type: "primarch",
+      config: { hasShowToggle: false, newAbilityDefaults: {} },
+    });
+  }
+
+  if (card.abilities?.damaged) {
+    sections.push({
+      key: "damaged",
+      label: "Damaged Profile",
+      type: "damaged",
+      config: { hasShowToggle: false },
+    });
+  }
+
+  if (card.abilities?.invul) {
+    sections.push({
+      key: "invul",
+      label: "Invulnerable Save",
+      type: "invul",
+      config: { valueOnly: true },
+    });
+  }
+
+  // Wargear lives in two fields and the card renders only one of them: the
+  // structured groups win when a card has any, otherwise the free-form
+  // sentences. Mirror the desktop panel and edit whichever one reaches the card
+  // (see Warhammer40k-11e/UnitCardEditor/UnitWargearOptions).
+  if (card.wargearOptions?.length) {
+    sections.push({
+      key: "wargearOptions",
+      label: "Wargear Options",
+      type: "wargearOptions",
+      config: {},
+    });
+  } else if (card.wargear) {
+    sections.push({
+      key: "wargear",
+      label: "Wargear",
+      type: "stringList",
+      config: { dataPath: "wargear", itemLabel: "Wargear text" },
+    });
+  }
+
+  if (card.composition) {
+    sections.push({
+      key: "composition",
+      label: "Unit Composition",
+      type: "stringList",
+      config: { dataPath: "composition", itemLabel: "Entry" },
+    });
+  }
+
+  if (card.loadout !== undefined) {
+    sections.push({ key: "loadout", label: "Loadout", type: "textField", config: { dataPath: "loadout" } });
+  }
+
+  if (card.leader !== undefined) {
+    sections.push({ key: "leader", label: "Leader", type: "textField", config: { dataPath: "leader" } });
+  }
+
+  if (card.transport !== undefined) {
+    sections.push({ key: "transport", label: "Transport", type: "textField", config: { dataPath: "transport" } });
+  }
+
+  sections.push({
+    key: "keywords",
+    label: "Keywords",
+    type: "keywords",
+    config: {
+      keywordsPath: "keywords",
+      factionKeywordsPath: "factions",
+      factionKeywordsLabel: "Factions",
+      // Keywords are language-keyed and project to `{ name }` objects; factions
+      // are plain strings the glossary matches in English.
+      keywordsAreObjects: true,
+    },
+  });
+
+  return sections;
+}
+
+function resolve11eStratagemSections() {
+  return [
+    { key: "name", label: "Name", type: "name", config: {} },
+    {
+      key: "fields",
+      label: "Details",
+      type: "fields",
+      config: {
+        fields: [
+          { key: "type", label: "Type", type: "string" },
+          { key: "detachment", label: "Detachment", type: "string" },
+          { key: "cost", label: "Cost", type: "string" },
+          { key: "turn", label: "Turn", type: "enum", options: ["your", "opponents", "either"] },
+          { key: "when", label: "When", type: "richtext" },
+          { key: "target", label: "Target", type: "richtext" },
+          { key: "effect", label: "Effect", type: "richtext" },
+          { key: "restrictions", label: "Restrictions", type: "richtext" },
+        ],
+      },
+    },
+  ];
+}
+
+function resolve11eEnhancementSections() {
+  return [
+    { key: "name", label: "Name", type: "name", config: {} },
+    {
+      key: "fields",
+      label: "Details",
+      type: "fields",
+      config: {
+        fields: [
+          { key: "detachment", label: "Detachment", type: "string" },
+          { key: "cost", label: "Cost", type: "string" },
+          { key: "description", label: "Description", type: "richtext" },
+        ],
+      },
+    },
+    {
+      key: "eligibility",
+      label: "Eligibility",
+      type: "keywords",
+      config: {
+        keywordsPath: "keywords",
+        keywordsLabel: "Requires keyword",
+        factionKeywordsPath: "excludes",
+        factionKeywordsLabel: "Excludes keyword",
+      },
+    },
+  ];
+}
+
+function resolve11eRuleSections() {
+  return [
+    { key: "name", label: "Name", type: "name", config: {} },
+    {
+      key: "fields",
+      label: "Details",
+      type: "fields",
+      config: {
+        fields: [
+          { key: "ruleType", label: "Rule Type", type: "enum", options: ["army", "detachment"] },
+          { key: "detachment", label: "Detachment", type: "string" },
+        ],
+      },
+    },
+    { key: "rules", label: "Rules", type: "rulesList", config: {} },
   ];
 }
 

--- a/src/Components/Viewer/MobileEditor/editorSchemaResolvers.js
+++ b/src/Components/Viewer/MobileEditor/editorSchemaResolvers.js
@@ -1,3 +1,5 @@
+import { classify11eCard } from "./localizedCard";
+
 /**
  * Resolves a card + game system into an array of editor section descriptors.
  * Each section describes what editor component to render and with what config.
@@ -350,24 +352,20 @@ const WEAPON_TYPE_11E = {
   newProfileDefaults: {},
 };
 
+// Classification is shared with the localization spec (`classify11eCard`): the
+// sections a card gets and the spec its text is merged against have to agree,
+// or a card would be edited through fields its spec does not describe.
 function resolve40k11eSections(card) {
-  switch (card.cardType) {
+  switch (classify11eCard(card)) {
     case "stratagem":
       return resolve11eStratagemSections();
     case "enhancement":
       return resolve11eEnhancementSections();
-    case "DataCard":
-      return resolve11eUnitSections(card);
+    case "rule":
+      return resolve11eRuleSections();
     default:
-      break;
+      return resolve11eUnitSections(card);
   }
-
-  const isUnit = Array.isArray(card.stats) || card.rangedWeapons || card.meleeWeapons;
-  if (isUnit) return resolve11eUnitSections(card);
-  if (card.when !== undefined || card.effect !== undefined) return resolve11eStratagemSections();
-  if (Array.isArray(card.rules)) return resolve11eRuleSections();
-  if (card.description !== undefined) return resolve11eEnhancementSections();
-  return resolve11eUnitSections(card);
 }
 
 function resolve11eUnitSections(card) {

--- a/src/Components/Viewer/MobileEditor/localizedCard.js
+++ b/src/Components/Viewer/MobileEditor/localizedCard.js
@@ -1,0 +1,271 @@
+/**
+ * Language projection for the mobile card editor.
+ *
+ * Multi-language datasources (40k-11e) store every displayable string as a
+ * language-keyed object: `{ en: "Leader", de: "Anführer", ... }`. The mobile
+ * editor's section components all read and write plain strings, so rather than
+ * teaching each of them about language keys, the editor edits a *projection* of
+ * the card:
+ *
+ *   project(card)  ->  the same card with every localized field resolved to a
+ *                      plain string in the active card language
+ *   merge(view)    ->  that view folded back into language-keyed shape, with
+ *                      every other language left untouched
+ *
+ * The projection carries the original language maps along in a `__i18n` sidecar
+ * on the object that owns each field. That is what makes the round trip safe
+ * under structural edits: when a section deletes weapon 0 or reorders the
+ * abilities, each surviving item takes its own language map with it, so nothing
+ * is merged back into the wrong entry's translations.
+ *
+ * Fields the datasource keeps as plain strings (a unit's `name`, a weapon's
+ * numeric stats, an enhancement's eligibility keywords) are simply absent from
+ * the spec and pass through both directions untouched.
+ */
+
+import { localize, setLocalizedFieldSeeded } from "../../../Helpers/localization.helpers";
+
+// Sidecar key holding the pre-projection language maps for one object's fields.
+export const I18N_KEY = "__i18n";
+
+// Spec leaf tokens.
+const TEXT = "text";
+// A field that is cleared to `null` rather than to an empty string: the points
+// tier restrictions, where `null` is what the datasource stores for a tier that
+// applies to every detachment / faction (and what the points helpers test for).
+const TEXT_OR_NULL = "textOrNull";
+// An array whose *entries* are themselves localized strings (keywords, unit
+// composition lines, wargear sentences). Entries project to `{ name }` objects
+// so each one can carry its own sidecar; the sections that render them already
+// accept that shape.
+const TEXT_LIST = "textList";
+
+const isPlainObject = (value) => value != null && typeof value === "object" && !Array.isArray(value);
+
+const NAMED = { name: TEXT };
+const NAMED_WITH_DESCRIPTION = { name: TEXT, description: TEXT };
+const WEAPONS = {
+  each: {
+    profiles: { each: NAMED },
+    abilities: { each: NAMED_WITH_DESCRIPTION },
+  },
+};
+
+/**
+ * Which fields of an 11th edition unit are language-keyed.
+ *
+ * `name` and `subname` are deliberately absent: the datasource loader already
+ * resolves a card's top-level name to a plain string (see `get40k11eData`) and
+ * the renderers read it raw, so projecting it would be a no-op on the way in
+ * and would risk turning it into an object on the way out.
+ */
+const UNIT_11E = {
+  stats: { each: NAMED },
+  rangedWeapons: WEAPONS,
+  meleeWeapons: WEAPONS,
+  abilities: {
+    core: { each: NAMED },
+    faction: { each: NAMED },
+    other: { each: NAMED_WITH_DESCRIPTION },
+    wargear: { each: NAMED_WITH_DESCRIPTION },
+    special: { each: NAMED_WITH_DESCRIPTION },
+    primarch: { each: { name: TEXT, abilities: { each: NAMED_WITH_DESCRIPTION } } },
+    damaged: { range: TEXT, description: TEXT },
+  },
+  // Keywords are localized; `factions` are plain strings matched in English.
+  keywords: TEXT_LIST,
+  composition: TEXT_LIST,
+  wargear: TEXT_LIST,
+  wargearOptions: { each: { instruction: TEXT, options: { each: NAMED } } },
+  loadout: TEXT,
+  transport: TEXT,
+  leader: TEXT,
+  points: { each: { keyword: TEXT, detachment: TEXT_OR_NULL, faction: TEXT_OR_NULL } },
+};
+
+const STRATAGEM_11E = {
+  detachment: TEXT,
+  type: TEXT,
+  when: TEXT,
+  target: TEXT,
+  effect: TEXT,
+  restrictions: TEXT,
+};
+
+// `keywords` / `excludes` stay out of the spec: the list builder matches an
+// enhancement's eligibility against English keywords, so they are plain strings.
+const ENHANCEMENT_11E = {
+  detachment: TEXT,
+  description: TEXT,
+};
+
+const RULE_11E = {
+  detachment: TEXT,
+  rules: { each: { title: TEXT, text: TEXT } },
+};
+
+/**
+ * The localization spec for a card, or `null` when the card needs no projection.
+ *
+ * Only 40k-11e ships language-keyed data today; every other source edits its
+ * plain strings directly.
+ */
+export function getLocalizationSpec(card, gameSystem) {
+  const source = card?.source || gameSystem;
+  if (source !== "40k-11e") return null;
+  return specFor11eCard(card);
+}
+
+// The 11e loader stamps a `cardType` on every card; the shape checks are the
+// fallback for cards stored before it did (and for hand-built test data).
+function specFor11eCard(card) {
+  if (!card) return null;
+  switch (card.cardType) {
+    case "stratagem":
+      return STRATAGEM_11E;
+    case "enhancement":
+      return ENHANCEMENT_11E;
+    case "DataCard":
+      return UNIT_11E;
+    default:
+      break;
+  }
+  if (Array.isArray(card.stats) || card.rangedWeapons || card.meleeWeapons) return UNIT_11E;
+  if (card.when !== undefined || card.effect !== undefined) return STRATAGEM_11E;
+  if (Array.isArray(card.rules)) return RULE_11E;
+  if (card.description !== undefined) return ENHANCEMENT_11E;
+  return UNIT_11E;
+}
+
+/**
+ * Resolve every localized field of `card` to a plain string in `language`,
+ * keeping the original language maps in `__i18n` sidecars for {@link mergeCard}.
+ */
+export function projectCard(card, spec, language = "en") {
+  if (!card || !spec) return card;
+  return projectObject(card, spec, language);
+}
+
+/**
+ * Fold an edited projection back into language-keyed shape, preserving every
+ * language the user was not editing.
+ */
+export function mergeCard(view, spec, language = "en") {
+  if (!view || !spec) return view;
+  return mergeObject(view, spec, language);
+}
+
+function projectObject(value, spec, language) {
+  if (!isPlainObject(value)) return value;
+
+  const out = { ...value };
+  const sidecar = {};
+
+  for (const [key, fieldSpec] of Object.entries(spec)) {
+    if (!(key in value)) continue;
+    const current = value[key];
+
+    if (fieldSpec === TEXT || fieldSpec === TEXT_OR_NULL) {
+      out[key] = localize(current, language);
+      sidecar[key] = current;
+      continue;
+    }
+
+    if (fieldSpec === TEXT_LIST) {
+      if (!Array.isArray(current)) continue;
+      out[key] = current.map((entry) => ({
+        name: localize(entry, language),
+        [I18N_KEY]: { name: entry },
+      }));
+      continue;
+    }
+
+    if (fieldSpec?.each) {
+      if (!Array.isArray(current)) continue;
+      out[key] = current.map((item) => projectObject(item, fieldSpec.each, language));
+      continue;
+    }
+
+    out[key] = projectObject(current, fieldSpec, language);
+  }
+
+  if (Object.keys(sidecar).length > 0) {
+    out[I18N_KEY] = sidecar;
+  }
+  return out;
+}
+
+function mergeObject(view, spec, language) {
+  if (!isPlainObject(view)) return view;
+
+  const { [I18N_KEY]: sidecar, ...out } = view;
+
+  for (const [key, fieldSpec] of Object.entries(spec)) {
+    if (!(key in out)) continue;
+    const edited = out[key];
+
+    if (fieldSpec === TEXT || fieldSpec === TEXT_OR_NULL) {
+      const original = sidecar?.[key];
+      const text = edited == null ? "" : String(edited);
+
+      // Coverage is uneven across the 11e data, so a field with only English
+      // text projects as that English fallback. Writing it back unchanged would
+      // silently stamp a copy of it into the active language on every save, so
+      // an untouched field is restored exactly as it came in.
+      if (isUnchanged(original, text, language)) {
+        out[key] = original;
+        continue;
+      }
+
+      // An unrestricted points tier is stored as null, not as an empty string.
+      if (fieldSpec === TEXT_OR_NULL && text.trim() === "") {
+        out[key] = null;
+        continue;
+      }
+      // A field the datasource omits (a stratagem's restrictions, a new
+      // ability's description) stays omitted until it actually has text, so
+      // cleared fields do not leave empty language objects behind.
+      if (original == null && text === "") {
+        delete out[key];
+        continue;
+      }
+      out[key] = setLocalizedFieldSeeded(original, language, text);
+      continue;
+    }
+
+    if (fieldSpec === TEXT_LIST) {
+      if (!Array.isArray(edited)) continue;
+      out[key] = edited.map((entry) => mergeTextListEntry(entry, language));
+      continue;
+    }
+
+    if (fieldSpec?.each) {
+      if (!Array.isArray(edited)) continue;
+      out[key] = edited.map((item) => mergeObject(item, fieldSpec.each, language));
+      continue;
+    }
+
+    out[key] = mergeObject(edited, fieldSpec, language);
+  }
+
+  return out;
+}
+
+// An entry added by a section arrives as a bare string (StringListSection seeds
+// new rows with ""), one that came from the card as a projected `{ name }`
+// object carrying its language map.
+function mergeTextListEntry(entry, language) {
+  if (isPlainObject(entry)) {
+    const original = entry[I18N_KEY]?.name;
+    const text = entry.name ?? "";
+    if (isUnchanged(original, text, language)) return original;
+    return setLocalizedFieldSeeded(original, language, text);
+  }
+  return setLocalizedFieldSeeded(null, language, entry ?? "");
+}
+
+// True when the edited text still reads exactly as the projection did, i.e. the
+// user did not touch this field.
+function isUnchanged(original, text, language) {
+  return original !== undefined && localize(original, language) === text;
+}

--- a/src/Components/Viewer/MobileEditor/localizedCard.js
+++ b/src/Components/Viewer/MobileEditor/localizedCard.js
@@ -104,6 +104,48 @@ const RULE_11E = {
   rules: { each: { title: TEXT, text: TEXT } },
 };
 
+const SPEC_BY_11E_CARD_TYPE = {
+  unit: UNIT_11E,
+  stratagem: STRATAGEM_11E,
+  enhancement: ENHANCEMENT_11E,
+  rule: RULE_11E,
+};
+
+/**
+ * Classify an 11th edition card as "unit" | "stratagem" | "enhancement" | "rule".
+ *
+ * The editor has to agree with itself about what a card is twice over — once to
+ * pick its localization spec and once to pick its editor sections — and a card
+ * resolved against a mismatched spec would silently mis-merge its text. So both
+ * go through this one function.
+ *
+ * The `cardType` stamped on a card is authoritative: the datasource loader sets
+ * `DataCard` / `stratagem` / `enhancement` (`get40k11eData`), and the viewer's
+ * unit list sets `rule` when it turns army and detachment rules into cards
+ * (`ViewerUnitList`). The shape checks below are the fallback for cards stored
+ * before those existed, and for hand-built test data.
+ */
+export function classify11eCard(card) {
+  switch (card?.cardType) {
+    case "DataCard":
+      return "unit";
+    case "stratagem":
+      return "stratagem";
+    case "enhancement":
+      return "enhancement";
+    case "rule":
+      return "rule";
+    default:
+      break;
+  }
+
+  if (Array.isArray(card?.stats) || card?.rangedWeapons || card?.meleeWeapons) return "unit";
+  if (card?.when !== undefined || card?.effect !== undefined) return "stratagem";
+  if (Array.isArray(card?.rules)) return "rule";
+  if (card?.description !== undefined) return "enhancement";
+  return "unit";
+}
+
 /**
  * The localization spec for a card, or `null` when the card needs no projection.
  *
@@ -113,28 +155,8 @@ const RULE_11E = {
 export function getLocalizationSpec(card, gameSystem) {
   const source = card?.source || gameSystem;
   if (source !== "40k-11e") return null;
-  return specFor11eCard(card);
-}
-
-// The 11e loader stamps a `cardType` on every card; the shape checks are the
-// fallback for cards stored before it did (and for hand-built test data).
-function specFor11eCard(card) {
   if (!card) return null;
-  switch (card.cardType) {
-    case "stratagem":
-      return STRATAGEM_11E;
-    case "enhancement":
-      return ENHANCEMENT_11E;
-    case "DataCard":
-      return UNIT_11E;
-    default:
-      break;
-  }
-  if (Array.isArray(card.stats) || card.rangedWeapons || card.meleeWeapons) return UNIT_11E;
-  if (card.when !== undefined || card.effect !== undefined) return STRATAGEM_11E;
-  if (Array.isArray(card.rules)) return RULE_11E;
-  if (card.description !== undefined) return ENHANCEMENT_11E;
-  return UNIT_11E;
+  return SPEC_BY_11E_CARD_TYPE[classify11eCard(card)];
 }
 
 /**

--- a/src/Components/Viewer/MobileEditor/sections/AbilitiesSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/AbilitiesSection.jsx
@@ -5,6 +5,7 @@ import { EditorSelectField } from "../shared/EditorSelectField";
 import { EditorTagInput } from "../shared/EditorTagInput";
 import { EditorToggle } from "../shared/EditorToggle";
 import { EditorChipListField } from "../shared/EditorChipListField";
+import { alignNameObjects, nameObjectLabel } from "../shared/nameObjects";
 import { AOS_PHASE_OPTIONS, AOS_ICON_OPTIONS } from "../../../AgeOfSigmar/constants";
 import { VALID_ABILITY_TYPES, VALID_ABILITY_COST_UNITS } from "../../../../Helpers/customSchema.helpers";
 
@@ -29,10 +30,12 @@ export const AbilitiesSection = ({ card, config, label, icon, updateField, repla
   return null;
 };
 
-// 40k abilities: categorized object with core (string[]), faction (string[]), other/wargear/special (ability objects[])
+// 40k abilities: categorized object with core (string[] in 10e, { name }[] in
+// 11e), faction (same) and other/wargear/special (ability objects[])
 const Abilities40k = ({ card, label, icon, replaceCard, config }) => {
   const abilities = card.abilities || {};
-  const { categories } = config;
+  const { categories, newAbilityDefaults } = config;
+  const abilityDefaults = newAbilityDefaults ?? { showAbility: true, showDescription: true };
 
   const handleUpdateNameOnly = (categoryKey, index, value) => {
     const arr = [...(abilities[categoryKey] || [])];
@@ -57,10 +60,7 @@ const Abilities40k = ({ card, label, icon, replaceCard, config }) => {
   };
 
   const handleAddAbility = (categoryKey) => {
-    const arr = [
-      ...(abilities[categoryKey] || []),
-      { name: "New Ability", description: "", showAbility: true, showDescription: true },
-    ];
+    const arr = [...(abilities[categoryKey] || []), { ...abilityDefaults, name: "New Ability", description: "" }];
     replaceCard({ ...card, abilities: { ...abilities, [categoryKey]: arr } });
   };
 
@@ -74,12 +74,18 @@ const Abilities40k = ({ card, label, icon, replaceCard, config }) => {
       {categories.map((cat) => {
         const items = abilities[cat.key] || [];
         if (cat.format === "name-only") {
+          const isObjectShape = cat.itemShape === "object";
           return (
             <div key={cat.key} style={{ marginBottom: 16 }}>
               <EditorTagInput
                 label={cat.label}
-                tags={items}
-                onChange={(tags) => replaceCard({ ...card, abilities: { ...abilities, [cat.key]: tags } })}
+                tags={isObjectShape ? items.map(nameObjectLabel) : items}
+                onChange={(tags) =>
+                  replaceCard({
+                    ...card,
+                    abilities: { ...abilities, [cat.key]: isObjectShape ? alignNameObjects(items, tags) : tags },
+                  })
+                }
               />
             </div>
           );

--- a/src/Components/Viewer/MobileEditor/sections/DamagedSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/DamagedSection.jsx
@@ -2,18 +2,24 @@ import { EditorAccordion } from "../shared/EditorAccordion";
 import { EditorTextField } from "../shared/EditorTextField";
 import { EditorToggle } from "../shared/EditorToggle";
 
-export const DamagedSection = ({ card, label, icon, updateField }) => {
+export const DamagedSection = ({ card, config = {}, label, icon, updateField }) => {
   const damaged = card.abilities?.damaged;
   if (!damaged) return null;
+
+  // 11e has no per-ability show flag here: the card shows the damaged profile
+  // whenever it has content, and the top-level `showDamaged` flag hides it.
+  const hasShowToggle = config.hasShowToggle !== false;
 
   return (
     <EditorAccordion title={label} icon={icon}>
       <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-        <EditorToggle
-          label="Show on card"
-          checked={damaged.showDamagedAbility !== false}
-          onChange={(value) => updateField("abilities.damaged.showDamagedAbility", value)}
-        />
+        {hasShowToggle && (
+          <EditorToggle
+            label="Show on card"
+            checked={damaged.showDamagedAbility !== false}
+            onChange={(value) => updateField("abilities.damaged.showDamagedAbility", value)}
+          />
+        )}
         <EditorTextField
           label="Wounds Remaining"
           value={damaged.range}

--- a/src/Components/Viewer/MobileEditor/sections/InvulSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/InvulSection.jsx
@@ -3,9 +3,14 @@ import { EditorNumberField } from "../shared/EditorNumberField";
 import { EditorTextField } from "../shared/EditorTextField";
 import { EditorToggle } from "../shared/EditorToggle";
 
-export const InvulSection = ({ card, label, icon, updateField }) => {
+export const InvulSection = ({ card, config = {}, label, icon, updateField }) => {
   const invul = card.abilities?.invul;
   if (!invul) return null;
+
+  // 11e invulnerable saves are a single value rendered in the card header:
+  // there is no info line and no per-field show flag (the panel switch owns
+  // visibility), so the extra controls would write keys the renderer ignores.
+  const valueOnly = config.valueOnly === true;
 
   return (
     <EditorAccordion title={label} icon={icon}>
@@ -15,22 +20,26 @@ export const InvulSection = ({ card, label, icon, updateField }) => {
           value={invul.value}
           onChange={(value) => updateField("abilities.invul.value", value)}
         />
-        <EditorTextField
-          label="Info"
-          value={invul.info}
-          onChange={(value) => updateField("abilities.invul.info", value)}
-          placeholder="e.g. Ranged attacks only"
-        />
-        <EditorToggle
-          label="Show on card"
-          checked={invul.showInvulnerableSave !== false}
-          onChange={(value) => updateField("abilities.invul.showInvulnerableSave", value)}
-        />
-        <EditorToggle
-          label="Show Info"
-          checked={!!invul.showInfo}
-          onChange={(value) => updateField("abilities.invul.showInfo", value)}
-        />
+        {!valueOnly && (
+          <>
+            <EditorTextField
+              label="Info"
+              value={invul.info}
+              onChange={(value) => updateField("abilities.invul.info", value)}
+              placeholder="e.g. Ranged attacks only"
+            />
+            <EditorToggle
+              label="Show on card"
+              checked={invul.showInvulnerableSave !== false}
+              onChange={(value) => updateField("abilities.invul.showInvulnerableSave", value)}
+            />
+            <EditorToggle
+              label="Show Info"
+              checked={!!invul.showInfo}
+              onChange={(value) => updateField("abilities.invul.showInfo", value)}
+            />
+          </>
+        )}
       </div>
     </EditorAccordion>
   );

--- a/src/Components/Viewer/MobileEditor/sections/KeywordsSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/KeywordsSection.jsx
@@ -1,27 +1,42 @@
 import { EditorAccordion } from "../shared/EditorAccordion";
 import { EditorTagInput } from "../shared/EditorTagInput";
+import { alignNameObjects, nameObjectLabel } from "../shared/nameObjects";
 
 export const KeywordsSection = ({ card, config, label, icon, updateField }) => {
-  const { keywordsPath, factionKeywordsPath, keywordsLabel, factionKeywordsLabel } = config;
+  const {
+    keywordsPath,
+    factionKeywordsPath,
+    keywordsLabel,
+    factionKeywordsLabel,
+    // 11e keywords are language-keyed and reach the editor as `{ name }`
+    // objects; factions stay plain strings (they are matched in English).
+    keywordsAreObjects,
+    factionKeywordsAreObjects,
+  } = config;
+
+  const renderTags = (path, isObjectShape, tagLabel, placeholder) => {
+    const items = card[path] || [];
+    return (
+      <EditorTagInput
+        label={tagLabel}
+        tags={isObjectShape ? items.map(nameObjectLabel) : items}
+        onChange={(tags) => updateField(path, isObjectShape ? alignNameObjects(items, tags) : tags)}
+        placeholder={placeholder}
+      />
+    );
+  };
 
   return (
     <EditorAccordion title={label} icon={icon}>
-      {keywordsPath && (
-        <EditorTagInput
-          label={keywordsLabel || "Keywords"}
-          tags={card[keywordsPath] || []}
-          onChange={(tags) => updateField(keywordsPath, tags)}
-          placeholder="Add keyword"
-        />
-      )}
+      {keywordsPath && renderTags(keywordsPath, keywordsAreObjects, keywordsLabel || "Keywords", "Add keyword")}
       {factionKeywordsPath && (
         <div style={{ marginTop: keywordsPath ? 16 : 0 }}>
-          <EditorTagInput
-            label={factionKeywordsLabel || "Faction Keywords"}
-            tags={card[factionKeywordsPath] || []}
-            onChange={(tags) => updateField(factionKeywordsPath, tags)}
-            placeholder="Add faction keyword"
-          />
+          {renderTags(
+            factionKeywordsPath,
+            factionKeywordsAreObjects,
+            factionKeywordsLabel || "Faction Keywords",
+            "Add faction keyword",
+          )}
         </div>
       )}
     </EditorAccordion>

--- a/src/Components/Viewer/MobileEditor/sections/PointsSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/PointsSection.jsx
@@ -7,7 +7,7 @@ import { EditorToggle } from "../shared/EditorToggle";
 export const PointsSection = ({ card, config, label, icon, updateField, replaceCard }) => {
   // Check actual data type first, then fall back to config hint
   if (Array.isArray(card.points)) {
-    return <PointsArray card={card} label={label} replaceCard={replaceCard} />;
+    return <PointsArray card={card} config={config} label={label} icon={icon} replaceCard={replaceCard} />;
   }
 
   // Scalar points (number or string)
@@ -22,8 +22,16 @@ export const PointsSection = ({ card, config, label, icon, updateField, replaceC
   );
 };
 
-const PointsArray = ({ card, label, replaceCard }) => {
+const PointsArray = ({ card, config = {}, label, icon, replaceCard }) => {
   const points = card.points || [];
+
+  // 11e tiers have no active flag — the first entry is the primary cost and the
+  // rest are listed when "Show All Points" is on — and a tier can be priced for
+  // a single detachment or a single faction.
+  const hasActive = config.hasActive !== false;
+  const hasRestrictions = config.hasRestrictions === true;
+  const hasAdditionalCost = config.hasAdditionalCost === true;
+  const additionalCost = card.additionalCost || null;
 
   const handleUpdate = (index, field, value) => {
     const updated = [...points];
@@ -31,19 +39,38 @@ const PointsArray = ({ card, label, replaceCard }) => {
     replaceCard({ ...card, points: updated });
   };
 
+  // A tier is priced for a detachment or for a faction, never both, and an
+  // emptied restriction drops back to null — the shape the datasource uses for
+  // an unrestricted tier and the one the points helpers test for.
+  const handleUpdateRestriction = (index, field, value) => {
+    handleUpdate(index, field, value.trim() === "" ? null : value);
+  };
+
   const handleAdd = () => {
-    replaceCard({
-      ...card,
-      points: [...points, { models: 1, cost: 0, active: true, keyword: "" }],
-    });
+    const blank = hasActive ? { models: 1, cost: 0, active: true, keyword: "" } : { models: "", cost: "", keyword: "" };
+    replaceCard({ ...card, points: [...points, blank] });
   };
 
   const handleRemove = (index) => {
     replaceCard({ ...card, points: points.filter((_, i) => i !== index) });
   };
 
+  // Clearing the surcharge removes it entirely, matching the desktop editor and
+  // the cards that never had one.
+  const handleUpdateAdditionalCost = (field, value) => {
+    if (field === "cost" && String(value).trim() === "") {
+      const { additionalCost: _removed, ...rest } = card;
+      replaceCard(rest);
+      return;
+    }
+    replaceCard({
+      ...card,
+      additionalCost: { cost: "", afterSelections: 1, ...(additionalCost || {}), [field]: value },
+    });
+  };
+
   return (
-    <EditorAccordion title={label} badge={points.length}>
+    <EditorAccordion title={label} icon={icon} badge={points.length}>
       {points.map((entry, index) => (
         <div key={index} className="mobile-editor-points-entry">
           <div className="mobile-editor-points-field">
@@ -68,11 +95,35 @@ const PointsArray = ({ card, label, replaceCard }) => {
               placeholder="e.g. Jump Packs"
             />
           </div>
-          <EditorToggle
-            label="Active"
-            checked={entry.active !== false}
-            onChange={(value) => handleUpdate(index, "active", value)}
-          />
+          {hasRestrictions && (
+            <>
+              <div className="mobile-editor-points-field">
+                <EditorTextField
+                  label="Detachment"
+                  value={entry.detachment || ""}
+                  disabled={Boolean(entry.faction)}
+                  onChange={(value) => handleUpdateRestriction(index, "detachment", value)}
+                  placeholder="All detachments"
+                />
+              </div>
+              <div className="mobile-editor-points-field">
+                <EditorTextField
+                  label="Faction"
+                  value={entry.faction || ""}
+                  disabled={Boolean(entry.detachment)}
+                  onChange={(value) => handleUpdateRestriction(index, "faction", value)}
+                  placeholder="All factions"
+                />
+              </div>
+            </>
+          )}
+          {hasActive && (
+            <EditorToggle
+              label="Active"
+              checked={entry.active !== false}
+              onChange={(value) => handleUpdate(index, "active", value)}
+            />
+          )}
           {points.length > 1 && (
             <button className="mobile-editor-weapon-delete" onClick={() => handleRemove(index)} type="button">
               <Trash2 size={14} />
@@ -84,6 +135,25 @@ const PointsArray = ({ card, label, replaceCard }) => {
         <Plus size={14} />
         <span>Add Points Option</span>
       </button>
+      {hasAdditionalCost && (
+        <div className="mobile-editor-points-entry" style={{ marginTop: 12 }}>
+          <label className="mobile-editor-field-label">Additional selection cost</label>
+          <div className="mobile-editor-points-field">
+            <EditorNumberField
+              label="Cost"
+              value={additionalCost?.cost ?? ""}
+              onChange={(value) => handleUpdateAdditionalCost("cost", value)}
+            />
+          </div>
+          <div className="mobile-editor-points-field">
+            <EditorNumberField
+              label="Included"
+              value={additionalCost?.afterSelections ?? ""}
+              onChange={(value) => handleUpdateAdditionalCost("afterSelections", Number(value) || 0)}
+            />
+          </div>
+        </div>
+      )}
     </EditorAccordion>
   );
 };

--- a/src/Components/Viewer/MobileEditor/sections/PrimarchSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/PrimarchSection.jsx
@@ -3,8 +3,15 @@ import { EditorAccordion } from "../shared/EditorAccordion";
 import { EditorTextField } from "../shared/EditorTextField";
 import { EditorToggle } from "../shared/EditorToggle";
 
-export const PrimarchSection = ({ card, label, icon, replaceCard }) => {
+export const PrimarchSection = ({ card, config = {}, label, icon, replaceCard }) => {
   const primarch = card.abilities?.primarch || [];
+
+  // 11e primarch groups carry no per-ability show flags (the panel switch owns
+  // visibility), so both the toggle and the keys a new entry starts with are
+  // supplied by the resolver.
+  const hasShowToggle = config.hasShowToggle !== false;
+  const newAbilityDefaults = config.newAbilityDefaults ?? { showAbility: true, showDescription: true };
+  const newGroupDefaults = config.newGroupDefaults ?? (hasShowToggle ? { showAbility: true } : {});
 
   const updatePrimarch = (updated) => {
     replaceCard({ ...card, abilities: { ...card.abilities, primarch: updated } });
@@ -28,7 +35,7 @@ export const PrimarchSection = ({ card, label, icon, replaceCard }) => {
     const updated = [...primarch];
     const abilities = [
       ...(updated[groupIndex].abilities || []),
-      { name: "New Ability", description: "", showAbility: true, showDescription: true },
+      { ...newAbilityDefaults, name: "New Ability", description: "" },
     ];
     updated[groupIndex] = { ...updated[groupIndex], abilities };
     updatePrimarch(updated);
@@ -44,7 +51,7 @@ export const PrimarchSection = ({ card, label, icon, replaceCard }) => {
   };
 
   const handleAddGroup = () => {
-    updatePrimarch([...primarch, { name: "Ability Group", showAbility: true, abilities: [] }]);
+    updatePrimarch([...primarch, { ...newGroupDefaults, name: "Ability Group", abilities: [] }]);
   };
 
   const handleRemoveGroup = (groupIndex) => {
@@ -66,11 +73,13 @@ export const PrimarchSection = ({ card, label, icon, replaceCard }) => {
               <Trash2 size={14} />
             </button>
           </div>
-          <EditorToggle
-            label="Show on card"
-            checked={group.showAbility !== false}
-            onChange={(value) => handleUpdateGroup(groupIndex, "showAbility", value)}
-          />
+          {hasShowToggle && (
+            <EditorToggle
+              label="Show on card"
+              checked={group.showAbility !== false}
+              onChange={(value) => handleUpdateGroup(groupIndex, "showAbility", value)}
+            />
+          )}
           <div
             style={{
               paddingLeft: 12,

--- a/src/Components/Viewer/MobileEditor/sections/StatsSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/StatsSection.jsx
@@ -20,7 +20,7 @@ const StatFieldInput = ({ field, value, onChange }) => {
 };
 
 export const StatsSection = ({ card, config, label, icon, updateField, replaceCard }) => {
-  const { fields, allowMultipleProfiles, dataPath, flatObject } = config;
+  const { fields, allowMultipleProfiles, dataPath, flatObject, newProfileDefaults } = config;
 
   if (flatObject) {
     return (
@@ -43,7 +43,9 @@ export const StatsSection = ({ card, config, label, icon, updateField, replaceCa
   };
 
   const handleAddProfile = () => {
-    const blank = { active: true, name: "New Profile" };
+    // 10e/custom stat lines carry an `active` flag; 11e ones do not, so the
+    // resolver supplies the keys a blank profile should start with.
+    const blank = { ...(newProfileDefaults ?? { active: true }), name: "New Profile" };
     fields.forEach((f) => (blank[f.key] = ""));
     replaceCard({ ...card, [dataPath]: [...stats, blank] });
   };

--- a/src/Components/Viewer/MobileEditor/sections/WargearOptionsSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/WargearOptionsSection.jsx
@@ -1,0 +1,103 @@
+import { Plus, Trash2 } from "lucide-react";
+import { EditorAccordion } from "../shared/EditorAccordion";
+import { EditorNumberField } from "../shared/EditorNumberField";
+import { EditorTextField } from "../shared/EditorTextField";
+
+/**
+ * Structured wargear groups (11e `wargearOptions`): an instruction plus the
+ * swaps it offers, each with a points cost.
+ *
+ * These are what the card back lists and what the list builder charges points
+ * for, so they win over the free-form `wargear` sentences whenever a card has
+ * any — the resolver shows one or the other, never both, mirroring the desktop
+ * panel. Costs stay strings, the shape the datasource uses.
+ */
+export const WargearOptionsSection = ({ card, label, icon, replaceCard }) => {
+  const groups = card.wargearOptions || [];
+
+  const setGroups = (updated) => replaceCard({ ...card, wargearOptions: updated });
+
+  const updateGroup = (groupIndex, changes) => {
+    const updated = [...groups];
+    updated[groupIndex] = { ...updated[groupIndex], ...changes };
+    setGroups(updated);
+  };
+
+  const updateOption = (groupIndex, optionIndex, changes) => {
+    const options = [...(groups[groupIndex]?.options || [])];
+    options[optionIndex] = { ...options[optionIndex], ...changes };
+    updateGroup(groupIndex, { options });
+  };
+
+  const removeOption = (groupIndex, optionIndex) => {
+    const options = (groups[groupIndex]?.options || []).filter((_, i) => i !== optionIndex);
+    updateGroup(groupIndex, { options });
+  };
+
+  const addOption = (groupIndex) => {
+    updateGroup(groupIndex, { options: [...(groups[groupIndex]?.options || []), { name: "", cost: "0" }] });
+  };
+
+  return (
+    <EditorAccordion title={label} icon={icon} badge={groups.length}>
+      {groups.map((group, groupIndex) => (
+        <div key={groupIndex} className="mobile-editor-ability-item">
+          <div className="mobile-editor-ability-header">
+            <label className="mobile-editor-field-label">Option {groupIndex + 1}</label>
+            <button
+              className="mobile-editor-weapon-delete"
+              onClick={() => setGroups(groups.filter((_, i) => i !== groupIndex))}
+              type="button">
+              <Trash2 size={14} />
+            </button>
+          </div>
+          <EditorTextField
+            label="Instruction"
+            value={group.instruction}
+            onChange={(value) => updateGroup(groupIndex, { instruction: value })}
+            placeholder="e.g. This model's boltgun can be replaced with one of the following:"
+            multiline
+          />
+          {(group.options || []).map((option, optionIndex) => (
+            <div
+              key={optionIndex}
+              style={{ display: "flex", gap: 8, alignItems: "flex-end", marginBottom: 8 }}
+              aria-label={`Option ${optionIndex + 1}`}>
+              <div style={{ flex: "1 1 auto", minWidth: 0 }}>
+                <EditorTextField
+                  value={option.name}
+                  onChange={(value) => updateOption(groupIndex, optionIndex, { name: value })}
+                  placeholder={`Swap ${optionIndex + 1}`}
+                />
+              </div>
+              <div style={{ flex: "0 0 72px" }}>
+                <EditorNumberField
+                  label="Pts"
+                  value={option.cost ?? ""}
+                  onChange={(value) => updateOption(groupIndex, optionIndex, { cost: value })}
+                />
+              </div>
+              <button
+                className="mobile-editor-weapon-delete"
+                onClick={() => removeOption(groupIndex, optionIndex)}
+                type="button">
+                <Trash2 size={14} />
+              </button>
+            </div>
+          ))}
+          <button className="mobile-editor-add-btn" onClick={() => addOption(groupIndex)} type="button">
+            <Plus size={14} />
+            <span>Add Swap</span>
+          </button>
+        </div>
+      ))}
+      <button
+        className="mobile-editor-add-btn"
+        onClick={() => setGroups([...groups, { instruction: "", options: [] }])}
+        type="button">
+        <Plus size={14} />
+        <span>Add Wargear Option</span>
+      </button>
+    </EditorAccordion>
+  );
+};

--- a/src/Components/Viewer/MobileEditor/shared/EditorTextField.jsx
+++ b/src/Components/Viewer/MobileEditor/shared/EditorTextField.jsx
@@ -4,7 +4,15 @@ import { useState, useRef, useEffect } from "react";
  * Auto-saving text input with debounce.
  * Debounces onChange by 300ms, but always flushes on blur.
  */
-export const EditorTextField = ({ label, value, onChange, placeholder, multiline = false, className = "" }) => {
+export const EditorTextField = ({
+  label,
+  value,
+  onChange,
+  placeholder,
+  multiline = false,
+  disabled = false,
+  className = "",
+}) => {
   const [localValue, setLocalValue] = useState(value ?? "");
   const timerRef = useRef(null);
   const onChangeRef = useRef(onChange);
@@ -57,6 +65,7 @@ export const EditorTextField = ({ label, value, onChange, placeholder, multiline
         onChange={handleChange}
         onBlur={handleBlur}
         placeholder={placeholder}
+        disabled={disabled}
         rows={multiline ? 3 : undefined}
       />
     </div>

--- a/src/Components/Viewer/MobileEditor/shared/nameObjects.js
+++ b/src/Components/Viewer/MobileEditor/shared/nameObjects.js
@@ -1,0 +1,29 @@
+/**
+ * Helpers for chip lists whose entries are `{ name }` objects instead of bare
+ * strings.
+ *
+ * 11th edition core / faction abilities and unit keywords are objects because
+ * their text is language-keyed; the language projection resolves the text but
+ * keeps the object so it can carry its `__i18n` sidecar (see localizedCard.js).
+ * The chip editor works in plain strings, so these two helpers convert in both
+ * directions.
+ */
+
+export const nameObjectLabel = (item) => (typeof item === "string" ? item : (item?.name ?? ""));
+
+/**
+ * Map an edited chip list back onto the original entries so each survivor keeps
+ * everything else it carries — above all its language map.
+ *
+ * The chip editor only ever removes an entry or appends one, never renames in
+ * place, so matching the remaining labels in order is enough to tell a survivor
+ * from a newly typed chip.
+ */
+export const alignNameObjects = (items, labels) => {
+  const remaining = [...items];
+  return labels.map((label) => {
+    const index = remaining.findIndex((item) => nameObjectLabel(item) === label);
+    if (index === -1) return { name: label };
+    return remaining.splice(index, 1)[0];
+  });
+};

--- a/src/Components/Viewer/MobileEditor/weapons/WeaponListView.jsx
+++ b/src/Components/Viewer/MobileEditor/weapons/WeaponListView.jsx
@@ -14,11 +14,14 @@ export const WeaponListView = ({ card, weaponTypeKey, config, replaceCard, onEdi
 
   const handleAdd = () => {
     if (profileBased) {
-      const profile = { name: "New Weapon", active: true, keywords: [] };
+      // 10e/custom weapons and profiles carry an `active` flag and 40k weapons
+      // an `abilities` array; 11e carries neither unless the weapon actually has
+      // abilities, so the resolver supplies the keys a blank entry starts with.
+      const profile = { ...(config.newProfileDefaults ?? { active: true }), name: "New Weapon", keywords: [] };
       columns?.forEach((col) => (profile[col.key] = ""));
-      const blank = { active: true, profiles: [profile] };
-      if (format === "40k") blank.abilities = [];
-      setWeapons([...weapons, blank]);
+      const weaponDefaults =
+        config.newWeaponDefaults ?? (format === "40k" ? { active: true, abilities: [] } : { active: true });
+      setWeapons([...weapons, { ...weaponDefaults, profiles: [profile] }]);
       return;
     }
 

--- a/src/Components/Viewer/MobileEditor/weapons/WeaponProfileEditor.jsx
+++ b/src/Components/Viewer/MobileEditor/weapons/WeaponProfileEditor.jsx
@@ -90,6 +90,10 @@ const ProfileWeaponEditor = ({ weapons, weaponIndex, profileIndex, columns, conf
   if (!profile) return null;
 
   const hasKeywords = config.hasKeywords !== false;
+  // 11e profiles have no `active` flag (every profile is rendered), but their
+  // weapons can carry named abilities shown under the profiles on the card.
+  const hasActiveFlag = config.hasActiveFlag !== false;
+  const hasWeaponAbilities = config.hasWeaponAbilities === true;
   const isParentChild = config.profileRelation === "parent-child";
   const childLabel = config.profileChildLabel || "Upgrade";
 
@@ -104,7 +108,7 @@ const ProfileWeaponEditor = ({ weapons, weaponIndex, profileIndex, columns, conf
   const addProfile = () => {
     const isUpgrade = isParentChild;
     const baseName = isUpgrade ? `${childLabel} ${profiles.length}` : `Profile ${profiles.length + 1}`;
-    const blank = { name: baseName, active: true, keywords: [] };
+    const blank = { ...(config.newProfileDefaults ?? { active: true }), name: baseName, keywords: [] };
     if (isUpgrade) blank.upgrade = true;
     columns?.forEach((col) => (blank[col.key] = ""));
     const updatedWeapons = [...weapons];
@@ -151,17 +155,37 @@ const ProfileWeaponEditor = ({ weapons, weaponIndex, profileIndex, columns, conf
         ))}
       </div>
 
-      <EditorToggle
-        label="Active"
-        checked={profile.active !== false}
-        onChange={(value) => updateProfile("active", value)}
-      />
+      {hasActiveFlag && (
+        <EditorToggle
+          label="Active"
+          checked={profile.active !== false}
+          onChange={(value) => updateProfile("active", value)}
+        />
+      )}
 
       {hasKeywords && (
         <EditorTagInput
           label="Keywords"
           tags={normalizeKeywords(profile.keywords)}
           onChange={(tags) => updateProfile("keywords", tags)}
+        />
+      )}
+
+      {hasWeaponAbilities && (
+        <WeaponAbilitiesEditor
+          weapon={weapon}
+          onChange={(abilities) => {
+            const updatedWeapons = [...weapons];
+            // A weapon with no abilities carries no `abilities` key at all in
+            // the source data, so clearing the last one removes the key again.
+            if (abilities.length === 0) {
+              const { abilities: _emptied, ...rest } = weapon;
+              updatedWeapons[weaponIndex] = rest;
+            } else {
+              updatedWeapons[weaponIndex] = { ...weapon, abilities };
+            }
+            setWeapons(updatedWeapons);
+          }}
         />
       )}
 
@@ -269,6 +293,55 @@ const FlatWeaponEditor = ({ weapons, weaponIndex, columns, config, setWeapons })
           onChange={(tags) => updateWeapon("keywords", tags)}
         />
       )}
+    </div>
+  );
+};
+
+// Abilities that apply to a whole weapon rather than one profile (Overcharge,
+// ...), rendered under the profiles on an 11e card.
+const WeaponAbilitiesEditor = ({ weapon, onChange }) => {
+  const abilities = Array.isArray(weapon.abilities) ? weapon.abilities : [];
+
+  const updateAbility = (index, field, value) => {
+    const updated = [...abilities];
+    updated[index] = { ...updated[index], [field]: value };
+    onChange(updated);
+  };
+
+  return (
+    <div>
+      <label className="mobile-editor-field-label">Weapon Abilities</label>
+      {abilities.map((ability, index) => (
+        <div key={index} className="mobile-editor-ability-item">
+          <div className="mobile-editor-ability-header">
+            <EditorTextField
+              value={ability.name}
+              onChange={(value) => updateAbility(index, "name", value)}
+              placeholder="Ability name"
+              className="mobile-editor-ability-name-input"
+            />
+            <button
+              className="mobile-editor-weapon-delete"
+              onClick={() => onChange(abilities.filter((_, i) => i !== index))}
+              type="button">
+              <Trash2 size={14} />
+            </button>
+          </div>
+          <EditorTextField
+            value={ability.description}
+            onChange={(value) => updateAbility(index, "description", value)}
+            placeholder="Description"
+            multiline
+          />
+        </div>
+      ))}
+      <button
+        className="mobile-editor-add-btn"
+        onClick={() => onChange([...abilities, { name: "New Ability", description: "" }])}
+        type="button">
+        <Plus size={14} />
+        <span>Add Weapon Ability</span>
+      </button>
     </div>
   );
 };

--- a/src/Pages/ViewerMobile.jsx
+++ b/src/Pages/ViewerMobile.jsx
@@ -36,6 +36,7 @@ import { useViewerNavigation } from "../Hooks/useViewerNavigation";
 import { useMobileSharing } from "../Hooks/useMobileSharing";
 import { useRecentSearches } from "../Hooks/useRecentSearches";
 import { useScrollRevealHeader } from "../Hooks/useScrollRevealHeader";
+import { getCardName } from "../Helpers/localization.helpers";
 
 const { Content } = Layout;
 const { useBreakpoint } = Grid;
@@ -107,10 +108,7 @@ export const ViewerMobile = ({
   const listCard = location.state?.listCard;
   const cloudCard = location.state?.cloudCard;
   const editableCard = listCard || cloudCard;
-  // 11th edition cards are desktop-edit only for now: the mobile editor has no
-  // 40k-11e resolver, and its generic fallback would overwrite language-keyed
-  // fields with plain strings.
-  const isEditableCard = !!editableCard && activeCard?.source !== "40k-11e";
+  const isEditableCard = !!editableCard;
 
   // Load custom datasource schema for the editor (only when editing a custom DS card)
   const [editorSchema, setEditorSchema] = useState(null);
@@ -414,7 +412,10 @@ export const ViewerMobile = ({
                     updateActiveCard(updatedCard, true);
                     // Build URL from updated name so useViewerNavigation can match it
                     const factionSlug = cardFaction?.name?.toLowerCase().replaceAll(" ", "-");
-                    const cardSlug = updatedCard.name?.toLowerCase().replaceAll(" ", "-");
+                    // 11e names arrive from the datasource already resolved to a
+                    // plain string, but a card stored before that could still hold
+                    // a language-keyed object.
+                    const cardSlug = getCardName(updatedCard, settings.language)?.toLowerCase().replaceAll(" ", "-");
                     const newPath = factionSlug && cardSlug ? `/mobile/${factionSlug}/${cardSlug}` : location.pathname;
                     const stateKey = listCard ? "listCard" : "cloudCard";
                     navigate(newPath, { replace: true, state: { [stateKey]: updatedCard } });


### PR DESCRIPTION
Three related mobile changes, described in the order they were found. The first is the original task; the other two came out of working on it.

---

## 1. 11th edition card editing on mobile

### The problem

Cards added to an 11th edition list on mobile had no Edit button. `ViewerMobile` gated the edit affordance on `activeCard?.source !== "40k-11e"`, added deliberately in 80ac39e: the mobile editor had no `40k-11e` resolver, and its generic fallback would have flattened language-keyed fields (`{ en: …, de: … }`) into plain strings, dropping every other language.

### The approach

Rather than teaching all sixteen section components to read through `localize` and write through `setLocalizedField`, the editor now works on a **projection** of the card (`src/Components/Viewer/MobileEditor/localizedCard.js`):

```
projectCard(card, spec, language)  ->  localized fields resolved to plain strings
mergeCard(view, spec, language)    ->  folded back, other languages untouched
```

`getLocalizationSpec` returns `null` for every single-language source, so 10e, AoS and custom datasources take exactly the path they did before.

Two details make the round trip safe:

- **`__i18n` sidecar.** Sections add, remove and reorder array items, so the nth entry of the edited view is not necessarily the nth entry of the card — merging by index would fold one keyword's text into another keyword's translations. Each field's original language map therefore rides along on the object that owns it, and travels with its entry through deletions and reorders. Entries with no sidecar are new, and are seeded as `{ [language]: value }`. The merge strips every sidecar, so none reaches storage.
- **Untouched fields are restored, not rewritten.** Language coverage in the 11e data is uneven, so a field with only English projects as its English fallback. Writing that back would stamp a copy of the English text into the active language on every save. A field whose text still equals its projection is restored exactly as it came in.

Fields absent from the spec pass through untouched, which is how the plain ones stay plain: a unit's `name`/`subname`, `factions[]`, weapon keywords and numeric stats, `abilities.invul.value`, and an enhancement's `keywords`/`excludes` (matched in English by the list builder).

Card classification goes through one shared `classify11eCard` helper, so the spec a card's text is merged against and the sections it is edited through can never disagree.

### Coverage

Units (stats, points with detachment/faction restrictions and the per-copy surcharge, weapons and profiles, weapon abilities, core/faction/other/wargear/special abilities, Primarch abilities, damaged profile, invulnerable save, wargear options, composition, loadout, leader, transport, keywords), plus stratagems, enhancements and rules.

The shapes 11e does not share with 10e are passed to the shared sections as config rather than branched on inside them — no `active`/`show*` flags, `{ name }` objects for core/faction abilities and keywords, points tiers, per-weapon abilities. Structured `wargearOptions` groups get their own section and are edited instead of the free-form `wargear` sentences whenever a card has them, matching the renderer and the desktop panel.

Not included: the desktop panel visibility switches (`showWeapons`, `showAbilities`, …), which the mobile editor does not expose for 10e either.

---

## 2. CI: push and pull_request runs were cancelling each other

A branch with an open PR fires `ci.yml` twice — once for `push`, once for `pull_request` — and both resolved to the same `concurrency` group (`github.ref_name` and `github.event.pull_request.head.ref` are the same string for a same-repo branch). With `cancel-in-progress: true` they cancelled each other, and only the `pull_request` run executes the `test` job. So whenever the push run won the race, **the PR reported green having run no tests at all.**

That is not hypothetical — it happened on this branch:

| Head | `push` run | `pull_request` run | Tests ran? |
|---|---|---|---|
| 5a5406a | 847 cancelled | 848 success | yes |
| afa936d | 849 success (`test` skipped) | 850 cancelled | **no** |

Keying the group on `github.event_name` as well lets the two runs stand alongside each other, while a second push to the same branch still cancels its own predecessor. Confirmed working on the two heads since. Cost: `Lint` runs twice on PR branches.

This is not specific to this branch — any PR in the repo where the push run won the race merged on a green badge with no test run behind it.

---

## 3. Sharing cloud categories from the mobile list overview

The "..." menu offered **Copy List** for every list but **Share List** only for local ones. The share sheet was hard-wired to `currentList` (the selected *local* list) and gated on `!isCloudCategory` in two places — so simply un-hiding the button would have shared a different list entirely. That is why both gates existed.

The category to share is now derived from what the overview is actually rendering, and the menu item is gated on there being one:

```js
const shareCategory = isCloudCategory ? selectedCloudCategory : currentList;
```

A cloud category shares the object the overview renders, so the link always contains what is on screen. It carries the same `uuid` as its local mirror, so `getExistingShare` still finds a share created on desktop and can update it from either device. Local-list sharing is unchanged.

`ListShareSheet` itself needed no change — it only reads `uuid`, `name` and `cards`. One addition: a failed share now shows why instead of doing nothing. That was previously silent, which matters more now that cloud categories reach this sheet and can exceed the 100-card limit `useCategorySharing` enforces.

---

## Testing

| File | Tests |
|---|---|
| `localizedCard.test.js` | 23 — projection, merge, round-trip identity, translations surviving removals and reorders, seeding, the null/omit rules, card classification |
| `MobileCardEditor11e.test.jsx` | 9 — the real editor with a real 11e card: localized display, edits landing in the active language only, plain names staying plain, no sidecar in saved data, the weapon drill-down and weapon abilities |
| `ListOverview.test.jsx` | 7 — local vs cloud sharing, the exact object handed to `shareOwned`/`shareAnonymous`, existing-share lookup by uuid, the item hidden when there is nothing to share, the failure message |
| `nameObjects.test.js` | 5 — chip-list alignment |
| `editorSchemaResolvers.test.js` | 10 new cases for the 11e resolver |

`yarn test:ci` 3329 passing (3274 on a clean `main`), `yarn lint` clean.

Note `releaseFragments.test.js` generates one test per file in `changes/unreleased/`, so the two fragments in this PR each add one and get schema-validated by it.

`yarn build` fails in the sandbox this was written in on a blocked Google Fonts import in `starcraft-tmg.less` — identical on a clean tree, unrelated to this change.

**Not verified against live data:** the datasource and Supabase fetches are blocked in that sandbox. The editor and sharing tests render the real components against real card and category shapes, but a hands-on pass on an actual 11e card and an actual cloud category is the gap they do not close.

## Docs

New `docs/mobile-card-editor.md` (indexed, cross-linked from `docs/40k-11e-card-editing.md`), and a release fragment in `changes/unreleased/` for each user-facing change.