### PR TITLE
Fix melee weapon keywords wrapping into the name column

### DIFF
--- a/changes/unreleased/melee-weapon-keyword-layout.json
+++ b/changes/unreleased/melee-weapon-keyword-layout.json
@@ -1,0 +1,5 @@
+{
+  "title": "Melee weapon keywords line up with ranged",
+  "body": "On 10th and 11th edition datasheets, a melee weapon with a long keyword list folded those keywords into a stack under the weapon name, while a ranged weapon kept them on one line. Melee weapons now read the same as ranged: the keywords run on in a single line under the characteristics, and the characteristic columns stay lined up with their headings.",
+  "severity": "info"
+}

--- a/src/styles/40k-10e.less
+++ b/src/styles/40k-10e.less
@@ -2332,6 +2332,14 @@
                   letter-spacing: normal;
                   z-index: 2;
 
+                  // A grid track's automatic minimum is its content's
+                  // min-content width, and the keyword list below is `nowrap`.
+                  // Without this the name column stretches to fit the keywords
+                  // and shoves the characteristic columns out of line with
+                  // their header; with it the keywords simply run on underneath
+                  // them.
+                  min-width: 0;
+
                   .name {
                     white-space: pre-line;
                   }
@@ -2412,8 +2420,21 @@
                   letter-spacing: normal;
                   z-index: 2;
 
+                  // A grid track's automatic minimum is its content's
+                  // min-content width, and the keyword list below is `nowrap`.
+                  // Without this the name column stretches to fit the keywords
+                  // and shoves the characteristic columns out of line with
+                  // their header; with it the keywords simply run on underneath
+                  // them.
+                  min-width: 0;
+
+                  // Keep the keyword list on one line, exactly as the ranged
+                  // block does. The keywords are inline-block buttons, so
+                  // without this they break between tags and fold into the
+                  // narrow name column instead of running on under the
+                  // characteristic columns.
                   .keyword {
-                    // white-space: nowrap;
+                    white-space: nowrap;
                   }
                 }
               }
@@ -3525,6 +3546,10 @@
                     letter-spacing: normal;
                     z-index: 2;
 
+                    // See the printed-card block: keeps the nowrap keyword list
+                    // from widening the name column.
+                    min-width: 0;
+
                     .name {
                       white-space: pre-line;
                     }
@@ -3625,6 +3650,10 @@
                     font-weight: 400;
                     letter-spacing: normal;
                     z-index: 2;
