### PR TITLE
Add a Wrap Keywords toggle for weapon keywords

### DIFF
--- a/changes/unreleased/melee-weapon-keyword-layout.json
+++ b/changes/unreleased/melee-weapon-keyword-layout.json
@@ -1,5 +1,5 @@
 {
-  "title": "Melee weapon keywords line up with ranged",
-  "body": "On 10th and 11th edition datasheets, a melee weapon with a long keyword list folded those keywords into a stack under the weapon name, while a ranged weapon kept them on one line. Melee weapons now read the same as ranged: the keywords run on in a single line under the characteristics, and the characteristic columns stay lined up with their headings.",
+  "title": "Choose how weapon keywords wrap",
+  "body": "On 10th and 11th edition datasheets, melee and ranged weapons used to lay their keywords out differently: a long melee keyword list stacked under the weapon name while a ranged one stayed on a single line. Both now wrap inside the weapon name column, and the characteristic columns stay lined up with their headings. A new Wrap Keywords switch in the Styling section lets you turn wrapping off per card, so the keywords run on in one line under the characteristics instead. It is on the mobile card editor too.",
   "severity": "info"
 }

--- a/docs/card-data-formats.md
+++ b/docs/card-data-formats.md
@@ -208,7 +208,10 @@ There are four `cardType` values:
   // Custom colours
   "useCustomColours": false,
   "customHeaderColour": "#000000",
