### PR TITLE
Fix faction symbol saving and resolution

### DIFF
--- a/changes/unreleased/faction-symbols.json
+++ b/changes/unreleased/faction-symbols.json
@@ -1,0 +1,5 @@
+{
+  "title": "Faction symbols stay on your datacards",
+  "body": "Switching the custom faction symbol on or off, uploading one, or removing it saved the card as it was before the change, so the setting flipped back after a reload and the symbol could not be replaced. Those actions now save what you actually did. Custom symbols also work on 11th edition cards, where the switch used to do nothing, and cards that showed an empty badge - 11th edition datasheets and cards from a custom datasource - now fall back to the symbol of the faction printed on the card.",
+  "severity": "info"
+}

--- a/docs/card-data-formats.md
+++ b/docs/card-data-formats.md
@@ -32,6 +32,7 @@ All text fields support Markdown formatting unless noted otherwise.
   - [Gangers](#gangers)
   - [Vehicles](#vehicles)
 - [Basic Cards](#basic-cards)
+- [Faction Symbols](#faction-symbols)
 - [Key Differences Between Systems](#key-differences-between-systems)
 
 ---
@@ -195,6 +196,14 @@ There are four `cardType` values:
   "imageZIndex": 0,
   "imagePositionX": 0,
   "imagePositionY": 0,
+
+  // Faction symbol (see "Faction Symbols" below)
+  "hasCustomFactionSymbol": false,  // Replace the default symbol
+  "externalFactionSymbol": null,    // URL string or null
+  "customFactionSymbolFilename": null,
+  "factionSymbolScale": 0.8,
+  "factionSymbolPositionX": 0,
+  "factionSymbolPositionY": 0,
 
   // Custom colours
   "useCustomColours": false,
@@ -721,6 +730,31 @@ Basic cards use the 9th edition stat format and serve as general-purpose templat
 ```
 
 Basic datasources can also include `stratagems`, `secondaries`, and `psychicpowers` using the 9th edition format.
+
+---
+
+
+## Faction Symbols
+
+The symbol in the diamond badge on a 40k datacard is an SVG from the legacy
+`40k-Data-Card` repository, addressed by a short code (`CSM`, `CHUL`, `TAU`).
+
+Resolution order, implemented in `src/Helpers/factionSymbol.helpers.js`:
+
+1. A card with `hasCustomFactionSymbol: true` uses its own symbol — the image
+   stored in IndexedDB under `faction-<card uuid>`, or `externalFactionSymbol`
+   when there is no uploaded one. With neither, the default symbol below is used,
+   so enabling the switch never leaves a card without a symbol.
+2. `faction_id`, but only when it already is a symbol code. 10th edition
+   datasheets carry one; 11th edition faction ids are UUIDs and custom
+   datasource faction ids are slugs, and those are skipped.
+3. The faction name(s): the card's `factions` (or `factionKeywords`) entries,
+   most specific first, then the datasource faction name. Names are matched
+   case- and punctuation-insensitively, and sub-factions map onto their parent's
+   symbol (`Farsight Enclaves` to `TAU`, `Heretic Astartes` to `CSM`).
+
+Candidates are tried in order and the first one that resolves to an SVG wins, so
+a faction without a symbol of its own still falls back to its parent's.
 
 ---
 

--- a/src/Components/AgeOfSigmar/WarscrollCardEditor/WarscrollStylingInfo.jsx
+++ b/src/Components/AgeOfSigmar/WarscrollCardEditor/WarscrollStylingInfo.jsx
@@ -67,10 +67,7 @@ export function WarscrollStylingInfo() {
         localImageFilename: actualFile.name,
       };
       updateActiveCard(updatedCard);
-
-      setTimeout(() => {
-        saveActiveCard();
-      }, 100);
+      saveActiveCard(updatedCard);
 
       setLocalImageInfo({
         filename: actualFile.name,
@@ -92,15 +89,9 @@ export function WarscrollStylingInfo() {
 
     try {
       await deleteImage(activeCard.uuid);
-      updateActiveCard({
-        ...activeCard,
-        hasLocalImage: false,
-        localImageFilename: null,
-      });
-
-      setTimeout(() => {
-        saveActiveCard();
-      }, 100);
+      const updatedCard = { ...activeCard, hasLocalImage: false, localImageFilename: null };
+      updateActiveCard(updatedCard);
+      saveActiveCard(updatedCard);
 
       setLocalImageInfo(null);
       message.success("Local image removed");

--- a/src/Components/DatasourceEditor/cards/Ds40kRuleCard.jsx
+++ b/src/Components/DatasourceEditor/cards/Ds40kRuleCard.jsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import { ReactFitty } from "react-fitty";
 import { MarkdownDisplay } from "../../MarkdownDisplay";
+import { buildFactionIconCandidates, factionNamesFromCard } from "../../../Helpers/factionSymbol.helpers";
 import { FactionIcon } from "../../Icons/FactionIcon";
 
 const formatRuleText = (text) => {
@@ -104,7 +105,12 @@ export const Ds40kRuleCard = ({ card, cardTypeDef, cardStyle, isMobile }) => {
             <div className="containers">
               <div className="rule-type-indicator">
                 <div className="faction-icon">
-                  <FactionIcon factionId={card.faction_id} />
+                  <FactionIcon
+                    factionId={buildFactionIconCandidates({
+                      factionId: card.faction_id,
+                      names: factionNamesFromCard(card),
+                    })}
+                  />
                 </div>
               </div>
             </div>

--- a/src/Components/Icons/CustomFactionSymbol.jsx
+++ b/src/Components/Icons/CustomFactionSymbol.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+import { useIndexedDBImages } from "../../Hooks/useIndexedDBImages";
+
+const SymbolImage = styled.div`
+  width: 100%;
+  height: 100%;
+  background-image: url(${(props) => props.$imageUrl});
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-position: center;
+  filter: invert(0%) sepia(2%) saturate(0%) hue-rotate(253deg) brightness(100%) contrast(100%);
+  rotate: -45deg;
+  scale: ${(props) => props.$scale || 0.8};
+  transform: translate(${(props) => props.$positionX || 0}px, ${(props) => props.$positionY || 0}px);
+`;
+
+/**
+ * Object URL for a card's uploaded faction symbol, or null when the card has no
+ * custom symbol (or it has not been stored yet). Shared by every renderset so a
+ * symbol uploaded in the styling editor shows up on all editions.
+ */
+export const useCustomFactionSymbolUrl = (card) => {
+  const { getFactionSymbolUrl, isReady } = useIndexedDBImages();
+  const [symbolUrl, setSymbolUrl] = useState(null);
+
+  const uuid = card?.uuid;
+  const enabled = card?.hasCustomFactionSymbol;
+
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl = null;
+
+    const loadCustomSymbol = async () => {
+      if (!enabled || !uuid || !isReady) {
+        setSymbolUrl(null);
+        return;
+      }
+      try {
+        const url = await getFactionSymbolUrl(uuid);
+        if (!url) return;
+        // The effect can be torn down while the lookup is in flight; revoke the
+        // url straight away in that case instead of leaking it.
+        if (cancelled) {
+          URL.revokeObjectURL(url);
+          return;
+        }
+        objectUrl = url;
+        setSymbolUrl(url);
+      } catch (error) {
+        // Failed to load custom faction symbol
+      }
+    };
+
+    loadCustomSymbol();
+
+    return () => {
+      cancelled = true;
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
+    // getFactionSymbolUrl is recreated on every render of the hook; depending on
+    // it would re-run this effect forever.
+  }, [uuid, enabled, isReady]);
+
+  return symbolUrl;
+};
+
+/** The uploaded (or externally linked) faction symbol, scaled and positioned. */
+export const CustomFactionSymbol = ({ card, imageUrl }) => (
+  <SymbolImage
+    $imageUrl={imageUrl}
+    $scale={card?.factionSymbolScale}
+    $positionX={card?.factionSymbolPositionX}
+    $positionY={card?.factionSymbolPositionY}
+  />
+);

--- a/src/Components/Icons/FactionIcon.jsx
+++ b/src/Components/Icons/FactionIcon.jsx
@@ -52,41 +52,73 @@ const sanitizeSvg = (raw) => {
   return svg.outerHTML;
 };
 
-// Cache for fetched SVG content to avoid re-fetching
+// Cache for fetched SVG content to avoid re-fetching. Misses are cached as null
+// so a faction without a symbol is not re-requested on every render.
 const svgCache = new Map();
 
+const BASE_URL = "https://raw.githubusercontent.com/ronplanken/40k-Data-Card/master/src/dc";
+
+const fetchSvg = async (factionId) => {
+  const url = `${BASE_URL}/${factionId}.svg`;
+  if (svgCache.has(url)) return svgCache.get(url);
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) throw new Error("Failed to fetch");
+    const cleaned = sanitizeSvg(await response.text());
+    svgCache.set(url, cleaned);
+    return cleaned;
+  } catch {
+    svgCache.set(url, null);
+    return null;
+  }
+};
+
+/**
+ * Renders a faction symbol. `factionId` accepts a single code or an ordered list
+ * of candidate codes: the first one that actually resolves to an SVG is used, so
+ * a card whose faction id is not a legacy symbol code (11th edition UUIDs,
+ * custom datasource slugs) can still fall back to a code resolved from its
+ * faction name.
+ */
 export const FactionIcon = ({ factionId, className = "", style = {} }) => {
   const [svgContent, setSvgContent] = useState(null);
   const [error, setError] = useState(false);
 
+  const candidates = (Array.isArray(factionId) ? factionId : [factionId]).filter(Boolean);
+  // Effects key off the candidate list by value; the array identity changes on
+  // every render because callers build it inline.
+  const candidateKey = candidates.join("|");
+
   useEffect(() => {
-    if (!factionId) return;
+    let cancelled = false;
 
-    const url = `https://raw.githubusercontent.com/ronplanken/40k-Data-Card/master/src/dc/${factionId}.svg`;
+    // Reset on every change so a previous miss never sticks to the next faction.
+    setSvgContent(null);
+    setError(false);
 
-    // Check cache first
-    if (svgCache.has(url)) {
-      setSvgContent(svgCache.get(url));
-      return;
-    }
+    if (!candidateKey) return undefined;
 
-    // Fetch the SVG
-    fetch(url)
-      .then((response) => {
-        if (!response.ok) throw new Error("Failed to fetch");
-        return response.text();
-      })
-      .then((svgText) => {
-        const cleaned = sanitizeSvg(svgText);
-        svgCache.set(url, cleaned);
-        setSvgContent(cleaned);
-      })
-      .catch(() => {
-        setError(true);
-      });
-  }, [factionId]);
+    const load = async () => {
+      for (const candidate of candidateKey.split("|")) {
+        const svg = await fetchSvg(candidate);
+        if (cancelled) return;
+        if (svg) {
+          setSvgContent(svg);
+          return;
+        }
+      }
+      setError(true);
+    };
 
-  if (!factionId || error) return null;
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [candidateKey]);
+
+  if (!candidateKey || error) return null;
 
   if (!svgContent) {
     // Loading state - render placeholder

--- a/src/Components/Warhammer40k-10e/RuleCard.jsx
+++ b/src/Components/Warhammer40k-10e/RuleCard.jsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import { ReactFitty } from "react-fitty";
 import { MarkdownDisplay } from "../MarkdownDisplay";
+import { buildFactionIconCandidates, factionNamesFromCard } from "../../Helpers/factionSymbol.helpers";
 import { FactionIcon } from "../Icons/FactionIcon";
 
 // Helper to convert single newlines to markdown line breaks
@@ -84,7 +85,12 @@ export const RuleCard = ({ rule, cardStyle, paddingTop = "32px", className = "ru
           <div className="containers">
             <div className="rule-type-indicator">
               <div className="faction-icon">
-                <FactionIcon factionId={rule.faction_id} />
+                <FactionIcon
+                  factionId={buildFactionIconCandidates({
+                    factionId: rule.faction_id,
+                    names: factionNamesFromCard(rule),
+                  })}
+                />
               </div>
             </div>
           </div>

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitFactionSymbol.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitFactionSymbol.jsx
@@ -1,56 +1,10 @@
-import React, { useState, useEffect } from "react";
-import styled from "styled-components";
-import { useIndexedDBImages } from "../../../Hooks/useIndexedDBImages";
+import React from "react";
+import { buildFactionIconCandidates, factionNamesFromCard } from "../../../Helpers/factionSymbol.helpers";
+import { CustomFactionSymbol, useCustomFactionSymbolUrl } from "../../Icons/CustomFactionSymbol";
 import { FactionIcon } from "../../Icons/FactionIcon";
 
-const CustomSymbol = styled.div`
-  width: 100%;
-  height: 100%;
-  background-image: url(${(props) => props.$imageUrl});
-  background-repeat: no-repeat;
-  background-size: contain;
-  background-position: center;
-  filter: invert(0%) sepia(2%) saturate(0%) hue-rotate(253deg) brightness(100%) contrast(100%);
-  rotate: -45deg;
-  scale: ${(props) => props.$scale || 0.8};
-  transform: translate(${(props) => props.$positionX || 0}px, ${(props) => props.$positionY || 0}px);
-`;
-
 export const UnitFactionSymbol = ({ unit }) => {
-  const { getFactionSymbolUrl, isReady } = useIndexedDBImages();
-  const [customSymbolUrl, setCustomSymbolUrl] = useState(null);
-
-  useEffect(() => {
-    let isMounted = true;
-    let objectUrl = null;
-
-    const loadCustomSymbol = async () => {
-      if (unit?.hasCustomFactionSymbol && unit?.uuid && isReady) {
-        try {
-          const url = await getFactionSymbolUrl(unit.uuid);
-          if (isMounted && url) {
-            objectUrl = url;
-            setCustomSymbolUrl(objectUrl);
-          }
-        } catch (error) {
-          // Failed to load custom faction symbol
-        }
-      } else {
-        if (isMounted) {
-          setCustomSymbolUrl(null);
-        }
-      }
-    };
-
-    loadCustomSymbol();
-
-    return () => {
-      isMounted = false;
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl);
-      }
-    };
-  }, [unit?.uuid, unit?.hasCustomFactionSymbol, isReady]);
+  const customSymbolUrl = useCustomFactionSymbolUrl(unit);
 
   // Determine the symbol URL (local takes priority over external)
   const symbolUrl = customSymbolUrl || unit?.externalFactionSymbol;
@@ -59,21 +13,23 @@ export const UnitFactionSymbol = ({ unit }) => {
   if (unit?.hasCustomFactionSymbol && symbolUrl) {
     return (
       <div className="faction">
-        <CustomSymbol
-          $imageUrl={symbolUrl}
-          $scale={unit.factionSymbolScale}
-          $positionX={unit.factionSymbolPositionX}
-          $positionY={unit.factionSymbolPositionY}
-        />
+        <CustomFactionSymbol card={unit} imageUrl={symbolUrl} />
       </div>
     );
   }
 
-  // Otherwise render default faction symbol using FactionIcon (print-friendly)
+  // Otherwise render default faction symbol using FactionIcon (print-friendly).
+  // 10th edition faction ids are symbol codes; cards from a custom datasource
+  // carry a slug instead, so the faction keywords are offered as a fallback.
+  const candidates = buildFactionIconCandidates({
+    factionId: unit?.faction_id,
+    names: factionNamesFromCard(unit),
+  });
+
   return (
     <div className="faction">
       <div className="faction-symbol-wrapper">
-        <FactionIcon factionId={unit.faction_id} />
+        <FactionIcon factionId={candidates} />
       </div>
     </div>
   );

--- a/src/Components/Warhammer40k-10e/UnitCardEditor/UnitStylingInfo.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCardEditor/UnitStylingInfo.jsx
@@ -104,11 +104,7 @@ export function UnitStylingInfo() {
         localImageFilename: actualFile.name,
       };
       updateActiveCard(updatedCard);
-
-      // Save the card to persist the changes
-      setTimeout(() => {
-        saveActiveCard();
-      }, 100);
+      saveActiveCard(updatedCard);
 
       setLocalImageInfo({
         filename: actualFile.name,
@@ -130,16 +126,9 @@ export function UnitStylingInfo() {
 
     try {
       await deleteImage(activeCard.uuid);
-      updateActiveCard({
-        ...activeCard,
-        hasLocalImage: false,
-        localImageFilename: null,
-      });
-
-      // Save the card to persist the changes
-      setTimeout(() => {
-        saveActiveCard();
-      }, 100);
+      const updatedCard = { ...activeCard, hasLocalImage: false, localImageFilename: null };
+      updateActiveCard(updatedCard);
+      saveActiveCard(updatedCard);
 
       setLocalImageInfo(null);
       message.success("Local image removed");
@@ -181,15 +170,13 @@ export function UnitStylingInfo() {
     try {
       await saveFactionSymbol(activeCard.uuid, actualFile);
 
-      updateActiveCard({
+      const updatedCard = {
         ...activeCard,
         hasCustomFactionSymbol: true,
         customFactionSymbolFilename: actualFile.name,
-      });
-
-      setTimeout(() => {
-        saveActiveCard();
-      }, 100);
+      };
+      updateActiveCard(updatedCard);
+      saveActiveCard(updatedCard);
 
       setFactionSymbolInfo({
         filename: actualFile.name,
@@ -210,15 +197,9 @@ export function UnitStylingInfo() {
 
     try {
       await deleteFactionSymbol(activeCard.uuid);
-      updateActiveCard({
-        ...activeCard,
-        hasCustomFactionSymbol: false,
-        customFactionSymbolFilename: null,
-      });
-
-      setTimeout(() => {
-        saveActiveCard();
-      }, 100);
+      const updatedCard = { ...activeCard, hasCustomFactionSymbol: false, customFactionSymbolFilename: null };
+      updateActiveCard(updatedCard);
+      saveActiveCard(updatedCard);
 
       setFactionSymbolInfo(null);
       message.success("Faction symbol removed");
@@ -325,8 +306,9 @@ export function UnitStylingInfo() {
           <Switch
             checked={activeCard.hasCustomFactionSymbol || false}
             onChange={(value) => {
-              updateActiveCard({ ...activeCard, hasCustomFactionSymbol: value });
-              setTimeout(() => saveActiveCard(), 100);
+              const updatedCard = { ...activeCard, hasCustomFactionSymbol: value };
+              updateActiveCard(updatedCard);
+              saveActiveCard(updatedCard);
             }}
           />
         }>

--- a/src/Components/Warhammer40k-11e/RuleCard.jsx
+++ b/src/Components/Warhammer40k-11e/RuleCard.jsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import { ReactFitty } from "react-fitty";
 import { FactionIcon } from "../Icons/FactionIcon";
 import { MarkupText } from "./UnitCard/UnitAbilityDescription";
-import { resolveFactionCode } from "./UnitCard/UnitFactionSymbol";
+import { buildFactionIconCandidates } from "../../Helpers/factionSymbol.helpers";
 import { useSettingsStorage } from "../../Hooks/useSettingsStorage";
 import { useDataSourceStorage } from "../../Hooks/useDataSourceStorage";
 import { localize } from "../../Helpers/localization.helpers";
@@ -58,7 +58,7 @@ export const RuleCard = ({ rule, cardStyle, paddingTop = "32px", className = "ru
   const useAutoHeight = rule.styling?.autoHeight !== false;
 
   const faction = dataSource?.data?.find((f) => f.id === rule.faction_id);
-  const factionCode = resolveFactionCode([faction?.name]);
+  const factionCodes = buildFactionIconCandidates({ factionId: rule.faction_id, names: [faction?.name] });
 
   return (
     <div
@@ -92,7 +92,7 @@ export const RuleCard = ({ rule, cardStyle, paddingTop = "32px", className = "ru
           </div>
           <div className="containers">
             <div className="rule-type-indicator">
-              <div className="faction-icon">{factionCode && <FactionIcon factionId={factionCode} />}</div>
+              <div className="faction-icon">{factionCodes.length > 0 && <FactionIcon factionId={factionCodes} />}</div>
             </div>
           </div>
         </div>

--- a/src/Components/Warhammer40k-11e/UnitCard/UnitFactionSymbol.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCard/UnitFactionSymbol.jsx
@@ -1,85 +1,41 @@
+import React from "react";
+import { buildFactionIconCandidates, factionNamesFromCard } from "../../../Helpers/factionSymbol.helpers";
 import { useDataSourceStorage } from "../../../Hooks/useDataSourceStorage";
+import { CustomFactionSymbol, useCustomFactionSymbolUrl } from "../../Icons/CustomFactionSymbol";
 import { FactionIcon } from "../../Icons/FactionIcon";
 
-// 11th edition datasheets reference factions by UUID, but the shared FactionIcon
-// fetches `<code>.svg` using the legacy short codes. Resolve the symbol from the
-// human-readable faction name(s) instead. Falls back to no symbol when unknown.
-const NAME_TO_CODE = {
-  "adeptus custodes": "AC",
-  "adeptus titanicus": "AT",
-  aeldari: "AE",
-  "agents of the imperium": "AoI",
-  "imperial agents": "AoI",
-  agents: "AoI",
-  "alpha legion": "LGAL",
-  "astra militarum": "AM",
-  "adepta sororitas": "AS",
-  "adeptus mechanicus": "AdM",
-  "blood angels": "CHBA",
-  "black legion": "LGBL",
-  "black templar": "CHBT",
-  "black templars": "CHBT",
-  "chaos daemons": "CD",
-  "chaos knights": "QT",
-  "chaos space marines": "CSM",
-  "dark angels": "CHDA",
-  "death guard": "DG",
-  deathwatch: "CHDW",
-  drukhari: "DRU",
-  "emperor's children": "LGEC",
-  "emperors children": "LGEC",
-  "genestealer cult": "GC",
-  "genestealer cults": "GC",
-  "grey knights": "GK",
-  harlequins: "HAR",
-  "imperial fists": "CHIF",
-  "iron hands": "CHIH",
-  "imperial knights": "QI",
-  "iron warriors": "LGIW",
-  "leagues of votann": "LoV",
-  necrons: "NEC",
-  "night lords": "LGNL",
-  orks: "ORK",
-  "red corsairs": "LGRC",
-  "raven guard": "CHRG",
-  salamanders: "CHSA",
-  "space marines": "SM",
-  "adeptus astartes": "SM",
-  "space wolves": "CHSW",
-  "t'au empire": "TAU",
-  tau: "TAU",
-  "thousand sons": "TS",
-  tyranids: "TYR",
-  ultramarines: "CHUL",
-  "word bearers": "LGWB",
-  "world eaters": "WE",
-  "white scars": "CHWS",
-};
-
-export const resolveFactionCode = (names) => {
-  for (const name of names) {
-    if (!name) continue;
-    const code = NAME_TO_CODE[name.toLowerCase().trim()];
-    if (code) return code;
-  }
-  return null;
-};
-
+// 11th edition datasheets reference factions by UUID, while faction symbols are
+// addressed by the legacy short codes. The code is therefore resolved from the
+// human-readable faction name(s) - see Helpers/factionSymbol.helpers.
 export const UnitFactionSymbol = ({ unit }) => {
   const { dataSource } = useDataSourceStorage();
+  const customSymbolUrl = useCustomFactionSymbolUrl(unit);
+
+  // A locally uploaded symbol takes priority over an external URL.
+  const symbolUrl = customSymbolUrl || unit?.externalFactionSymbol;
+  if (unit?.hasCustomFactionSymbol && symbolUrl) {
+    return (
+      <div className="faction">
+        <CustomFactionSymbol card={unit} imageUrl={symbolUrl} />
+      </div>
+    );
+  }
+
   const faction = dataSource?.data?.find((f) => f.id === unit?.faction_id);
   // Prefer the most specific (last) subfaction keyword, then the parent faction.
-  const candidates = [...(unit?.factions ? [...unit.factions].reverse() : []), faction?.name];
-  const code = resolveFactionCode(candidates);
+  const candidates = buildFactionIconCandidates({
+    factionId: unit?.faction_id,
+    names: [...factionNamesFromCard(unit), faction?.name],
+  });
 
-  if (!code) {
+  if (candidates.length === 0) {
     return <div className="faction" />;
   }
 
   return (
     <div className="faction">
       <div className="faction-symbol-wrapper">
-        <FactionIcon factionId={code} />
+        <FactionIcon factionId={candidates} />
       </div>
     </div>
   );

--- a/src/Components/Warhammer40k-11e/UnitCard/__tests__/UnitFactionSymbol.test.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCard/__tests__/UnitFactionSymbol.test.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const getFactionSymbolUrl = vi.fn();
+
+vi.mock("../../../../Hooks/useIndexedDBImages", () => ({
+  useIndexedDBImages: () => ({ getFactionSymbolUrl, isReady: true }),
+}));
+
+vi.mock("../../../../Hooks/useDataSourceStorage", () => ({
+  useDataSourceStorage: () => ({
+    dataSource: { data: [{ id: "faction-uuid", name: "Chaos Space Marines" }] },
+  }),
+}));
+
+vi.mock("../../../Icons/FactionIcon", () => ({
+  FactionIcon: ({ factionId }) => <div data-testid="faction-icon" data-candidates={[].concat(factionId).join(",")} />,
+}));
+
+import { UnitFactionSymbol } from "../UnitFactionSymbol";
+
+const unit = {
+  uuid: "card-uuid",
+  faction_id: "faction-uuid",
+  factions: ["Chaos", "Heretic Astartes"],
+};
+
+describe("UnitFactionSymbol (11e)", () => {
+  beforeEach(() => {
+    getFactionSymbolUrl.mockReset();
+    global.URL.createObjectURL = vi.fn(() => "blob:symbol");
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  it("resolves the default symbol from the faction keyword and the faction name", () => {
+    render(<UnitFactionSymbol unit={unit} />);
+    expect(screen.getByTestId("faction-icon").dataset.candidates).toBe("CSM");
+  });
+
+  it("does not pass the faction uuid to the icon (it is not a symbol code)", () => {
+    render(<UnitFactionSymbol unit={{ ...unit, factions: [] }} />);
+    expect(screen.getByTestId("faction-icon").dataset.candidates).toBe("CSM");
+  });
+
+  it("renders an uploaded custom symbol instead of the default one", async () => {
+    getFactionSymbolUrl.mockResolvedValue("blob:symbol");
+    const { container } = render(<UnitFactionSymbol unit={{ ...unit, hasCustomFactionSymbol: true }} />);
+
+    await waitFor(() => expect(container.querySelector(".faction > div")).toBeTruthy());
+    expect(screen.queryByTestId("faction-icon")).toBeNull();
+    expect(getFactionSymbolUrl).toHaveBeenCalledWith("card-uuid");
+  });
+
+  it("renders an external custom symbol without an upload", () => {
+    render(
+      <UnitFactionSymbol
+        unit={{ ...unit, hasCustomFactionSymbol: true, externalFactionSymbol: "https://example.test/s.svg" }}
+      />,
+    );
+    expect(screen.queryByTestId("faction-icon")).toBeNull();
+  });
+
+  it("falls back to the default symbol when the custom symbol is enabled but empty", () => {
+    render(<UnitFactionSymbol unit={{ ...unit, hasCustomFactionSymbol: true }} />);
+    expect(screen.getByTestId("faction-icon").dataset.candidates).toBe("CSM");
+  });
+});

--- a/src/Components/Warhammer40k-11e/UnitCardEditor/UnitStylingInfo.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCardEditor/UnitStylingInfo.jsx
@@ -100,10 +100,7 @@ export function UnitStylingInfo() {
         localImageFilename: actualFile.name,
       };
       updateActiveCard(updatedCard);
-
-      setTimeout(() => {
-        saveActiveCard();
-      }, 100);
+      saveActiveCard(updatedCard);
 
       setLocalImageInfo({
         filename: actualFile.name,
@@ -124,15 +121,9 @@ export function UnitStylingInfo() {
 
     try {
       await deleteImage(activeCard.uuid);
-      updateActiveCard({
-        ...activeCard,
-        hasLocalImage: false,
-        localImageFilename: null,
-      });
-
-      setTimeout(() => {
-        saveActiveCard();
-      }, 100);
+      const updatedCard = { ...activeCard, hasLocalImage: false, localImageFilename: null };
+      updateActiveCard(updatedCard);
+      saveActiveCard(updatedCard);
 
       setLocalImageInfo(null);
       message.success("Local image removed");
@@ -174,15 +165,13 @@ export function UnitStylingInfo() {
     try {
       await saveFactionSymbol(activeCard.uuid, actualFile);
 
-      updateActiveCard({
+      const updatedCard = {
         ...activeCard,
         hasCustomFactionSymbol: true,
         customFactionSymbolFilename: actualFile.name,
-      });
-
-      setTimeout(() => {
-        saveActiveCard();
-      }, 100);
+      };
+      updateActiveCard(updatedCard);
+      saveActiveCard(updatedCard);
 
       setFactionSymbolInfo({
         filename: actualFile.name,
@@ -203,15 +192,9 @@ export function UnitStylingInfo() {
 
     try {
       await deleteFactionSymbol(activeCard.uuid);
-      updateActiveCard({
-        ...activeCard,
-        hasCustomFactionSymbol: false,
-        customFactionSymbolFilename: null,
-      });
-
-      setTimeout(() => {
-        saveActiveCard();
-      }, 100);
+      const updatedCard = { ...activeCard, hasCustomFactionSymbol: false, customFactionSymbolFilename: null };
+      updateActiveCard(updatedCard);
+      saveActiveCard(updatedCard);
 
       setFactionSymbolInfo(null);
       message.success("Faction symbol removed");
@@ -318,8 +301,9 @@ export function UnitStylingInfo() {
           <Switch
             checked={activeCard.hasCustomFactionSymbol || false}
             onChange={(value) => {
-              updateActiveCard({ ...activeCard, hasCustomFactionSymbol: value });
-              setTimeout(() => saveActiveCard(), 100);
+              const updatedCard = { ...activeCard, hasCustomFactionSymbol: value };
+              updateActiveCard(updatedCard);
+              saveActiveCard(updatedCard);
             }}
           />
         }>

--- a/src/Helpers/__tests__/factionSymbol.helpers.test.js
+++ b/src/Helpers/__tests__/factionSymbol.helpers.test.js
@@ -53,6 +53,8 @@ describe("isLegacyFactionCode", () => {
     expect(isLegacyFactionCode("CSM")).toBe(true);
     expect(isLegacyFactionCode("AoI")).toBe(true);
     expect(isLegacyFactionCode("farsight-enclaves")).toBe(false);
+    // A generated slug is always lowercase, so it is never a code.
+    expect(isLegacyFactionCode("orks")).toBe(false);
     expect(isLegacyFactionCode("2f1c4b9e-9a1e-4d64-9d0e-0f7bb7f1c4aa")).toBe(false);
     expect(isLegacyFactionCode(undefined)).toBe(false);
   });
@@ -63,8 +65,14 @@ describe("factionNamesFromCard", () => {
     expect(factionNamesFromCard({ factions: ["Chaos", "Heretic Astartes"] })).toEqual(["Heretic Astartes", "Chaos"]);
   });
 
-  it("falls back to the custom datasource field and tolerates missing values", () => {
+  it("prefers the custom datasource field, which is the one its card prints", () => {
     expect(factionNamesFromCard({ factionKeywords: ["Necrons"] })).toEqual(["Necrons"]);
+    expect(factionNamesFromCard({ factionKeywords: ["Necrons"], factions: ["Orks"] })).toEqual(["Necrons"]);
+  });
+
+  it("treats an empty array as absent and tolerates missing values", () => {
+    expect(factionNamesFromCard({ factions: [], factionKeywords: ["Necrons"] })).toEqual(["Necrons"]);
+    expect(factionNamesFromCard({ factionKeywords: [], factions: ["Orks"] })).toEqual(["Orks"]);
     expect(factionNamesFromCard({})).toEqual([]);
     expect(factionNamesFromCard(undefined)).toEqual([]);
   });
@@ -80,6 +88,8 @@ describe("buildFactionIconCandidates", () => {
     // 11th edition (UUID) and custom datasource (slug) faction ids.
     expect(buildFactionIconCandidates({ factionId: "3f0a-uuid-9931", names: ["Heretic Astartes"] })).toEqual(["CSM"]);
     expect(buildFactionIconCandidates({ factionId: "farsight-enclaves", names: ["T'au Empire"] })).toEqual(["TAU"]);
+    // A slug short enough to look like a code is not requested first.
+    expect(buildFactionIconCandidates({ factionId: "orks", names: ["Orks"] })).toEqual(["ORK"]);
   });
 
   it("returns an empty list when nothing resolves", () => {

--- a/src/Helpers/__tests__/factionSymbol.helpers.test.js
+++ b/src/Helpers/__tests__/factionSymbol.helpers.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildFactionIconCandidates,
+  factionNamesFromCard,
+  isLegacyFactionCode,
+  normalizeFactionName,
+  resolveFactionCode,
+  resolveFactionCodes,
+} from "../factionSymbol.helpers";
+
+describe("normalizeFactionName", () => {
+  it("ignores case, punctuation, accents and a leading 'the'", () => {
+    expect(normalizeFactionName("T'au Empire")).toBe("tauempire");
+    expect(normalizeFactionName("  Tau   Empire ")).toBe("tauempire");
+    expect(normalizeFactionName("The Emperor's Children")).toBe("emperorschildren");
+    expect(normalizeFactionName("Adeptus-Mechanicus")).toBe("adeptusmechanicus");
+  });
+
+  it("survives missing values", () => {
+    expect(normalizeFactionName(undefined)).toBe("");
+    expect(normalizeFactionName(null)).toBe("");
+  });
+});
+
+describe("resolveFactionCode", () => {
+  it("resolves faction keywords that are not the datasource faction name", () => {
+    // The bug: 11e cards print FACTION: Heretic Astartes, which used to resolve
+    // to nothing and left the badge empty.
+    expect(resolveFactionCode(["Heretic Astartes"])).toBe("CSM");
+    expect(resolveFactionCode(["Adeptus Astartes"])).toBe("SM");
+    expect(resolveFactionCode(["Asuryani"])).toBe("AE");
+  });
+
+  it("resolves sub-factions onto their parent symbol", () => {
+    expect(resolveFactionCode(["Farsight Enclaves"])).toBe("TAU");
+    expect(resolveFactionCode(["Crimson Fists"])).toBe("CHIF");
+  });
+
+  it("returns null for an unknown faction", () => {
+    expect(resolveFactionCode(["Squats of Mars"])).toBeNull();
+    expect(resolveFactionCode([])).toBeNull();
+    expect(resolveFactionCode([undefined, null])).toBeNull();
+  });
+
+  it("keeps every distinct match, most specific first", () => {
+    expect(resolveFactionCodes(["Ultramarines", "Space Marines"])).toEqual(["CHUL", "SM"]);
+    expect(resolveFactionCodes(["Space Marines", "Adeptus Astartes"])).toEqual(["SM"]);
+  });
+});
+
+describe("isLegacyFactionCode", () => {
+  it("accepts 10th edition symbol codes only", () => {
+    expect(isLegacyFactionCode("CSM")).toBe(true);
+    expect(isLegacyFactionCode("AoI")).toBe(true);
+    expect(isLegacyFactionCode("farsight-enclaves")).toBe(false);
+    expect(isLegacyFactionCode("2f1c4b9e-9a1e-4d64-9d0e-0f7bb7f1c4aa")).toBe(false);
+    expect(isLegacyFactionCode(undefined)).toBe(false);
+  });
+});
+
+describe("factionNamesFromCard", () => {
+  it("returns the most specific faction keyword first", () => {
+    expect(factionNamesFromCard({ factions: ["Chaos", "Heretic Astartes"] })).toEqual(["Heretic Astartes", "Chaos"]);
+  });
+
+  it("falls back to the custom datasource field and tolerates missing values", () => {
+    expect(factionNamesFromCard({ factionKeywords: ["Necrons"] })).toEqual(["Necrons"]);
+    expect(factionNamesFromCard({})).toEqual([]);
+    expect(factionNamesFromCard(undefined)).toEqual([]);
+  });
+});
+
+describe("buildFactionIconCandidates", () => {
+  it("keeps the 10th edition faction id first", () => {
+    expect(buildFactionIconCandidates({ factionId: "CSM", names: ["Heretic Astartes"] })).toEqual(["CSM"]);
+    expect(buildFactionIconCandidates({ factionId: "SM", names: ["Ultramarines"] })).toEqual(["SM", "CHUL"]);
+  });
+
+  it("falls back to the faction names for ids that are not symbol codes", () => {
+    // 11th edition (UUID) and custom datasource (slug) faction ids.
+    expect(buildFactionIconCandidates({ factionId: "3f0a-uuid-9931", names: ["Heretic Astartes"] })).toEqual(["CSM"]);
+    expect(buildFactionIconCandidates({ factionId: "farsight-enclaves", names: ["T'au Empire"] })).toEqual(["TAU"]);
+  });
+
+  it("returns an empty list when nothing resolves", () => {
+    expect(buildFactionIconCandidates({ factionId: "my-own-faction", names: ["My Own Faction"] })).toEqual([]);
+    expect(buildFactionIconCandidates()).toEqual([]);
+  });
+});

--- a/src/Helpers/factionSymbol.helpers.js
+++ b/src/Helpers/factionSymbol.helpers.js
@@ -1,0 +1,116 @@
+// Faction symbols are SVGs in the legacy 40k-Data-Card repository, addressed by
+// short codes (CSM, CHUL, TAU, ...). Only 10th edition datasheets carry such a
+// code in `faction_id`: 11th edition references factions by UUID and custom
+// datasources by a slug generated from the faction name, so for those the code
+// has to be resolved from the human readable faction name(s) instead.
+//
+// Keys below are normalised (lowercase, punctuation stripped) so "T'au Empire",
+// "Tau Empire" and "t'au  empire" all resolve to the same code. Both the FACTION
+// keyword(s) printed on the card and the datasource faction name are used as
+// lookup candidates, which is why sub-faction names (chapters, legions, sects)
+// map onto their parent's symbol.
+
+const ALIASES = {
+  AC: ["adeptus custodes", "custodes", "talons of the emperor"],
+  AE: ["aeldari", "asuryani", "craftworlds", "craftworld aeldari", "ynnari"],
+  AoI: ["agents of the imperium", "imperial agents", "agents", "inquisition", "officio assassinorum"],
+  AM: ["astra militarum", "imperial guard", "militarum tempestus"],
+  AS: ["adepta sororitas", "adeptus sororitas", "sisters of battle"],
+  AdM: ["adeptus mechanicus", "ad mech", "admech", "cult mechanicus", "skitarii"],
+  CD: ["chaos daemons", "daemons", "chaos daemon"],
+  CHBA: ["blood angels", "flesh tearers", "blood drinkers"],
+  CHBT: ["black templar", "black templars"],
+  CHDA: ["dark angels", "unforgiven"],
+  CHDW: ["deathwatch"],
+  CHIF: ["imperial fists", "crimson fists"],
+  CHIH: ["iron hands"],
+  CHRG: ["raven guard"],
+  CHSA: ["salamanders"],
+  CHSW: ["space wolves"],
+  CHUL: ["ultramarines"],
+  CHWS: ["white scars"],
+  CSM: ["chaos space marines", "heretic astartes", "chaos astartes"],
+  DG: ["death guard"],
+  DRU: ["drukhari", "dark eldar"],
+  GC: ["genestealer cults", "genestealer cult", "gsc"],
+  GK: ["grey knights"],
+  HAR: ["harlequins", "aeldari harlequins"],
+  LGAL: ["alpha legion"],
+  LGBL: ["black legion"],
+  LGEC: ["emperors children"],
+  LGIW: ["iron warriors"],
+  LGNL: ["night lords"],
+  LGRC: ["red corsairs"],
+  LGWB: ["word bearers"],
+  LoV: ["leagues of votann", "votann"],
+  NEC: ["necrons"],
+  ORK: ["orks", "ork"],
+  QI: ["imperial knights", "questor imperialis"],
+  QT: ["chaos knights", "questor traitoris"],
+  SM: ["space marines", "adeptus astartes"],
+  TAU: ["tau empire", "tau", "farsight enclaves", "vior la", "borkan", "sacea", "dal yth", "kel shan"],
+  TS: ["thousand sons"],
+  TYR: ["tyranids"],
+  WE: ["world eaters"],
+};
+
+// Strips accents and punctuation so apostrophes, hyphens and stray whitespace in
+// a faction name never decide whether a symbol is found.
+export const normalizeFactionName = (name) =>
+  String(name ?? "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/^the\s+/, "")
+    .replace(/[^a-z0-9]/g, "");
+
+const CODE_BY_NAME = Object.entries(ALIASES).reduce((acc, [code, names]) => {
+  names.forEach((name) => {
+    acc[normalizeFactionName(name)] = code;
+  });
+  return acc;
+}, {});
+
+// A legacy short code as used by 10th edition (`CSM`, `CHUL`, `AoI`). Custom
+// datasource faction ids are slugs ("farsight-enclaves") and 11th edition ids
+// are UUIDs, so neither is mistaken for a symbol filename.
+const LEGACY_CODE_PATTERN = /^[A-Za-z]{2,6}$/;
+
+export const isLegacyFactionCode = (factionId) => LEGACY_CODE_PATTERN.test(String(factionId ?? ""));
+
+/** Every symbol code the given names resolve to, most specific name first. */
+export const resolveFactionCodes = (names = []) => {
+  const codes = [];
+  for (const name of names) {
+    if (!name) continue;
+    const code = CODE_BY_NAME[normalizeFactionName(name)];
+    if (code && !codes.includes(code)) codes.push(code);
+  }
+  return codes;
+};
+
+/** The first symbol code the given names resolve to, or null. */
+export const resolveFactionCode = (names = []) => resolveFactionCodes(names)[0] ?? null;
+
+/**
+ * The faction keyword(s) printed on a card, most specific (last) keyword first.
+ * Custom datasources may store them under `factionKeywords`.
+ */
+export const factionNamesFromCard = (card) => {
+  const keywords = card?.factions || card?.factionKeywords || [];
+  return Array.isArray(keywords) ? [...keywords].reverse() : [];
+};
+
+/**
+ * Ordered list of symbol codes to try for a card. The card's own faction id wins
+ * when it already is a legacy code (10th edition), and the faction names are
+ * tried after it so 11th edition and custom datasource cards still get a symbol.
+ */
+export const buildFactionIconCandidates = ({ factionId, names = [] } = {}) => {
+  const candidates = [];
+  if (isLegacyFactionCode(factionId)) candidates.push(factionId);
+  resolveFactionCodes(names).forEach((code) => {
+    if (!candidates.includes(code)) candidates.push(code);
+  });
+  return candidates;
+};

--- a/src/Helpers/factionSymbol.helpers.js
+++ b/src/Helpers/factionSymbol.helpers.js
@@ -73,8 +73,11 @@ const CODE_BY_NAME = Object.entries(ALIASES).reduce((acc, [code, names]) => {
 
 // A legacy short code as used by 10th edition (`CSM`, `CHUL`, `AoI`). Custom
 // datasource faction ids are slugs ("farsight-enclaves") and 11th edition ids
-// are UUIDs, so neither is mistaken for a symbol filename.
-const LEGACY_CODE_PATTERN = /^[A-Za-z]{2,6}$/;
+// are UUIDs, so neither is mistaken for a symbol filename. The required capital
+// rules out a short slug that would otherwise pass ("orks"): generateIdFromName
+// lowercases, so a generated slug never has one. Matching against the alias
+// table's codes instead would drop any 10e code this file does not list.
+const LEGACY_CODE_PATTERN = /^(?=.*[A-Z])[A-Za-z]{2,6}$/;
 
 export const isLegacyFactionCode = (factionId) => LEGACY_CODE_PATTERN.test(String(factionId ?? ""));
 
@@ -94,10 +97,12 @@ export const resolveFactionCode = (names = []) => resolveFactionCodes(names)[0] 
 
 /**
  * The faction keyword(s) printed on a card, most specific (last) keyword first.
- * Custom datasources may store them under `factionKeywords`.
+ * Custom datasources may store them under `factionKeywords`, which is also the
+ * field their card renders, so it wins when both are filled. Empty arrays fall
+ * through to the other field rather than counting as an answer.
  */
 export const factionNamesFromCard = (card) => {
-  const keywords = card?.factions || card?.factionKeywords || [];
+  const keywords = card?.factionKeywords?.length ? card.factionKeywords : card?.factions;
   return Array.isArray(keywords) ? [...keywords].reverse() : [];
 };
 

--- a/src/Hooks/__tests__/useCardStorage.saveActiveCard.test.jsx
+++ b/src/Hooks/__tests__/useCardStorage.saveActiveCard.test.jsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { CardStorageProviderComponent, useCardStorage } from "../useCardStorage";
+
+vi.mock("../../Components/Toast/message", () => ({
+  message: { error: vi.fn(), success: vi.fn() },
+}));
+
+const CATEGORY_UUID = "cat-1";
+const CARD_UUID = "card-1";
+
+const seedStorage = () => {
+  localStorage.setItem(
+    "storage",
+    JSON.stringify({
+      version: "1.0.0",
+      categories: [
+        {
+          uuid: CATEGORY_UUID,
+          name: "My Cards",
+          cards: [{ uuid: CARD_UUID, name: "Chosen", hasCustomFactionSymbol: false }],
+        },
+      ],
+    }),
+  );
+};
+
+const renderStorage = () => {
+  const api = {};
+  const Probe = () => {
+    Object.assign(api, useCardStorage());
+    return null;
+  };
+  render(
+    <CardStorageProviderComponent>
+      <Probe />
+    </CardStorageProviderComponent>,
+  );
+  return api;
+};
+
+const storedCard = () =>
+  JSON.parse(localStorage.getItem("storage")).categories.find((c) => c.uuid === CATEGORY_UUID).cards[0];
+
+describe("saveActiveCard", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    seedStorage();
+  });
+
+  it("persists a card handed to it directly", () => {
+    const api = renderStorage();
+    act(() => {
+      api.setActiveCategory({ uuid: CATEGORY_UUID });
+      api.setActiveCard({ uuid: CARD_UUID, name: "Chosen", hasCustomFactionSymbol: false });
+    });
+
+    act(() => {
+      api.saveActiveCard({ uuid: CARD_UUID, name: "Chosen", hasCustomFactionSymbol: true });
+    });
+
+    expect(storedCard().hasCustomFactionSymbol).toBe(true);
+  });
+
+  it("persists the latest update, not the card of the render it was created in", () => {
+    // Regression: a deferred save used to write back the card as it was before
+    // the update, so toggling the custom faction symbol off saved it on again.
+    const api = renderStorage();
+    act(() => {
+      api.setActiveCategory({ uuid: CATEGORY_UUID });
+      api.setActiveCard({ uuid: CARD_UUID, name: "Chosen", hasCustomFactionSymbol: true });
+    });
+
+    const staleSave = api.saveActiveCard;
+    act(() => {
+      api.updateActiveCard({ uuid: CARD_UUID, name: "Chosen", hasCustomFactionSymbol: false });
+    });
+    act(() => {
+      staleSave();
+    });
+
+    expect(storedCard().hasCustomFactionSymbol).toBe(false);
+  });
+
+  it("leaves storage untouched when there is no category or no matching card", () => {
+    const api = renderStorage();
+    act(() => {
+      api.setActiveCard({ uuid: CARD_UUID, name: "Chosen", hasCustomFactionSymbol: true });
+    });
+    act(() => {
+      api.saveActiveCard();
+    });
+    expect(storedCard().hasCustomFactionSymbol).toBe(false);
+
+    act(() => {
+      api.setActiveCategory({ uuid: CATEGORY_UUID });
+    });
+    act(() => {
+      api.saveActiveCard({ uuid: "not-in-this-category", hasCustomFactionSymbol: true });
+    });
+    expect(storedCard().hasCustomFactionSymbol).toBe(false);
+    expect(JSON.parse(localStorage.getItem("storage")).categories[0].cards).toHaveLength(1);
+  });
+});

--- a/src/Hooks/useCardStorage.jsx
+++ b/src/Hooks/useCardStorage.jsx
@@ -50,6 +50,16 @@ export const CardStorageProviderComponent = (props) => {
     localStorage.setItem("storage", JSON.stringify({ ...cardStorage, version }));
   }, [cardStorage]);
 
+  // The latest active card, readable synchronously. `saveActiveCard` used to
+  // close over the `activeCard` of the render it was created in, so anything
+  // that updated a card and then saved it (a timeout, a promise callback)
+  // persisted the *previous* card and silently reverted the change.
+  const activeCardRef = React.useRef(null);
+
+  useEffect(() => {
+    activeCardRef.current = activeCard;
+  }, [activeCard]);
+
   const updateActiveCard = (card, noUpdate = false) => {
     if (!card) {
       return;
@@ -58,6 +68,7 @@ export const CardStorageProviderComponent = (props) => {
     if (!noUpdate) {
       setCardUpdated(true);
     }
+    activeCardRef.current = copiedCard;
     setActiveCard(copiedCard);
   };
 
@@ -72,8 +83,12 @@ export const CardStorageProviderComponent = (props) => {
     });
   };
 
-  const saveActiveCard = () => {
-    if (!activeCard) {
+  // `cardToSave` lets a caller persist the exact card it just built, without
+  // waiting for the state update to land. Without it, the most recent card is
+  // read from the ref above.
+  const saveActiveCard = (cardToSave) => {
+    const card = cardToSave || activeCardRef.current || activeCard;
+    if (!card || !activeCategory) {
       return;
     }
     setCardUpdated(false);
@@ -81,8 +96,15 @@ export const CardStorageProviderComponent = (props) => {
       const newStorage = clone(prevStorage);
       const categoryIndex = newStorage.categories.findIndex((cat) => cat.uuid === activeCategory.uuid);
       const category = newStorage.categories[categoryIndex];
+      if (!category) {
+        return prevStorage;
+      }
       const newCards = category.cards;
-      newCards[newCards.findIndex((card) => card.uuid === activeCard.uuid)] = activeCard;
+      const cardIndex = newCards.findIndex((existing) => existing.uuid === card.uuid);
+      if (cardIndex === -1) {
+        return prevStorage;
+      }
+      newCards[cardIndex] = card;
       newStorage.categories[categoryIndex] = {
         ...category,
         cards: newCards,


### PR DESCRIPTION
## Proposed Changes

Reported on Discord: changing a datasheet's faction symbol did not add the new symbol, cleared the old one, and left the custom-symbol switch impossible to turn off — it came back on after a reload, and new datasheets showed an empty faction badge.

Three separate defects, all visible as "the faction symbol is gone":

**1. Every faction symbol action saved the previous version of the card.**
`UnitStylingInfo` (10e and 11e) and `WarscrollStylingInfo` (AoS) called `updateActiveCard(...)` and then `setTimeout(() => saveActiveCard(), 100)`. `saveActiveCard` closed over the `activeCard` of the render its closure was created in, so 100ms later it persisted the card as it was *before* the change. Turning the switch off wrote it back on; uploading a symbol persisted the state without it. The same call also set `cardUpdated` to `false`, which hides the toolbar Save button (`showSave = activeCard.isCustom && cardUpdated`), so the user could not correct it by hand — and on a synced category the wrong state was pushed to the cloud.

`saveActiveCard` now accepts the card to persist and otherwise reads the latest one from a ref; the styling editors save synchronously with the card they just built. It also no longer dereferences a missing category or writes at index `-1`. Local card images were saved through the same broken path and are fixed with it.

**2. 11th edition never rendered custom faction symbols.**
`Warhammer40k-11e/UnitCard/UnitFactionSymbol` ignored `hasCustomFactionSymbol`, `externalFactionSymbol`, the IndexedDB upload and the scale/position settings, while the 11e styling editor offered the full panel. Symbol loading and rendering moved to a shared `Icons/CustomFactionSymbol` used by both 40k rendersets.

**3. Cards whose faction id is not a symbol code had no default symbol.**
Faction symbols are SVGs addressed by short codes (`CSM`, `CHUL`, `TAU`). 10e datasheets carry such a code in `faction_id`, but 11e faction ids are UUIDs and custom datasource ids are slugs, so `FactionIcon` requested a URL that 404s and rendered nothing. 11e worked around this with a 45-entry name map that missed common faction keywords (`Heretic Astartes`, `Asuryani`, `Farsight Enclaves`), did not normalise apostrophes, and mapped Adeptus Titanicus to an `AT.svg` that does not exist upstream; custom datasource cards had no fallback at all.

Resolution now lives in `src/Helpers/factionSymbol.helpers.js`: the faction id is used only when it already is a symbol code, otherwise the code is resolved from the faction name(s) on the card (most specific keyword first, then the datasource faction name), matched case- and punctuation-insensitively, with sub-factions mapping onto their parent's symbol. `FactionIcon` takes an ordered candidate list and uses the first that resolves, caches misses so a missing symbol is not re-fetched, and resets its error state when the faction changes (previously one miss stuck to every later faction). The rule cards get the same fallback.

Existing broken cards need no cleanup: a card with the switch on and no image falls back to the default symbol again, and the switch now turns off for good.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

`docs/card-data-formats.md` gains the faction symbol card fields and a "Faction Symbols" section describing the resolution order. Release note added as `changes/unreleased/faction-symbols.json`; the patch bump and `releaseNotes.json` entry are applied by `.github/workflows/release.yml` after merge, per `changes/README.md`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes

`yarn lint` and `yarn test:ci` pass (207 files, 3295 tests). New tests: `factionSymbol.helpers.test.js`, `Warhammer40k-11e/UnitCard/__tests__/UnitFactionSymbol.test.jsx`, and `useCardStorage.saveActiveCard.test.jsx` (verified to fail against the old save behaviour). `yarn build` could not be run here — the sandbox blocks the Google Fonts `@import` in `starcraft-tmg.less`, unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4SnaGvGYom2KRkWzgvm8b)_