+
+                    // See the printed-card block: keeps the nowrap keyword list
+                    // from widening the name column.
+                    min-width: 0;
 
                     .keyword {
                       white-space: nowrap;

--- a/src/styles/__tests__/weaponKeywords.styles.test.js
+++ b/src/styles/__tests__/weaponKeywords.styles.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import less from "less";
+
+// The 10e/11e weapon row renders its keyword list as a `.keyword` span of
+// inline-block buttons inside the (narrow) name column. `white-space: nowrap`
+// is what keeps that list on one line so it runs on under the characteristic
+// columns; without it the list folds inside the name column and the row grows.
+// The melee block used to carry the rule commented out, so melee and ranged
+// weapons laid their keywords out differently on the same card.
+const STYLE_FILE = resolve(process.cwd(), "src/styles/40k-10e.less");
+
+const CARD = ".unit .data_container .data .weapons";
+const VIEWER = ".viewer .unit .data_container .data .weapons";
+const CELL = ".weapon .line .value";
+const KEYWORD = `${CELL} .keyword`;
+
+let css = "";
+
+beforeAll(async () => {
+  const source = readFileSync(STYLE_FILE, "utf8");
+  const output = await less.render(source, { filename: STYLE_FILE, paths: [dirname(STYLE_FILE)] });
+  css = output.css;
+});
+
+// Returns the declaration block of the rule whose selector list contains
+// exactly `selector`. Matching on a whole selector matters: the printed card
+// selector is a suffix of the mobile viewer one, so a substring search would
+// silently answer for the wrong rule.
+const ruleBody = (selector) => {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`(?:^|[\\n,])\\s*${escaped}\\s*[,{][^}]*}`, "m").exec(css);
+  if (!match) return null;
+  return match[0].slice(match[0].indexOf("{") + 1, -1);
+};
+
+describe("40k 10e/11e weapon keyword layout", () => {
+  it.each([
+    ["ranged", "printed card", `.data-40k-10e ${CARD} .ranged ${KEYWORD}`],
+    ["melee", "printed card", `.data-40k-10e ${CARD} .melee ${KEYWORD}`],
+    ["ranged", "mobile viewer", `.data-40k-10e ${VIEWER} .ranged ${KEYWORD}`],
+    ["melee", "mobile viewer", `.data-40k-10e ${VIEWER} .melee ${KEYWORD}`],
+  ])("keeps %s weapon keywords on one line on the %s", (_type, _surface, selector) => {
+    const body = ruleBody(selector);
+
+    expect(body, `${selector} should be present in the compiled stylesheet`).not.toBeNull();
+    expect(body).toContain("white-space: nowrap");
+  });
+
+  // A grid track's automatic minimum is its content's min-content width, so a
+  // nowrap keyword list widens the name column and drags the characteristic
+  // columns out of line with their header row unless the cell can shrink.
+  it.each([
+    ["ranged", "printed card", `.data-40k-10e ${CARD} .ranged ${CELL}`],
+    ["melee", "printed card", `.data-40k-10e ${CARD} .melee ${CELL}`],
+    ["ranged", "mobile viewer", `.data-40k-10e ${VIEWER} .ranged ${CELL}`],
+    ["melee", "mobile viewer", `.data-40k-10e ${VIEWER} .melee ${CELL}`],
+  ])("lets the %s name column shrink on the %s", (_type, _surface, selector) => {
+    expect(ruleBody(selector)).toContain("min-width: 0");
+  });
+
+  it("applies the same rules to 11th edition", () => {
+    expect(ruleBody(`.data-40k-11e ${CARD} .melee ${KEYWORD}`)).toContain("white-space: nowrap");
+    expect(ruleBody(`.data-40k-11e ${CARD} .melee ${CELL}`)).toContain("min-width: 0");
+  });
+});


### PR DESCRIPTION
## Proposed Changes

On a 10th/11th edition datasheet, a melee weapon with a long keyword list folded its keywords into a stack inside the weapon-name column, while a ranged weapon on the same card kept them on one line running under the characteristic columns.

Root cause: in `src/styles/40k-10e.less`, the melee weapon row had its keyword rule commented out —

```less
.keyword {
  // white-space: nowrap;
}
```

— while the ranged row a few lines above declared `white-space: nowrap`. Keywords render as a row of inline-block `.keyword-button`s, so without `nowrap` the browser breaks between tags and wraps them inside the ~50%-wide name cell, growing the row. It was the only commented-out `white-space` rule in the stylesheet.

Restoring `nowrap` alone surfaced a second, latent problem that ranged already had: a grid track's automatic minimum is its content's min-content width, so a `nowrap` keyword list widens the name column and drags the characteristic values out of line with their header row (which is a separate grid). Both rows now also set `min-width: 0` on the line cells, so the keywords overflow visually under the characteristics instead of pushing them sideways.

Both edits are applied to the ranged and melee blocks in the printed-card and mobile-viewer sections. The rules are scoped under `.data-40k-10e` and `.data-40k-11e`, so 11th edition — which shares this stylesheet — is fixed too.

Also adds `changes/unreleased/melee-weapon-keyword-layout.json` so the release workflow ships the patch bump and notification note.

Verified by compiling the stylesheet and rendering the exact DOM `UnitWeapon` emits: melee keywords now sit on one line under the characteristics, and both rows stay aligned with their headings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes

`yarn lint` clean; `yarn test:ci` 3284 tests passing, including a new `src/styles/__tests__/weaponKeywords.styles.test.js` that compiles the LESS and asserts both weapon types declare the same keyword rules on both surfaces and both editions. That test fails on the two melee cases before the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_013eNBCaxyfuang99c9Vmc1M)_