-  "customBannerColour": "#000000"
+  "customBannerColour": "#000000",
+
+  // Styling
+  "wrapKeywords": true         // Wrap long weapon keyword lists (absent = true)
 }
 ```
 
@@ -217,6 +220,7 @@ There are four `cardType` values:
 - `abilities.core` and `abilities.faction` are string arrays (just names), not objects.
 - `abilities.other`, `abilities.wargear`, and `abilities.special` are arrays of `{ name, description, showAbility, showDescription }` objects.
 - Weapons have a two-level structure: weapon groups contain `profiles` (for multi-profile weapons like "Combi-weapon") and optional `abilities`.
+- `wrapKeywords` controls weapon keyword layout, and is set by the "Wrap Keywords" switch in the editor's Styling panel. When `true` (or absent) a long keyword list wraps inside the weapon name column; when `false` it stays on one line, running on under the characteristic columns. The same field is read by the 11th edition renderer.
 
 ---
 

--- a/src/Components/Viewer/MobileEditor/MobileCardEditor.jsx
+++ b/src/Components/Viewer/MobileEditor/MobileCardEditor.jsx
@@ -16,6 +16,7 @@ import {
   Wrench,
   Users,
   ScrollText,
+  WrapText,
 } from "lucide-react";
 import { useMobileList } from "../useMobileList";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
@@ -39,6 +40,7 @@ import { StringListSection } from "./sections/StringListSection";
 import { TextFieldSection } from "./sections/TextFieldSection";
 import { LeaderInfoSection } from "./sections/LeaderInfoSection";
 import { WargearOptionsSection } from "./sections/WargearOptionsSection";
+import { StylingSection } from "./sections/StylingSection";
 import { DrillDownView } from "./shared/DrillDownView";
 import { WeaponListView } from "./weapons/WeaponListView";
 import { WeaponProfileEditor } from "./weapons/WeaponProfileEditor";
@@ -63,6 +65,7 @@ const SECTION_COMPONENTS = {
   textField: TextFieldSection,
   leaderInfo: LeaderInfoSection,
   wargearOptions: WargearOptionsSection,
+  styling: StylingSection,
 };
 
 const SECTION_ICONS = {
@@ -82,6 +85,7 @@ const SECTION_ICONS = {
   textField: ScrollText,
   leaderInfo: Users,
   wargearOptions: Wrench,
+  styling: WrapText,
 };
 
 export const MobileCardEditor = ({ isOpen, onClose, card, cardUuid, gameSystem, schema, factionColours }) => {

--- a/src/Components/Viewer/MobileEditor/__tests__/StylingSection.test.jsx
+++ b/src/Components/Viewer/MobileEditor/__tests__/StylingSection.test.jsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { StylingSection } from "../sections/StylingSection";
+import { resolveEditorSections } from "../editorSchemaResolvers";
+
+// The mobile counterpart of the desktop editor's Styling panel. It carries the
+// "Wrap Keywords" toggle, which controls whether long weapon keyword lists wrap
+// inside the weapon name column or run on as one line under the characteristics.
+
+const unitCard = (source, overrides = {}) => ({
+  name: "Intercessors",
+  source,
+  stats: [{ m: 6, t: 4, sv: "3+", w: 2, ld: "6+", oc: 2, active: true }],
+  rangedWeapons: [{ profiles: [{ name: "Bolt Rifle", range: "24", attacks: "2" }] }],
+  meleeWeapons: [{ profiles: [{ name: "Close Combat", range: "Melee", attacks: "3" }] }],
+  keywords: ["Infantry"],
+  factions: ["Adeptus Astartes"],
+  ...overrides,
+});
+
+describe("mobile Styling section", () => {
+  describe("wiring into the editor", () => {
+    it.each(["40k-10e", "40k-11e"])("offers a styling section for %s unit cards", (source) => {
+      const sections = resolveEditorSections(unitCard(source), source, null);
+
+      const styling = sections.find((s) => s.type === "styling");
+      expect(styling).toBeDefined();
+      expect(styling.label).toBe("Styling");
+    });
+
+    // Keywords live on weapon profiles, so with no weapons the section would
+    // offer a toggle that changes nothing on the card.
+    it.each(["40k-10e", "40k-11e"])("omits the section for %s cards with no weapons", (source) => {
+      const sections = resolveEditorSections(unitCard(source, { rangedWeapons: [], meleeWeapons: [] }), source, null);
+
+      expect(sections.map((s) => s.type)).not.toContain("styling");
+    });
+  });
+
+  describe("the Wrap Keywords toggle", () => {
+    const renderToggle = (card) => {
+      const updateField = vi.fn();
+      render(<StylingSection card={card} label="Styling" icon={null} updateField={updateField} />);
+      return { updateField, toggle: screen.getByText("Wrap Keywords").parentElement.querySelector("button") };
+    };
+
+    // Cards saved before the toggle existed carry no flag and must still wrap.
+    it("reads as on when the card carries no flag", () => {
+      const { toggle } = renderToggle({ name: "Intercessors" });
+
+      expect(toggle.className).toContain("active");
+    });
+
+    it("reads as off when the card opted out", () => {
+      const { toggle } = renderToggle({ name: "Intercessors", wrapKeywords: false });
+
+      expect(toggle.className).not.toContain("active");
+    });
+
+    it("writes the flag as a plain boolean the renderer understands", () => {
+      const { updateField, toggle } = renderToggle({ name: "Intercessors" });
+
+      fireEvent.click(toggle);
+
+      expect(updateField).toHaveBeenCalledWith("wrapKeywords", false);
+    });
+
+    it("turns wrapping back on", () => {
+      const { updateField, toggle } = renderToggle({ name: "Intercessors", wrapKeywords: false });
+
+      fireEvent.click(toggle);
+
+      expect(updateField).toHaveBeenCalledWith("wrapKeywords", true);
+    });
+  });
+});

--- a/src/Components/Viewer/MobileEditor/__tests__/editorSchemaResolvers.test.js
+++ b/src/Components/Viewer/MobileEditor/__tests__/editorSchemaResolvers.test.js
@@ -484,6 +484,7 @@ describe("editorSchemaResolvers 40k-11e", () => {
       "leader",
       "transport",
       "keywords",
+      "styling",
     ]);
   });
 

--- a/src/Components/Viewer/MobileEditor/editorSchemaResolvers.js
+++ b/src/Components/Viewer/MobileEditor/editorSchemaResolvers.js
@@ -259,6 +259,13 @@ function resolve40kUnitSections(card) {
     });
   }
 
+  // Styling. Weapon keyword wrapping is the only styling option that applies on
+  // a phone, so the section is only worth showing when the card has weapons to
+  // carry keywords.
+  if (card.rangedWeapons?.length || card.meleeWeapons?.length) {
+    sections.push({ key: "styling", label: "Styling", type: "styling", config: {} });
+  }
+
   return sections;
 }
 
@@ -513,6 +520,10 @@ function resolve11eUnitSections(card) {
       keywordsAreObjects: true,
     },
   });
+
+  if (card.rangedWeapons?.length || card.meleeWeapons?.length) {
+    sections.push({ key: "styling", label: "Styling", type: "styling", config: {} });
+  }
 
   return sections;
 }

--- a/src/Components/Viewer/MobileEditor/sections/StylingSection.jsx
+++ b/src/Components/Viewer/MobileEditor/sections/StylingSection.jsx
@@ -1,0 +1,26 @@
+import { EditorAccordion } from "../shared/EditorAccordion";
+import { EditorToggle } from "../shared/EditorToggle";
+
+/**
+ * Per-card styling toggles, mirroring the desktop editor's Styling panel.
+ *
+ * Only the options that make sense on a phone live here; the desktop panel's
+ * image and colour pickers stay desktop-only.
+ *
+ * Wrap Keywords: long weapon keyword lists wrap inside the weapon name column
+ * by default. Off keeps each list on one line, running on under the
+ * characteristic columns. An absent flag means wrap.
+ */
+export const StylingSection = ({ card, label, icon, updateField }) => {
+  return (
+    <EditorAccordion title={label} icon={icon}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <EditorToggle
+          label="Wrap Keywords"
+          checked={card.wrapKeywords !== false}
+          onChange={(value) => updateField("wrapKeywords", value)}
+        />
+      </div>
+    </EditorAccordion>
+  );
+};

--- a/src/Components/Warhammer40k-10e/UnitCard/UnitWeapons.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCard/UnitWeapons.jsx
@@ -2,8 +2,13 @@ import { UnitAbilityDescription } from "./UnitAbilityDescription";
 import { UnitWeaponsType } from "./UnitWeaponsType";
 
 export const UnitWeapons = ({ unit }) => {
+  // Weapon keyword lists wrap inside the name column by default. Cards that
+  // turn the "Wrap Keywords" styling toggle off opt into one unbreakable line
+  // per list instead; an absent flag means wrap.
+  const wrapKeywords = unit.wrapKeywords !== false;
+
   return (
-    <div className="weapons">
+    <div className={`weapons${wrapKeywords ? "" : " keywords-nowrap"}`}>
       {unit.showWeapons?.["rangedWeapons"] !== false && unit.rangedWeapons && unit.rangedWeapons.length > 0 && (
         <UnitWeaponsType
           weaponType={{ name: "Ranged weapons", class: "ranged", skill: "BS" }}

--- a/src/Components/Warhammer40k-10e/UnitCardEditor/UnitStylingInfo.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCardEditor/UnitStylingInfo.jsx
@@ -409,6 +409,21 @@ export function UnitStylingInfo() {
         )}
       </Card>
 
+      <Card type={"inner"} title="Weapon Keywords" size="small" bodyStyle={{ padding: 16 }} style={{ marginTop: 16 }}>
+        <Form size="small">
+          <Form.Item label={"Wrap Keywords"} style={{ marginBottom: 0 }}>
+            <Switch
+              checked={activeCard.wrapKeywords !== false}
+              onChange={(value) => updateActiveCard({ ...activeCard, wrapKeywords: value })}
+            />
+            <Text type="secondary" style={{ fontSize: "12px", display: "block", marginTop: 4 }}>
+              Long keyword lists wrap inside the weapon name column. Turn this off to keep each list on one line,
+              running on under the characteristics.
+            </Text>
+          </Form.Item>
+        </Form>
+      </Card>
+
       <Card
         type={"inner"}
         title="Custom Colours"

--- a/src/Components/Warhammer40k-10e/__tests__/UnitStylingInfo.wrapKeywords.test.jsx
+++ b/src/Components/Warhammer40k-10e/__tests__/UnitStylingInfo.wrapKeywords.test.jsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+// The desktop Styling panel's "Wrap Keywords" toggle. It writes a plain
+// `wrapKeywords` boolean on the card, which UnitWeapons turns into the
+// `keywords-nowrap` class (see WeaponKeywordWrapping.test.jsx).
+
+const mockUpdateActiveCard = vi.fn();
+const mockSaveActiveCard = vi.fn();
+const mockActiveCard = { ref: {} };
+
+vi.mock("../../../Hooks/useCardStorage", () => ({
+  useCardStorage: () => ({
+    activeCard: mockActiveCard.ref,
+    updateActiveCard: mockUpdateActiveCard,
+    saveActiveCard: mockSaveActiveCard,
+  }),
+}));
+
+vi.mock("../../../Hooks/useSettingsStorage", () => ({
+  useSettingsStorage: () => ({ settings: {}, updateSettings: vi.fn() }),
+}));
+
+vi.mock("../../../Hooks/useDataSourceStorage", () => ({
+  useDataSourceStorage: () => ({ dataSource: { data: [] } }),
+}));
+
+vi.mock("../../../Hooks/useIndexedDBImages", () => ({
+  useIndexedDBImages: () => ({
+    saveImage: vi.fn(),
+    deleteImage: vi.fn(),
+    getImageData: vi.fn().mockResolvedValue(null),
+    saveFactionSymbol: vi.fn(),
+    deleteFactionSymbol: vi.fn(),
+    getFactionSymbolData: vi.fn().mockResolvedValue(null),
+    isReady: true,
+  }),
+}));
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+import { UnitStylingInfo as UnitStylingInfo10e } from "../UnitCardEditor/UnitStylingInfo";
+import { UnitStylingInfo as UnitStylingInfo11e } from "../../Warhammer40k-11e/UnitCardEditor/UnitStylingInfo";
+
+describe.each([
+  ["10th edition", UnitStylingInfo10e],
+  ["11th edition", UnitStylingInfo11e],
+])("%s Styling panel: Wrap Keywords", (_edition, UnitStylingInfo) => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveCard.ref = {};
+  });
+
+  const wrapSwitch = () => {
+    const label = screen.getByText("Wrap Keywords");
+    return label.closest(".ant-form-item").querySelector("button[role='switch']");
+  };
+
+  // Cards saved before the toggle existed carry no flag and must still wrap.
+  it("shows as on when the card carries no flag", () => {
+    render(<UnitStylingInfo />);
+
+    expect(wrapSwitch()).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("shows as off when the card opted out", () => {
+    mockActiveCard.ref = { wrapKeywords: false };
+    render(<UnitStylingInfo />);
+
+    expect(wrapSwitch()).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("writes the flag when switched off", () => {
+    render(<UnitStylingInfo />);
+
+    fireEvent.click(wrapSwitch());
+
+    expect(mockUpdateActiveCard).toHaveBeenCalledWith(expect.objectContaining({ wrapKeywords: false }));
+  });
+
+  it("writes the flag when switched back on", () => {
+    mockActiveCard.ref = { wrapKeywords: false };
+    render(<UnitStylingInfo />);
+
+    fireEvent.click(wrapSwitch());
+
+    expect(mockUpdateActiveCard).toHaveBeenCalledWith(expect.objectContaining({ wrapKeywords: true }));
+  });
+});

--- a/src/Components/Warhammer40k-10e/__tests__/WeaponKeywordWrapping.test.jsx
+++ b/src/Components/Warhammer40k-10e/__tests__/WeaponKeywordWrapping.test.jsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// Weapon keyword lists wrap inside the weapon name column by default. The
+// card's "Wrap Keywords" styling toggle turns that off, which the renderer
+// signals with a `keywords-nowrap` class on the weapons panel — the stylesheet
+// hangs the `white-space: nowrap` opt-out off it (see
+// src/styles/__tests__/weaponKeywords.styles.test.js).
+//
+// The flag is per card and absent on every card saved before the toggle
+// existed, so an absent flag has to mean wrap.
+
+vi.mock("../../../Hooks/useSettingsStorage", () => ({
+  useSettingsStorage: () => ({ settings: { language: "en" } }),
+}));
+
+vi.mock("../../../Hooks/use11eKeywordGlossary", () => ({
+  use11eKeywordGlossary: () => [],
+}));
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+import { UnitWeapons as UnitWeapons10e } from "../UnitCard/UnitWeapons";
+import { UnitWeapons as UnitWeapons11e } from "../../Warhammer40k-11e/UnitCard/UnitWeapons";
+
+const unitWith = (overrides) => ({
+  abilities: { primarch: [] },
+  rangedWeapons: [
+    {
+      profiles: [
+        {
+          active: true,
+          name: "Bloody Twins",
+          keywords: ["Pistol", "Assault"],
+          range: '24"',
+          attacks: "6",
+          skill: "2+",
+          strength: "8",
+          ap: "-1",
+          damage: "2",
+        },
+      ],
+    },
+  ],
+  meleeWeapons: [
+    {
+      profiles: [
+        {
+          active: true,
+          name: "Sword of Asur",
+          keywords: ["Devastating wounds", "Anti-daemon 3+"],
+          range: "Melee",
+          attacks: "8",
+          skill: "2+",
+          strength: "10",
+          ap: "-3",
+          damage: "2",
+        },
+      ],
+    },
+  ],
+  ...overrides,
+});
+
+describe.each([
+  ["10th edition", UnitWeapons10e],
+  ["11th edition", UnitWeapons11e],
+])("%s weapon keyword wrapping", (_edition, UnitWeapons) => {
+  const weaponsPanel = (container) => container.querySelector(".weapons");
+
+  it("wraps keywords by default when the card carries no flag", () => {
+    const { container } = render(<UnitWeapons unit={unitWith({})} />);
+
+    expect(weaponsPanel(container).className).not.toContain("keywords-nowrap");
+  });
+
+  it("wraps keywords when the toggle is on", () => {
+    const { container } = render(<UnitWeapons unit={unitWith({ wrapKeywords: true })} />);
+
+    expect(weaponsPanel(container).className).not.toContain("keywords-nowrap");
+  });
+
+  it("opts out of wrapping when the toggle is off", () => {
+    const { container } = render(<UnitWeapons unit={unitWith({ wrapKeywords: false })} />);
+
+    expect(weaponsPanel(container).className).toContain("keywords-nowrap");
+  });
+
+  // One class governs both weapon types — the bug that started this was ranged
+  // and melee disagreeing about keyword layout on the same card.
+  it("applies the opt-out to ranged and melee together", () => {
+    const { container } = render(<UnitWeapons unit={unitWith({ wrapKeywords: false })} />);
+    const panel = weaponsPanel(container);
+
+    expect(panel.querySelector(".ranged")).not.toBeNull();
+    expect(panel.querySelector(".melee")).not.toBeNull();
+    expect(panel.querySelectorAll(".keywords-nowrap")).toHaveLength(0);
+    expect(panel.className).toContain("keywords-nowrap");
+  });
+});

--- a/src/Components/Warhammer40k-11e/UnitCard/UnitWeapons.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCard/UnitWeapons.jsx
@@ -9,8 +9,12 @@ import { UnitWeaponsType } from "./UnitWeaponsType";
 export const UnitWeapons = ({ unit }) => {
   const showRanged = unit.showWeapons?.rangedWeapons !== false;
   const showMelee = unit.showWeapons?.meleeWeapons !== false;
+  // Weapon keyword lists wrap inside the name column by default. Cards that
+  // turn the "Wrap Keywords" styling toggle off opt into one unbreakable line
+  // per list instead; an absent flag means wrap.
+  const wrapKeywords = unit.wrapKeywords !== false;
   return (
-    <div className="weapons">
+    <div className={`weapons${wrapKeywords ? "" : " keywords-nowrap"}`}>
       {showRanged && unit.rangedWeapons && unit.rangedWeapons.length > 0 && (
         <UnitWeaponsType
           weaponType={{ name: "Ranged weapons", class: "ranged", skill: "BS" }}

--- a/src/Components/Warhammer40k-11e/UnitCardEditor/UnitStylingInfo.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCardEditor/UnitStylingInfo.jsx
@@ -404,6 +404,21 @@ export function UnitStylingInfo() {
         )}
       </Card>
 
+      <Card type={"inner"} title="Weapon Keywords" size="small" bodyStyle={{ padding: 16 }} style={{ marginTop: 16 }}>
+        <Form size="small">
+          <Form.Item label={"Wrap Keywords"} style={{ marginBottom: 0 }}>
+            <Switch
+              checked={activeCard.wrapKeywords !== false}
+              onChange={(value) => updateActiveCard({ ...activeCard, wrapKeywords: value })}
+            />
+            <Text type="secondary" style={{ fontSize: "12px", display: "block", marginTop: 4 }}>
+              Long keyword lists wrap inside the weapon name column. Turn this off to keep each list on one line,
+              running on under the characteristics.
+            </Text>
+          </Form.Item>
+        </Form>
+      </Card>
+
       <Card
         type={"inner"}
         title="Custom Colours"

--- a/src/styles/40k-10e.less
+++ b/src/styles/40k-10e.less
@@ -2263,6 +2263,15 @@
           gap: 16px;
           padding-bottom: 16px;
 
+          // Weapon keyword lists wrap by default, so a long list stays inside
+          // the weapon name column. The card's "Wrap Keywords" styling
+          // toggle turns that off by adding `keywords-nowrap` here, which
+          // keeps each list on one line running on under the characteristic
+          // columns instead.
+          &.keywords-nowrap .weapon .line .keyword {
+            white-space: nowrap;
+          }
+
           .ranged {
             position: relative;
 
@@ -2333,19 +2342,15 @@
                   z-index: 2;
 
                   // A grid track's automatic minimum is its content's
-                  // min-content width, and the keyword list below is `nowrap`.
-                  // Without this the name column stretches to fit the keywords
-                  // and shoves the characteristic columns out of line with
-                  // their header; with it the keywords simply run on underneath
-                  // them.
+                  // min-content width. With `keywords-nowrap` the keyword list
+                  // is one unbreakable run, so without this the name column
+                  // stretches to fit it and shoves the characteristic columns
+                  // out of line with their header; with it the keywords simply
+                  // run on underneath them.
                   min-width: 0;
 
                   .name {
                     white-space: pre-line;
-                  }
-
-                  .keyword {
-                    white-space: nowrap;
                   }
                 }
               }
@@ -2421,21 +2426,12 @@
                   z-index: 2;
 
                   // A grid track's automatic minimum is its content's
-                  // min-content width, and the keyword list below is `nowrap`.
-                  // Without this the name column stretches to fit the keywords
-                  // and shoves the characteristic columns out of line with
-                  // their header; with it the keywords simply run on underneath
-                  // them.
+                  // min-content width. With `keywords-nowrap` the keyword list
+                  // is one unbreakable run, so without this the name column
+                  // stretches to fit it and shoves the characteristic columns
+                  // out of line with their header; with it the keywords simply
+                  // run on underneath them.
                   min-width: 0;
-
-                  // Keep the keyword list on one line, exactly as the ranged
-                  // block does. The keywords are inline-block buttons, so
-                  // without this they break between tags and fold into the
-                  // narrow name column instead of running on under the
-                  // characteristic columns.
-                  .keyword {
-                    white-space: nowrap;
-                  }
                 }
               }
             }
@@ -3456,6 +3452,15 @@
             flex-direction: column;
             gap: 16px;
 
+            // Weapon keyword lists wrap by default, so a long list stays inside
+            // the weapon name column. The card's "Wrap Keywords" styling
+            // toggle turns that off by adding `keywords-nowrap` here, which
+            // keeps each list on one line running on under the characteristic
+            // columns instead.
+            &.keywords-nowrap .weapon .line .keyword {
+              white-space: nowrap;
+            }
+
             .ranged {
               position: relative;
 
@@ -3546,16 +3551,12 @@
                     letter-spacing: normal;
                     z-index: 2;
 
-                    // See the printed-card block: keeps the nowrap keyword list
-                    // from widening the name column.
+                    // See the printed-card block: keeps a `keywords-nowrap`
+                    // keyword list from widening the name column.
                     min-width: 0;
 
                     .name {
                       white-space: pre-line;
-                    }
-
-                    .keyword {
-                      white-space: nowrap;
                     }
                   }
                 }
@@ -3651,12 +3652,11 @@
                     letter-spacing: normal;
                     z-index: 2;
 
-                    // See the printed-card block: keeps the nowrap keyword list
-                    // from widening the name column.
+                    // See the printed-card block: keeps a `keywords-nowrap`
+                    // keyword list from widening the name column.
                     min-width: 0;
 
                     .keyword {
-                      white-space: nowrap;
                       grid-area: column-8;
                     }
                   }

--- a/src/styles/__tests__/weaponKeywords.styles.test.js
+++ b/src/styles/__tests__/weaponKeywords.styles.test.js
@@ -4,17 +4,20 @@ import { resolve, dirname } from "node:path";
 import less from "less";
 
 // The 10e/11e weapon row renders its keyword list as a `.keyword` span of
-// inline-block buttons inside the (narrow) name column. `white-space: nowrap`
-// is what keeps that list on one line so it runs on under the characteristic
-// columns; without it the list folds inside the name column and the row grows.
-// The melee block used to carry the rule commented out, so melee and ranged
-// weapons laid their keywords out differently on the same card.
+// inline-block buttons inside the (narrow) name column.
+//
+// By default that list wraps, so a long list stays inside the name column. The
+// card's "Wrap Keywords" styling toggle turns wrapping off by adding
+// `keywords-nowrap` to the weapons panel, which keeps each list on one unbroken
+// line running on under the characteristic columns.
+//
+// Both weapon types must behave identically: melee once carried its keyword
+// rule commented out, so melee and ranged laid out differently on one card.
 const STYLE_FILE = resolve(process.cwd(), "src/styles/40k-10e.less");
 
 const CARD = ".unit .data_container .data .weapons";
 const VIEWER = ".viewer .unit .data_container .data .weapons";
 const CELL = ".weapon .line .value";
-const KEYWORD = `${CELL} .keyword`;
 
 let css = "";
 
@@ -36,15 +39,29 @@ const ruleBody = (selector) => {
 };
 
 describe("40k 10e/11e weapon keyword layout", () => {
+  // The bug this replaced: an unconditional `white-space: nowrap` on ranged and
+  // a commented-out one on melee. Nothing may reintroduce it outside the
+  // `keywords-nowrap` opt-out.
   it.each([
-    ["ranged", "printed card", `.data-40k-10e ${CARD} .ranged ${KEYWORD}`],
-    ["melee", "printed card", `.data-40k-10e ${CARD} .melee ${KEYWORD}`],
-    ["ranged", "mobile viewer", `.data-40k-10e ${VIEWER} .ranged ${KEYWORD}`],
-    ["melee", "mobile viewer", `.data-40k-10e ${VIEWER} .melee ${KEYWORD}`],
-  ])("keeps %s weapon keywords on one line on the %s", (_type, _surface, selector) => {
-    const body = ruleBody(selector);
+    ["ranged", "printed card", `.data-40k-10e ${CARD} .ranged ${CELL} .keyword`],
+    ["melee", "printed card", `.data-40k-10e ${CARD} .melee ${CELL} .keyword`],
+    ["ranged", "mobile viewer", `.data-40k-10e ${VIEWER} .ranged ${CELL} .keyword`],
+    ["melee", "mobile viewer", `.data-40k-10e ${VIEWER} .melee ${CELL} .keyword`],
+  ])("lets %s weapon keywords wrap by default on the %s", (_type, _surface, selector) => {
+    // The rule may be absent entirely — what matters is that nothing forces
+    // the list onto one line.
+    expect(ruleBody(selector) ?? "").not.toContain("white-space: nowrap");
+  });
 
-    expect(body, `${selector} should be present in the compiled stylesheet`).not.toBeNull();
+  it.each([
+    ["printed card", `.data-40k-10e ${CARD}`],
+    ["mobile viewer", `.data-40k-10e ${VIEWER}`],
+    ["11th edition printed card", `.data-40k-11e ${CARD}`],
+    ["11th edition mobile viewer", `.data-40k-11e ${VIEWER}`],
+  ])("keeps keywords on one line when the toggle is off, on the %s", (_surface, prefix) => {
+    const body = ruleBody(`${prefix}.keywords-nowrap .weapon .line .keyword`);
+
+    expect(body, `${prefix}.keywords-nowrap should be present in the compiled stylesheet`).not.toBeNull();
     expect(body).toContain("white-space: nowrap");
   });
 
@@ -58,10 +75,5 @@ describe("40k 10e/11e weapon keyword layout", () => {
     ["melee", "mobile viewer", `.data-40k-10e ${VIEWER} .melee ${CELL}`],
   ])("lets the %s name column shrink on the %s", (_type, _surface, selector) => {
     expect(ruleBody(selector)).toContain("min-width: 0");
-  });
-
-  it("applies the same rules to 11th edition", () => {
-    expect(ruleBody(`.data-40k-11e ${CARD} .melee ${KEYWORD}`)).toContain("white-space: nowrap");
-    expect(ruleBody(`.data-40k-11e ${CARD} .melee ${CELL}`)).toContain("min-width: 0");
   });
 });


### PR DESCRIPTION
## Proposed Changes

Follow-up to [#269](https://github.com/ronplanken/game-datacards/pull/269), which made melee weapon keywords match ranged by forcing both onto one line. That picked the wrong side of the inconsistency: wrapping is the wanted behaviour. This reverses the default and makes the choice a per-card setting.

**Wrapping is now the default**, on ranged and melee alike. The unconditional `white-space: nowrap` is gone from all four weapon-row blocks in `src/styles/40k-10e.less` (ranged/melee × printed card/mobile viewer).

**The one-line layout stays available per card.** The Styling panel gains a "Weapon Keywords → Wrap Keywords" switch writing a `wrapKeywords` boolean. `UnitWeapons` turns that into a `keywords-nowrap` class on the `.weapons` panel, and the stylesheet hangs the `nowrap` opt-out off it. `.weapons` is the one node that has the unit in scope and is an ancestor of every weapon row, so a single class covers ranged and melee, all four card variants, and both the printed card and the mobile viewer.

An absent flag means wrap, so cards saved before the toggle keep the default.

`min-width: 0` on the name cell is kept from #269 — it is what stops the unwrapped list from widening the name column and dragging the characteristic columns out of line with their headings.

**Mobile** gets the same toggle: a new `StylingSection` in the mobile card editor, registered in `MobileCardEditor` and pushed by the 10e and 11e resolvers. It only appears when the card has weapons, since keywords live on weapon profiles.

Both editions are covered — 11e shares this stylesheet and has the same `UnitWeapons` structure.

**Patch note:** adds `changes/unreleased/wrap-weapon-keywords-toggle.json`. The #269 note shipped as v3.11.8 while this branch was open, so this change needs its own entry and the note is written to read as a follow-on for anyone who saw the previous one.

Also documents `wrapKeywords` in `docs/card-data-formats.md`.

`main` was merged in to resolve a conflict: the release backlog drained while this was open, consuming #269's fragment. Those commits are release bookkeeping only (`package.json`, `releaseNotes.json`, and the consumed fragments) with no source changes, so nothing here needed rework.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes

`yarn lint` clean; `yarn test:ci` 3377 tests passing after the merge. New coverage:

- `src/styles/__tests__/weaponKeywords.styles.test.js` — compiles the LESS and asserts nothing forces `nowrap` by default, that the `keywords-nowrap` opt-out exists on both surfaces and both editions, and that `min-width: 0` is retained.
- `WeaponKeywordWrapping.test.jsx` — renders `UnitWeapons` for both editions across absent/true/false flags, and checks one class governs ranged and melee together.
- `UnitStylingInfo.wrapKeywords.test.jsx` — the desktop switch's state and writes, both editions.
- `StylingSection.test.jsx` — the mobile toggle plus its wiring into the resolvers, including that it is omitted for cards with no weapons.

One existing assertion in `editorSchemaResolvers.test.js` pins the exact 11e section list and was updated for the new section.

Verified visually by compiling the stylesheet and rendering the DOM `UnitWeapon` emits, in both toggle states: wrapping keeps long lists inside the name column, the opt-out runs them on under the characteristics, and the characteristic columns stay aligned with their headings either way.