### PR TITLE
Add faction symbol colour toggle and reuse library

### DIFF
--- a/changes/unreleased/faction-symbol-colours-and-library.json
+++ b/changes/unreleased/faction-symbol-colours-and-library.json
@@ -1,0 +1,5 @@
+{
+  "title": "Reuse faction symbols and keep their colours",
+  "body": "Custom faction symbols were always flattened to black, so an uploaded symbol lost its colours. A new Original Colours switch in the Faction Symbol panel leaves them alone; it stays off by default, which is the look that matches the printed cards. Uploading a symbol onto a card that already had one also kept showing the old image until you switched the panel off and on again, and that now updates straight away. Finally, a Saved symbols button lists every symbol you have uploaded in this browser so you can put one on another card without hunting for the file again, and removing a symbol no longer closes the panel so you can pick a replacement right away.",
+  "severity": "info"
+}

--- a/docs/card-data-formats.md
+++ b/docs/card-data-formats.md
@@ -201,6 +201,8 @@ There are four `cardType` values:
   "hasCustomFactionSymbol": false,  // Replace the default symbol
   "externalFactionSymbol": null,    // URL string or null
   "customFactionSymbolFilename": null,
+  "factionSymbolUpdatedAt": null,   // Timestamp; bumped when the stored symbol changes
+  "keepFactionSymbolColours": false, // Skip the flatten-to-black filter
   "factionSymbolScale": 0.8,
   "factionSymbolPositionX": 0,
   "factionSymbolPositionY": 0,
@@ -759,6 +761,23 @@ Resolution order, implemented in `src/Helpers/factionSymbol.helpers.js`:
 
 Candidates are tried in order and the first one that resolves to an SVG wins, so
 a faction without a symbol of its own still falls back to its parent's.
+
+### Custom symbols
+
+Uploads are stored in IndexedDB (database `CardImagesDB`, store `images`) under
+`faction-<card uuid>`, alongside the card artwork stored under the bare uuid.
+One card, one stored symbol.
+
+- `factionSymbolUpdatedAt` is the card's cache key for that entry. Replacing a
+  symbol changes neither the card uuid nor `hasCustomFactionSymbol`, so without
+  a new timestamp the renderers keep showing the previous image.
+- `keepFactionSymbolColours` skips the `saturate(0%)` filter that flattens a
+  symbol to black. The filter is on by default because it is what matches the
+  printed cards; the built-in symbols are always flattened.
+- The symbol library (`FactionSymbolLibraryModal`) lists every `faction-`
+  entry in this browser so an existing symbol can be copied onto another card.
+  Entries are deduplicated by filename, size and type, since reusing a symbol
+  stores a copy per card.
 
 ---
 

--- a/src/Components/CardEditor/FactionSymbolPanel.jsx
+++ b/src/Components/CardEditor/FactionSymbolPanel.jsx
@@ -1,6 +1,7 @@
 import { Button, Card, Form, Input, Slider, Space, Switch, Typography, Upload } from "antd";
 import { Images, Trash2, Upload as UploadIcon } from "lucide-react";
 import React, { useEffect, useState } from "react";
+import { formatFileSize } from "../../Helpers/generic.helpers";
 import { useCardStorage } from "../../Hooks/useCardStorage";
 import { useIndexedDBImages } from "../../Hooks/useIndexedDBImages";
 import { message } from "../Toast/message";
@@ -9,12 +10,6 @@ import { FactionSymbolLibraryModal } from "../FactionSymbolLibraryModal";
 const { Text } = Typography;
 
 const MAX_SYMBOL_BYTES = 2 * 1024 * 1024;
-
-const formatFileSize = (bytes) => {
-  if (bytes < 1024) return `${bytes} bytes`;
-  if (bytes < 1048576) return `${Math.round(bytes / 1024)} KB`;
-  return `${Math.round((bytes / 1048576) * 10) / 10} MB`;
-};
 
 /**
  * The faction symbol section of the card styling editor. Shared by the 10th and

--- a/src/Components/CardEditor/FactionSymbolPanel.jsx
+++ b/src/Components/CardEditor/FactionSymbolPanel.jsx
@@ -1,0 +1,271 @@
+import { Button, Card, Form, Input, Slider, Space, Switch, Typography, Upload } from "antd";
+import { Images, Trash2, Upload as UploadIcon } from "lucide-react";
+import React, { useEffect, useState } from "react";
+import { useCardStorage } from "../../Hooks/useCardStorage";
+import { useIndexedDBImages } from "../../Hooks/useIndexedDBImages";
+import { message } from "../Toast/message";
+import { FactionSymbolLibraryModal } from "../FactionSymbolLibraryModal";
+
+const { Text } = Typography;
+
+const MAX_SYMBOL_BYTES = 2 * 1024 * 1024;
+
+const formatFileSize = (bytes) => {
+  if (bytes < 1024) return `${bytes} bytes`;
+  if (bytes < 1048576) return `${Math.round(bytes / 1024)} KB`;
+  return `${Math.round((bytes / 1048576) * 10) / 10} MB`;
+};
+
+/**
+ * The faction symbol section of the card styling editor. Shared by the 10th and
+ * 11th edition editors, which render the same panel against the same card
+ * fields.
+ */
+export function FactionSymbolPanel() {
+  const { activeCard, updateActiveCard, saveActiveCard } = useCardStorage();
+  const { saveFactionSymbol, deleteFactionSymbol, getFactionSymbolData, isReady } = useIndexedDBImages();
+  const [factionSymbolInfo, setFactionSymbolInfo] = useState(null);
+  const [uploadingFactionSymbol, setUploadingFactionSymbol] = useState(false);
+  const [libraryOpen, setLibraryOpen] = useState(false);
+
+  useEffect(() => {
+    const loadFactionSymbolInfo = async () => {
+      if (activeCard?.uuid && isReady) {
+        const symbolData = await getFactionSymbolData(activeCard.uuid);
+        if (symbolData) {
+          setFactionSymbolInfo({ filename: symbolData.filename, size: symbolData.size });
+        } else {
+          setFactionSymbolInfo(null);
+        }
+      } else {
+        setFactionSymbolInfo(null);
+      }
+    };
+    loadFactionSymbolInfo();
+    // getFactionSymbolData is rebuilt on every render; depending on it loops.
+  }, [activeCard?.uuid, isReady]);
+
+  // Persisting the timestamp is what tells the card renderers to re-read the
+  // stored symbol: swapping one on a card that already had a symbol changes
+  // nothing else they watch.
+  const applySymbol = (filename, size) => {
+    const updatedCard = {
+      ...activeCard,
+      hasCustomFactionSymbol: true,
+      customFactionSymbolFilename: filename,
+      factionSymbolUpdatedAt: Date.now(),
+    };
+    updateActiveCard(updatedCard);
+    saveActiveCard(updatedCard);
+    setFactionSymbolInfo({ filename, size });
+  };
+
+  const handleFactionSymbolUpload = async (file) => {
+    const actualFile = file?.file || file;
+
+    if (!actualFile) {
+      message.error("No file selected");
+      return false;
+    }
+
+    if (!activeCard?.uuid) {
+      message.error("Please add this card to a category first");
+      return false;
+    }
+
+    if (actualFile.size > MAX_SYMBOL_BYTES) {
+      message.error("Symbol size must be less than 2MB");
+      return false;
+    }
+
+    if (!actualFile.type.startsWith("image/")) {
+      message.error("Please upload an image file");
+      return false;
+    }
+
+    setUploadingFactionSymbol(true);
+    try {
+      await saveFactionSymbol(activeCard.uuid, actualFile);
+      applySymbol(actualFile.name, actualFile.size);
+      message.success("Faction symbol uploaded successfully");
+    } catch (error) {
+      message.error("Failed to upload faction symbol");
+    } finally {
+      setUploadingFactionSymbol(false);
+    }
+
+    return false;
+  };
+
+  const handleSelectSavedSymbol = async (symbol) => {
+    if (!activeCard?.uuid) {
+      message.error("Please add this card to a category first");
+      return;
+    }
+
+    try {
+      // The stored blob carries no name of its own, so pass the original one on.
+      await saveFactionSymbol(activeCard.uuid, symbol.image, symbol.filename);
+      applySymbol(symbol.filename, symbol.size);
+      setLibraryOpen(false);
+      message.success("Faction symbol applied");
+    } catch (error) {
+      message.error("Failed to apply faction symbol");
+    }
+  };
+
+  const handleDeleteFactionSymbol = async () => {
+    if (!activeCard?.uuid) return;
+
+    try {
+      await deleteFactionSymbol(activeCard.uuid);
+      const updatedCard = {
+        ...activeCard,
+        customFactionSymbolFilename: null,
+        factionSymbolUpdatedAt: Date.now(),
+      };
+      updateActiveCard(updatedCard);
+      saveActiveCard(updatedCard);
+      setFactionSymbolInfo(null);
+      message.success("Faction symbol removed");
+    } catch (error) {
+      message.error("Failed to delete faction symbol");
+    }
+  };
+
+  return (
+    <Card
+      type={"inner"}
+      title="Faction Symbol"
+      size="small"
+      bodyStyle={{ padding: activeCard.hasCustomFactionSymbol ? 16 : 0 }}
+      extra={
+        <Switch
+          checked={activeCard.hasCustomFactionSymbol || false}
+          onChange={(value) => {
+            const updatedCard = { ...activeCard, hasCustomFactionSymbol: value };
+            updateActiveCard(updatedCard);
+            saveActiveCard(updatedCard);
+          }}
+        />
+      }>
+      {activeCard.hasCustomFactionSymbol && (
+        <Form size="small">
+          <Form.Item label={"External URL"}>
+            <Input
+              type={"text"}
+              value={activeCard.externalFactionSymbol}
+              onChange={(e) => updateActiveCard({ ...activeCard, externalFactionSymbol: e.target.value })}
+              placeholder="https://example.com/symbol.svg"
+            />
+          </Form.Item>
+
+          <Form.Item label={"Local Image"}>
+            <Space direction="vertical" style={{ width: "100%" }}>
+              {factionSymbolInfo && (
+                <Space>
+                  <Text>
+                    {factionSymbolInfo.filename} ({formatFileSize(factionSymbolInfo.size)})
+                  </Text>
+                  <Button icon={<Trash2 size={14} />} size="small" danger onClick={handleDeleteFactionSymbol}>
+                    Remove
+                  </Button>
+                </Space>
+              )}
+              <Space>
+                <Upload
+                  accept="image/*,.svg"
+                  showUploadList={false}
+                  beforeUpload={(file) => {
+                    handleFactionSymbolUpload(file);
+                    return false;
+                  }}
+                  disabled={!isReady}>
+                  <Button icon={<UploadIcon size={14} />} loading={uploadingFactionSymbol} disabled={!isReady}>
+                    {factionSymbolInfo ? "Replace" : "Upload Symbol"}
+                  </Button>
+                </Upload>
+                <Button icon={<Images size={14} />} disabled={!isReady} onClick={() => setLibraryOpen(true)}>
+                  Saved symbols
+                </Button>
+              </Space>
+              <Text type="secondary" style={{ fontSize: "12px" }}>
+                SVG or PNG recommended. Symbol will be displayed in the faction badge.
+              </Text>
+            </Space>
+          </Form.Item>
+
+          <Form.Item label={"Original Colours"}>
+            <Space>
+              <Switch
+                checked={activeCard.keepFactionSymbolColours || false}
+                onChange={(value) => updateActiveCard({ ...activeCard, keepFactionSymbolColours: value })}
+              />
+              <Text type="secondary" style={{ fontSize: "12px" }}>
+                Off matches the printed cards by flattening the symbol to black
+              </Text>
+            </Space>
+          </Form.Item>
+
+          <Form.Item label={"Scale"}>
+            <div style={{ paddingRight: "20px" }}>
+              <Slider
+                min={0.5}
+                max={2}
+                step={0.1}
+                value={activeCard.factionSymbolScale || 0.8}
+                onChange={(value) => updateActiveCard({ ...activeCard, factionSymbolScale: value })}
+                marks={{
+                  0.5: "50%",
+                  1: "100%",
+                  2: "200%",
+                }}
+                tooltip={{ formatter: (value) => `${Math.round(value * 100)}%` }}
+              />
+            </div>
+          </Form.Item>
+
+          <Form.Item label={"Horizontal Position"}>
+            <div style={{ paddingRight: "20px" }}>
+              <Slider
+                min={-30}
+                max={30}
+                value={activeCard.factionSymbolPositionX || 0}
+                onChange={(value) => updateActiveCard({ ...activeCard, factionSymbolPositionX: value })}
+                marks={{
+                  [-30]: "Left",
+                  0: "Center",
+                  30: "Right",
+                }}
+                tooltip={{ formatter: (value) => `${value > 0 ? "+" : ""}${value}px` }}
+              />
+            </div>
+          </Form.Item>
+
+          <Form.Item label={"Vertical Position"} style={{ marginBottom: 0 }}>
+            <div style={{ paddingRight: "20px" }}>
+              <Slider
+                min={-30}
+                max={30}
+                value={activeCard.factionSymbolPositionY || 0}
+                onChange={(value) => updateActiveCard({ ...activeCard, factionSymbolPositionY: value })}
+                marks={{
+                  [-30]: "Top",
+                  0: "Center",
+                  30: "Bottom",
+                }}
+                tooltip={{ formatter: (value) => `${value > 0 ? "+" : ""}${value}px` }}
+              />
+            </div>
+          </Form.Item>
+
+          <FactionSymbolLibraryModal
+            open={libraryOpen}
+            onCancel={() => setLibraryOpen(false)}
+            onSelect={handleSelectSavedSymbol}
+          />
+        </Form>
+      )}
+    </Card>
+  );
+}

--- a/src/Components/CardEditor/__tests__/FactionSymbolPanel.test.jsx
+++ b/src/Components/CardEditor/__tests__/FactionSymbolPanel.test.jsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const saveFactionSymbol = vi.fn();
+const deleteFactionSymbol = vi.fn();
+const getFactionSymbolData = vi.fn();
+const updateActiveCard = vi.fn();
+const saveActiveCard = vi.fn();
+
+let activeCard = {};
+
+vi.mock("../../../Hooks/useCardStorage", () => ({
+  useCardStorage: () => ({ activeCard, updateActiveCard, saveActiveCard }),
+}));
+
+vi.mock("../../../Hooks/useIndexedDBImages", () => ({
+  useIndexedDBImages: () => ({ saveFactionSymbol, deleteFactionSymbol, getFactionSymbolData, isReady: true }),
+}));
+
+vi.mock("../../Toast/message", () => ({
+  message: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("../../FactionSymbolLibraryModal", () => ({
+  FactionSymbolLibraryModal: ({ open, onSelect }) =>
+    open ? (
+      <button
+        data-testid="pick-saved"
+        onClick={() => onSelect({ image: "stored-blob", filename: "saved.svg", size: 900, type: "image/svg+xml" })}
+      />
+    ) : null,
+}));
+
+// antd's responsive Row needs matchMedia, which jsdom does not provide.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+import { FactionSymbolPanel } from "../FactionSymbolPanel";
+
+describe("FactionSymbolPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getFactionSymbolData.mockResolvedValue(null);
+    saveFactionSymbol.mockResolvedValue(undefined);
+    deleteFactionSymbol.mockResolvedValue(undefined);
+    activeCard = { uuid: "card-1", hasCustomFactionSymbol: true };
+  });
+
+  it("stamps the card when a symbol is uploaded so the preview refreshes", async () => {
+    render(<FactionSymbolPanel />);
+    const file = new File(["x"], "badge.png", { type: "image/png" });
+
+    fireEvent.change(document.querySelector('input[type="file"]'), { target: { files: [file] } });
+
+    await waitFor(() => expect(saveFactionSymbol).toHaveBeenCalledWith("card-1", file));
+    const saved = saveActiveCard.mock.calls[0][0];
+    expect(saved.hasCustomFactionSymbol).toBe(true);
+    expect(saved.customFactionSymbolFilename).toBe("badge.png");
+    expect(typeof saved.factionSymbolUpdatedAt).toBe("number");
+  });
+
+  it("copies a symbol picked from the library onto this card, keeping its name", async () => {
+    render(<FactionSymbolPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /saved symbols/i }));
+    fireEvent.click(screen.getByTestId("pick-saved"));
+
+    await waitFor(() => expect(saveFactionSymbol).toHaveBeenCalledWith("card-1", "stored-blob", "saved.svg"));
+    const saved = saveActiveCard.mock.calls[0][0];
+    expect(saved.customFactionSymbolFilename).toBe("saved.svg");
+    expect(typeof saved.factionSymbolUpdatedAt).toBe("number");
+  });
+
+  it("leaves the panel open after removing a symbol so another can be picked", async () => {
+    getFactionSymbolData.mockResolvedValue({ filename: "badge.png", size: 900 });
+    render(<FactionSymbolPanel />);
+
+    await waitFor(() => expect(screen.getByText(/badge.png/)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
+
+    await waitFor(() => expect(deleteFactionSymbol).toHaveBeenCalledWith("card-1"));
+    const saved = saveActiveCard.mock.calls[0][0];
+    expect(saved.hasCustomFactionSymbol).toBe(true);
+    expect(saved.customFactionSymbolFilename).toBeNull();
+  });
+
+  it("toggles the symbol's own colours on the card", () => {
+    render(<FactionSymbolPanel />);
+    const colourSwitch = screen.getAllByRole("switch")[1];
+
+    fireEvent.click(colourSwitch);
+
+    expect(updateActiveCard).toHaveBeenCalledWith(expect.objectContaining({ keepFactionSymbolColours: true }));
+  });
+
+  it("hides the controls while the custom symbol is switched off", () => {
+    activeCard = { uuid: "card-1", hasCustomFactionSymbol: false };
+    render(<FactionSymbolPanel />);
+    expect(screen.queryByRole("button", { name: /saved symbols/i })).toBeNull();
+  });
+});

--- a/src/Components/FactionSymbolLibraryModal.jsx
+++ b/src/Components/FactionSymbolLibraryModal.jsx
@@ -1,0 +1,127 @@
+import { Empty, Modal, Spin, Typography } from "antd";
+import React, { useEffect, useState } from "react";
+import { useIndexedDBImages } from "../Hooks/useIndexedDBImages";
+
+const { Text } = Typography;
+
+const formatFileSize = (bytes) => {
+  if (!bytes && bytes !== 0) return "";
+  if (bytes < 1024) return `${bytes} bytes`;
+  if (bytes < 1048576) return `${Math.round(bytes / 1024)} KB`;
+  return `${Math.round((bytes / 1048576) * 10) / 10} MB`;
+};
+
+/**
+ * The same symbol uploaded onto several cards is stored once per card. Collapse
+ * those into one entry so the library lists symbols, not cards.
+ */
+export const dedupeSymbols = (symbols = []) => {
+  const byContent = new Map();
+  symbols.forEach((symbol) => {
+    const key = `${symbol.filename}|${symbol.size}|${symbol.type}`;
+    const existing = byContent.get(key);
+    if (existing) {
+      existing.usedOnCards += 1;
+      return;
+    }
+    byContent.set(key, { ...symbol, usedOnCards: 1 });
+  });
+  return [...byContent.values()];
+};
+
+/**
+ * Picks one of the faction symbols already stored in this browser so it can be
+ * reused on another card without hunting for the file again.
+ */
+export const FactionSymbolLibraryModal = ({ open, onCancel, onSelect }) => {
+  const { listFactionSymbols, isReady } = useIndexedDBImages();
+  const [symbols, setSymbols] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open || !isReady) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    const previewUrls = [];
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        const stored = await listFactionSymbols();
+        const entries = dedupeSymbols(stored).map((symbol) => {
+          const previewUrl = URL.createObjectURL(symbol.image);
+          previewUrls.push(previewUrl);
+          return { ...symbol, previewUrl };
+        });
+        if (cancelled) return;
+        setSymbols(entries);
+      } catch (error) {
+        if (!cancelled) setSymbols([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+      previewUrls.forEach((url) => URL.revokeObjectURL(url));
+    };
+    // listFactionSymbols is rebuilt on every render of the hook; depending on it
+    // would reload the library in a loop.
+  }, [open, isReady]);
+
+  return (
+    <Modal open={open} onCancel={onCancel} footer={null} title="Saved faction symbols" width={520}>
+      {loading ? (
+        <div style={{ display: "flex", justifyContent: "center", padding: 32 }}>
+          <Spin />
+        </div>
+      ) : symbols.length === 0 ? (
+        <Empty description="You have not uploaded any faction symbols yet" />
+      ) : (
+        <>
+          <Text type="secondary" style={{ fontSize: 12, display: "block", marginBottom: 12 }}>
+            Symbols you uploaded before, stored in this browser. Pick one to use it on this card.
+          </Text>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))", gap: 12 }}>
+            {symbols.map((symbol) => (
+              <button
+                key={symbol.id}
+                type="button"
+                onClick={() => onSelect(symbol)}
+                title={symbol.filename}
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  gap: 6,
+                  padding: 8,
+                  border: "1px solid #d9d9d9",
+                  borderRadius: 6,
+                  background: "#fff",
+                  cursor: "pointer",
+                }}>
+                <img
+                  src={symbol.previewUrl}
+                  alt={symbol.filename}
+                  style={{ width: 64, height: 64, objectFit: "contain" }}
+                />
+                <Text ellipsis style={{ fontSize: 12, maxWidth: "100%" }}>
+                  {symbol.filename}
+                </Text>
+                <Text type="secondary" style={{ fontSize: 11 }}>
+                  {formatFileSize(symbol.size)}
+                  {symbol.usedOnCards > 1 ? ` · on ${symbol.usedOnCards} cards` : ""}
+                </Text>
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </Modal>
+  );
+};

--- a/src/Components/FactionSymbolLibraryModal.jsx
+++ b/src/Components/FactionSymbolLibraryModal.jsx
@@ -1,15 +1,9 @@
 import { Empty, Modal, Spin, Typography } from "antd";
 import React, { useEffect, useState } from "react";
+import { formatFileSize } from "../Helpers/generic.helpers";
 import { useIndexedDBImages } from "../Hooks/useIndexedDBImages";
 
 const { Text } = Typography;
-
-const formatFileSize = (bytes) => {
-  if (!bytes && bytes !== 0) return "";
-  if (bytes < 1024) return `${bytes} bytes`;
-  if (bytes < 1048576) return `${Math.round(bytes / 1024)} KB`;
-  return `${Math.round((bytes / 1048576) * 10) / 10} MB`;
-};
 
 /**
  * The same symbol uploaded onto several cards is stored once per card. Collapse

--- a/src/Components/FactionSymbolLibraryModal.jsx
+++ b/src/Components/FactionSymbolLibraryModal.jsx
@@ -50,12 +50,14 @@ export const FactionSymbolLibraryModal = ({ open, onCancel, onSelect }) => {
       setLoading(true);
       try {
         const stored = await listFactionSymbols();
+        // Bail before creating any url: cleanup has already revoked whatever
+        // previewUrls held, so anything made after it would never be released.
+        if (cancelled) return;
         const entries = dedupeSymbols(stored).map((symbol) => {
           const previewUrl = URL.createObjectURL(symbol.image);
           previewUrls.push(previewUrl);
           return { ...symbol, previewUrl };
         });
-        if (cancelled) return;
         setSymbols(entries);
       } catch (error) {
         if (!cancelled) setSymbols([]);

--- a/src/Components/Icons/CustomFactionSymbol.jsx
+++ b/src/Components/Icons/CustomFactionSymbol.jsx
@@ -2,6 +2,11 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import { useIndexedDBImages } from "../../Hooks/useIndexedDBImages";
 
+// The built-in faction symbols are flattened to black to match the printed
+// cards; an uploaded symbol gets the same treatment unless the card asks to keep
+// its colours.
+const GREYSCALE_FILTER = "invert(0%) sepia(2%) saturate(0%) hue-rotate(253deg) brightness(100%) contrast(100%)";
+
 const SymbolImage = styled.div`
   width: 100%;
   height: 100%;
@@ -9,7 +14,7 @@ const SymbolImage = styled.div`
   background-repeat: no-repeat;
   background-size: contain;
   background-position: center;
-  filter: invert(0%) sepia(2%) saturate(0%) hue-rotate(253deg) brightness(100%) contrast(100%);
+  filter: ${(props) => (props.$keepColours ? "none" : GREYSCALE_FILTER)};
   rotate: -45deg;
   scale: ${(props) => props.$scale || 0.8};
   transform: translate(${(props) => props.$positionX || 0}px, ${(props) => props.$positionY || 0}px);
@@ -26,6 +31,10 @@ export const useCustomFactionSymbolUrl = (card) => {
 
   const uuid = card?.uuid;
   const enabled = card?.hasCustomFactionSymbol;
+  // Bumped whenever the stored symbol is replaced or removed. The card uuid and
+  // the enabled flag both stay put when a symbol is swapped on a card that
+  // already had one, so without this the preview keeps the previous image.
+  const updatedAt = card?.factionSymbolUpdatedAt;
 
   useEffect(() => {
     let cancelled = false;
@@ -62,7 +71,7 @@ export const useCustomFactionSymbolUrl = (card) => {
     };
     // getFactionSymbolUrl is recreated on every render of the hook; depending on
     // it would re-run this effect forever.
-  }, [uuid, enabled, isReady]);
+  }, [uuid, enabled, isReady, updatedAt]);
 
   return symbolUrl;
 };
@@ -71,6 +80,7 @@ export const useCustomFactionSymbolUrl = (card) => {
 export const CustomFactionSymbol = ({ card, imageUrl }) => (
   <SymbolImage
     $imageUrl={imageUrl}
+    $keepColours={card?.keepFactionSymbolColours}
     $scale={card?.factionSymbolScale}
     $positionX={card?.factionSymbolPositionX}
     $positionY={card?.factionSymbolPositionY}

--- a/src/Components/Icons/__tests__/CustomFactionSymbol.test.jsx
+++ b/src/Components/Icons/__tests__/CustomFactionSymbol.test.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const getFactionSymbolUrl = vi.fn();
+
+vi.mock("../../../Hooks/useIndexedDBImages", () => ({
+  useIndexedDBImages: () => ({ getFactionSymbolUrl, isReady: true }),
+}));
+
+import { CustomFactionSymbol, useCustomFactionSymbolUrl } from "../CustomFactionSymbol";
+
+const Probe = ({ card }) => {
+  const url = useCustomFactionSymbolUrl(card);
+  return <div data-testid="url">{url || "none"}</div>;
+};
+
+describe("useCustomFactionSymbolUrl", () => {
+  beforeEach(() => {
+    getFactionSymbolUrl.mockReset();
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  it("re-reads the stored symbol when it is replaced on the same card", async () => {
+    // Regression: uploading over an existing symbol changes neither the card
+    // uuid nor the enabled flag, so the preview kept showing the old image
+    // until the switch was toggled off and on again.
+    getFactionSymbolUrl.mockResolvedValueOnce("blob:first").mockResolvedValueOnce("blob:second");
+    const card = { uuid: "card-1", hasCustomFactionSymbol: true, factionSymbolUpdatedAt: 1 };
+
+    const { getByTestId, rerender } = render(<Probe card={card} />);
+    await waitFor(() => expect(getByTestId("url").textContent).toBe("blob:first"));
+
+    rerender(<Probe card={{ ...card, factionSymbolUpdatedAt: 2 }} />);
+    await waitFor(() => expect(getByTestId("url").textContent).toBe("blob:second"));
+    expect(getFactionSymbolUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not re-read when nothing about the symbol changed", async () => {
+    getFactionSymbolUrl.mockResolvedValue("blob:first");
+    const card = { uuid: "card-1", hasCustomFactionSymbol: true, factionSymbolUpdatedAt: 1 };
+
+    const { getByTestId, rerender } = render(<Probe card={card} />);
+    await waitFor(() => expect(getByTestId("url").textContent).toBe("blob:first"));
+
+    rerender(<Probe card={{ ...card, factionSymbolScale: 1.2 }} />);
+    expect(getFactionSymbolUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads nothing while the custom symbol is switched off", async () => {
+    const { getByTestId } = render(<Probe card={{ uuid: "card-1", hasCustomFactionSymbol: false }} />);
+    await waitFor(() => expect(getByTestId("url").textContent).toBe("none"));
+    expect(getFactionSymbolUrl).not.toHaveBeenCalled();
+  });
+});
+
+describe("CustomFactionSymbol", () => {
+  it("flattens the symbol to black by default", () => {
+    const { container } = render(<CustomFactionSymbol card={{}} imageUrl="blob:s" />);
+    expect(getComputedStyle(container.firstChild).filter).toContain("saturate(0%)");
+  });
+
+  it("keeps the symbol's own colours when the card asks for them", () => {
+    const { container } = render(<CustomFactionSymbol card={{ keepFactionSymbolColours: true }} imageUrl="blob:s" />);
+    expect(getComputedStyle(container.firstChild).filter).toBe("none");
+  });
+});

--- a/src/Components/Warhammer40k-10e/UnitCardEditor/UnitStylingInfo.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCardEditor/UnitStylingInfo.jsx
@@ -2,6 +2,7 @@ import { Form, Input, Select, Switch, Upload, Button, Space, Typography, Slider,
 import { message } from "../../Toast/message";
 import { Upload as UploadIcon, Trash2 } from "lucide-react";
 import React, { useState, useEffect, useCallback } from "react";
+import { formatFileSize } from "../../../Helpers/generic.helpers";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
 import { FactionSymbolPanel } from "../../CardEditor/FactionSymbolPanel";
 import { FactionSelect } from "../FactionSelect";
@@ -107,12 +108,6 @@ export function UnitStylingInfo() {
     } catch (error) {
       message.error("Failed to delete image");
     }
-  };
-
-  const formatFileSize = (bytes) => {
-    if (bytes < 1024) return bytes + " bytes";
-    else if (bytes < 1048576) return Math.round(bytes / 1024) + " KB";
-    else return Math.round((bytes / 1048576) * 10) / 10 + " MB";
   };
 
   return (

--- a/src/Components/Warhammer40k-10e/UnitCardEditor/UnitStylingInfo.jsx
+++ b/src/Components/Warhammer40k-10e/UnitCardEditor/UnitStylingInfo.jsx
@@ -3,6 +3,7 @@ import { message } from "../../Toast/message";
 import { Upload as UploadIcon, Trash2 } from "lucide-react";
 import React, { useState, useEffect, useCallback } from "react";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
+import { FactionSymbolPanel } from "../../CardEditor/FactionSymbolPanel";
 import { FactionSelect } from "../FactionSelect";
 import { useSettingsStorage } from "../../../Hooks/useSettingsStorage";
 import { useIndexedDBImages } from "../../../Hooks/useIndexedDBImages";
@@ -15,19 +16,9 @@ export function UnitStylingInfo() {
   const { activeCard, updateActiveCard, saveActiveCard } = useCardStorage();
   const { settings, updateSettings } = useSettingsStorage();
   const { dataSource } = useDataSourceStorage();
-  const {
-    saveImage,
-    deleteImage,
-    getImageData,
-    saveFactionSymbol,
-    deleteFactionSymbol,
-    getFactionSymbolData,
-    isReady,
-  } = useIndexedDBImages();
+  const { saveImage, deleteImage, getImageData, isReady } = useIndexedDBImages();
   const [localImageInfo, setLocalImageInfo] = useState(null);
   const [uploading, setUploading] = useState(false);
-  const [factionSymbolInfo, setFactionSymbolInfo] = useState(null);
-  const [uploadingFactionSymbol, setUploadingFactionSymbol] = useState(false);
 
   useEffect(() => {
     const loadImageInfo = async () => {
@@ -49,25 +40,6 @@ export function UnitStylingInfo() {
     };
     loadImageInfo();
   }, [activeCard?.uuid, isReady]); // getImageData excluded to prevent infinite loop
-
-  useEffect(() => {
-    const loadFactionSymbolInfo = async () => {
-      if (activeCard?.uuid && isReady) {
-        const symbolData = await getFactionSymbolData(activeCard.uuid);
-        if (symbolData) {
-          setFactionSymbolInfo({
-            filename: symbolData.filename,
-            size: symbolData.size,
-          });
-        } else {
-          setFactionSymbolInfo(null);
-        }
-      } else {
-        setFactionSymbolInfo(null);
-      }
-    };
-    loadFactionSymbolInfo();
-  }, [activeCard?.uuid, isReady]);
 
   const handleImageUpload = async (file) => {
     // Handle both direct file and wrapped file object from Ant Design
@@ -141,71 +113,6 @@ export function UnitStylingInfo() {
     if (bytes < 1024) return bytes + " bytes";
     else if (bytes < 1048576) return Math.round(bytes / 1024) + " KB";
     else return Math.round((bytes / 1048576) * 10) / 10 + " MB";
-  };
-
-  const handleFactionSymbolUpload = async (file) => {
-    const actualFile = file?.file || file;
-
-    if (!actualFile) {
-      message.error("No file selected");
-      return false;
-    }
-
-    if (!activeCard?.uuid) {
-      message.error("Please add this card to a category first");
-      return false;
-    }
-
-    if (actualFile.size > 2 * 1024 * 1024) {
-      message.error("Symbol size must be less than 2MB");
-      return false;
-    }
-
-    if (!actualFile.type.startsWith("image/")) {
-      message.error("Please upload an image file");
-      return false;
-    }
-
-    setUploadingFactionSymbol(true);
-    try {
-      await saveFactionSymbol(activeCard.uuid, actualFile);
-
-      const updatedCard = {
-        ...activeCard,
-        hasCustomFactionSymbol: true,
-        customFactionSymbolFilename: actualFile.name,
-      };
-      updateActiveCard(updatedCard);
-      saveActiveCard(updatedCard);
-
-      setFactionSymbolInfo({
-        filename: actualFile.name,
-        size: actualFile.size,
-      });
-      message.success("Faction symbol uploaded successfully");
-    } catch (error) {
-      message.error("Failed to upload faction symbol");
-    } finally {
-      setUploadingFactionSymbol(false);
-    }
-
-    return false;
-  };
-
-  const handleDeleteFactionSymbol = async () => {
-    if (!activeCard?.uuid) return;
-
-    try {
-      await deleteFactionSymbol(activeCard.uuid);
-      const updatedCard = { ...activeCard, hasCustomFactionSymbol: false, customFactionSymbolFilename: null };
-      updateActiveCard(updatedCard);
-      saveActiveCard(updatedCard);
-
-      setFactionSymbolInfo(null);
-      message.success("Faction symbol removed");
-    } catch (error) {
-      message.error("Failed to delete faction symbol");
-    }
   };
 
   return (
@@ -297,117 +204,7 @@ export function UnitStylingInfo() {
         </Form>
       </Card>
 
-      <Card
-        type={"inner"}
-        title="Faction Symbol"
-        size="small"
-        bodyStyle={{ padding: activeCard.hasCustomFactionSymbol ? 16 : 0 }}
-        extra={
-          <Switch
-            checked={activeCard.hasCustomFactionSymbol || false}
-            onChange={(value) => {
-              const updatedCard = { ...activeCard, hasCustomFactionSymbol: value };
-              updateActiveCard(updatedCard);
-              saveActiveCard(updatedCard);
-            }}
-          />
-        }>
-        {activeCard.hasCustomFactionSymbol && (
-          <Form size="small">
-            <Form.Item label={"External URL"}>
-              <Input
-                type={"text"}
-                value={activeCard.externalFactionSymbol}
-                onChange={(e) => updateActiveCard({ ...activeCard, externalFactionSymbol: e.target.value })}
-                placeholder="https://example.com/symbol.svg"
-              />
-            </Form.Item>
-
-            <Form.Item label={"Local Image"}>
-              <Space direction="vertical" style={{ width: "100%" }}>
-                {!factionSymbolInfo ? (
-                  <Upload
-                    accept="image/*,.svg"
-                    showUploadList={false}
-                    beforeUpload={(file) => {
-                      handleFactionSymbolUpload(file);
-                      return false;
-                    }}
-                    disabled={!isReady}>
-                    <Button icon={<UploadIcon size={14} />} loading={uploadingFactionSymbol} disabled={!isReady}>
-                      Upload Symbol
-                    </Button>
-                  </Upload>
-                ) : (
-                  <Space>
-                    <Text>
-                      {factionSymbolInfo.filename} ({formatFileSize(factionSymbolInfo.size)})
-                    </Text>
-                    <Button icon={<Trash2 size={14} />} size="small" danger onClick={handleDeleteFactionSymbol}>
-                      Remove
-                    </Button>
-                  </Space>
-                )}
-                <Text type="secondary" style={{ fontSize: "12px" }}>
-                  SVG or PNG recommended. Symbol will be displayed in the faction badge.
-                </Text>
-              </Space>
-            </Form.Item>
-
-            <Form.Item label={"Scale"}>
-              <div style={{ paddingRight: "20px" }}>
-                <Slider
-                  min={0.5}
-                  max={2}
-                  step={0.1}
-                  value={activeCard.factionSymbolScale || 0.8}
-                  onChange={(value) => updateActiveCard({ ...activeCard, factionSymbolScale: value })}
-                  marks={{
-                    0.5: "50%",
-                    1: "100%",
-                    2: "200%",
-                  }}
-                  tooltip={{ formatter: (value) => `${Math.round(value * 100)}%` }}
-                />
-              </div>
-            </Form.Item>
-
-            <Form.Item label={"Horizontal Position"}>
-              <div style={{ paddingRight: "20px" }}>
-                <Slider
-                  min={-30}
-                  max={30}
-                  value={activeCard.factionSymbolPositionX || 0}
-                  onChange={(value) => updateActiveCard({ ...activeCard, factionSymbolPositionX: value })}
-                  marks={{
-                    [-30]: "Left",
-                    0: "Center",
-                    30: "Right",
-                  }}
-                  tooltip={{ formatter: (value) => `${value > 0 ? "+" : ""}${value}px` }}
-                />
-              </div>
-            </Form.Item>
-
-            <Form.Item label={"Vertical Position"} style={{ marginBottom: 0 }}>
-              <div style={{ paddingRight: "20px" }}>
-                <Slider
-                  min={-30}
-                  max={30}
-                  value={activeCard.factionSymbolPositionY || 0}
-                  onChange={(value) => updateActiveCard({ ...activeCard, factionSymbolPositionY: value })}
-                  marks={{
-                    [-30]: "Top",
-                    0: "Center",
-                    30: "Bottom",
-                  }}
-                  tooltip={{ formatter: (value) => `${value > 0 ? "+" : ""}${value}px` }}
-                />
-              </div>
-            </Form.Item>
-          </Form>
-        )}
-      </Card>
+      <FactionSymbolPanel />
 
       <Card type={"inner"} title="Weapon Keywords" size="small" bodyStyle={{ padding: 16 }} style={{ marginTop: 16 }}>
         <Form size="small">

--- a/src/Components/Warhammer40k-11e/UnitCardEditor/UnitStylingInfo.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCardEditor/UnitStylingInfo.jsx
@@ -3,6 +3,7 @@ import { message } from "../../Toast/message";
 import { Upload as UploadIcon, Trash2 } from "lucide-react";
 import React, { useState, useEffect } from "react";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
+import { FactionSymbolPanel } from "../../CardEditor/FactionSymbolPanel";
 import { useIndexedDBImages } from "../../../Hooks/useIndexedDBImages";
 import { useDataSourceStorage } from "../../../Hooks/useDataSourceStorage";
 
@@ -15,19 +16,9 @@ const { Text } = Typography;
 export function UnitStylingInfo() {
   const { activeCard, updateActiveCard, saveActiveCard } = useCardStorage();
   const { dataSource } = useDataSourceStorage();
-  const {
-    saveImage,
-    deleteImage,
-    getImageData,
-    saveFactionSymbol,
-    deleteFactionSymbol,
-    getFactionSymbolData,
-    isReady,
-  } = useIndexedDBImages();
+  const { saveImage, deleteImage, getImageData, isReady } = useIndexedDBImages();
   const [localImageInfo, setLocalImageInfo] = useState(null);
   const [uploading, setUploading] = useState(false);
-  const [factionSymbolInfo, setFactionSymbolInfo] = useState(null);
-  const [uploadingFactionSymbol, setUploadingFactionSymbol] = useState(false);
 
   useEffect(() => {
     const loadImageInfo = async () => {
@@ -47,25 +38,6 @@ export function UnitStylingInfo() {
     };
     loadImageInfo();
   }, [activeCard?.uuid, isReady]); // getImageData excluded to prevent infinite loop
-
-  useEffect(() => {
-    const loadFactionSymbolInfo = async () => {
-      if (activeCard?.uuid && isReady) {
-        const symbolData = await getFactionSymbolData(activeCard.uuid);
-        if (symbolData) {
-          setFactionSymbolInfo({
-            filename: symbolData.filename,
-            size: symbolData.size,
-          });
-        } else {
-          setFactionSymbolInfo(null);
-        }
-      } else {
-        setFactionSymbolInfo(null);
-      }
-    };
-    loadFactionSymbolInfo();
-  }, [activeCard?.uuid, isReady]);
 
   const handleImageUpload = async (file) => {
     const actualFile = file?.file || file;
@@ -136,71 +108,6 @@ export function UnitStylingInfo() {
     if (bytes < 1024) return bytes + " bytes";
     else if (bytes < 1048576) return Math.round(bytes / 1024) + " KB";
     else return Math.round((bytes / 1048576) * 10) / 10 + " MB";
-  };
-
-  const handleFactionSymbolUpload = async (file) => {
-    const actualFile = file?.file || file;
-
-    if (!actualFile) {
-      message.error("No file selected");
-      return false;
-    }
-
-    if (!activeCard?.uuid) {
-      message.error("Please add this card to a category first");
-      return false;
-    }
-
-    if (actualFile.size > 2 * 1024 * 1024) {
-      message.error("Symbol size must be less than 2MB");
-      return false;
-    }
-
-    if (!actualFile.type.startsWith("image/")) {
-      message.error("Please upload an image file");
-      return false;
-    }
-
-    setUploadingFactionSymbol(true);
-    try {
-      await saveFactionSymbol(activeCard.uuid, actualFile);
-
-      const updatedCard = {
-        ...activeCard,
-        hasCustomFactionSymbol: true,
-        customFactionSymbolFilename: actualFile.name,
-      };
-      updateActiveCard(updatedCard);
-      saveActiveCard(updatedCard);
-
-      setFactionSymbolInfo({
-        filename: actualFile.name,
-        size: actualFile.size,
-      });
-      message.success("Faction symbol uploaded successfully");
-    } catch (error) {
-      message.error("Failed to upload faction symbol");
-    } finally {
-      setUploadingFactionSymbol(false);
-    }
-
-    return false;
-  };
-
-  const handleDeleteFactionSymbol = async () => {
-    if (!activeCard?.uuid) return;
-
-    try {
-      await deleteFactionSymbol(activeCard.uuid);
-      const updatedCard = { ...activeCard, hasCustomFactionSymbol: false, customFactionSymbolFilename: null };
-      updateActiveCard(updatedCard);
-      saveActiveCard(updatedCard);
-
-      setFactionSymbolInfo(null);
-      message.success("Faction symbol removed");
-    } catch (error) {
-      message.error("Failed to delete faction symbol");
-    }
   };
 
   return (
@@ -292,117 +199,7 @@ export function UnitStylingInfo() {
         </Form>
       </Card>
 
-      <Card
-        type={"inner"}
-        title="Faction Symbol"
-        size="small"
-        bodyStyle={{ padding: activeCard.hasCustomFactionSymbol ? 16 : 0 }}
-        extra={
-          <Switch
-            checked={activeCard.hasCustomFactionSymbol || false}
-            onChange={(value) => {
-              const updatedCard = { ...activeCard, hasCustomFactionSymbol: value };
-              updateActiveCard(updatedCard);
-              saveActiveCard(updatedCard);
-            }}
-          />
-        }>
-        {activeCard.hasCustomFactionSymbol && (
-          <Form size="small">
-            <Form.Item label={"External URL"}>
-              <Input
-                type={"text"}
-                value={activeCard.externalFactionSymbol}
-                onChange={(e) => updateActiveCard({ ...activeCard, externalFactionSymbol: e.target.value })}
-                placeholder="https://example.com/symbol.svg"
-              />
-            </Form.Item>
-
-            <Form.Item label={"Local Image"}>
-              <Space direction="vertical" style={{ width: "100%" }}>
-                {!factionSymbolInfo ? (
-                  <Upload
-                    accept="image/*,.svg"
-                    showUploadList={false}
-                    beforeUpload={(file) => {
-                      handleFactionSymbolUpload(file);
-                      return false;
-                    }}
-                    disabled={!isReady}>
-                    <Button icon={<UploadIcon size={14} />} loading={uploadingFactionSymbol} disabled={!isReady}>
-                      Upload Symbol
-                    </Button>
-                  </Upload>
-                ) : (
-                  <Space>
-                    <Text>
-                      {factionSymbolInfo.filename} ({formatFileSize(factionSymbolInfo.size)})
-                    </Text>
-                    <Button icon={<Trash2 size={14} />} size="small" danger onClick={handleDeleteFactionSymbol}>
-                      Remove
-                    </Button>
-                  </Space>
-                )}
-                <Text type="secondary" style={{ fontSize: "12px" }}>
-                  SVG or PNG recommended. Symbol will be displayed in the faction badge.
-                </Text>
-              </Space>
-            </Form.Item>
-
-            <Form.Item label={"Scale"}>
-              <div style={{ paddingRight: "20px" }}>
-                <Slider
-                  min={0.5}
-                  max={2}
-                  step={0.1}
-                  value={activeCard.factionSymbolScale || 0.8}
-                  onChange={(value) => updateActiveCard({ ...activeCard, factionSymbolScale: value })}
-                  marks={{
-                    0.5: "50%",
-                    1: "100%",
-                    2: "200%",
-                  }}
-                  tooltip={{ formatter: (value) => `${Math.round(value * 100)}%` }}
-                />
-              </div>
-            </Form.Item>
-
-            <Form.Item label={"Horizontal Position"}>
-              <div style={{ paddingRight: "20px" }}>
-                <Slider
-                  min={-30}
-                  max={30}
-                  value={activeCard.factionSymbolPositionX || 0}
-                  onChange={(value) => updateActiveCard({ ...activeCard, factionSymbolPositionX: value })}
-                  marks={{
-                    [-30]: "Left",
-                    0: "Center",
-                    30: "Right",
-                  }}
-                  tooltip={{ formatter: (value) => `${value > 0 ? "+" : ""}${value}px` }}
-                />
-              </div>
-            </Form.Item>
-
-            <Form.Item label={"Vertical Position"} style={{ marginBottom: 0 }}>
-              <div style={{ paddingRight: "20px" }}>
-                <Slider
-                  min={-30}
-                  max={30}
-                  value={activeCard.factionSymbolPositionY || 0}
-                  onChange={(value) => updateActiveCard({ ...activeCard, factionSymbolPositionY: value })}
-                  marks={{
-                    [-30]: "Top",
-                    0: "Center",
-                    30: "Bottom",
-                  }}
-                  tooltip={{ formatter: (value) => `${value > 0 ? "+" : ""}${value}px` }}
-                />
-              </div>
-            </Form.Item>
-          </Form>
-        )}
-      </Card>
+      <FactionSymbolPanel />
 
       <Card type={"inner"} title="Weapon Keywords" size="small" bodyStyle={{ padding: 16 }} style={{ marginTop: 16 }}>
         <Form size="small">

--- a/src/Components/Warhammer40k-11e/UnitCardEditor/UnitStylingInfo.jsx
+++ b/src/Components/Warhammer40k-11e/UnitCardEditor/UnitStylingInfo.jsx
@@ -2,6 +2,7 @@ import { Form, Input, Select, Switch, Upload, Button, Space, Typography, Slider,
 import { message } from "../../Toast/message";
 import { Upload as UploadIcon, Trash2 } from "lucide-react";
 import React, { useState, useEffect } from "react";
+import { formatFileSize } from "../../../Helpers/generic.helpers";
 import { useCardStorage } from "../../../Hooks/useCardStorage";
 import { FactionSymbolPanel } from "../../CardEditor/FactionSymbolPanel";
 import { useIndexedDBImages } from "../../../Hooks/useIndexedDBImages";
@@ -102,12 +103,6 @@ export function UnitStylingInfo() {
     } catch (error) {
       message.error("Failed to delete image");
     }
-  };
-
-  const formatFileSize = (bytes) => {
-    if (bytes < 1024) return bytes + " bytes";
-    else if (bytes < 1048576) return Math.round(bytes / 1024) + " KB";
-    else return Math.round((bytes / 1048576) * 10) / 10 + " MB";
   };
 
   return (

--- a/src/Components/__tests__/FactionSymbolLibraryModal.test.jsx
+++ b/src/Components/__tests__/FactionSymbolLibraryModal.test.jsx
@@ -74,6 +74,23 @@ describe("FactionSymbolLibraryModal", () => {
     expect(listFactionSymbols).not.toHaveBeenCalled();
   });
 
+  it("creates no preview urls when it closes while the library is loading", async () => {
+    let resolveList;
+    listFactionSymbols.mockReturnValue(
+      new Promise((resolve) => {
+        resolveList = resolve;
+      }),
+    );
+
+    const { unmount } = render(<FactionSymbolLibraryModal open onCancel={vi.fn()} onSelect={vi.fn()} />);
+    unmount();
+    resolveList([symbol()]);
+    await waitFor(() => expect(listFactionSymbols).toHaveBeenCalled());
+
+    // Cleanup has already run, so a url made now would never be revoked.
+    expect(global.URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
   it("releases the preview urls it created when it closes", async () => {
     listFactionSymbols.mockResolvedValue([symbol()]);
     const { unmount } = render(<FactionSymbolLibraryModal open onCancel={vi.fn()} onSelect={vi.fn()} />);

--- a/src/Components/__tests__/FactionSymbolLibraryModal.test.jsx
+++ b/src/Components/__tests__/FactionSymbolLibraryModal.test.jsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const listFactionSymbols = vi.fn();
+
+vi.mock("../../Hooks/useIndexedDBImages", () => ({
+  useIndexedDBImages: () => ({ listFactionSymbols, isReady: true }),
+}));
+
+import { FactionSymbolLibraryModal, dedupeSymbols } from "../FactionSymbolLibraryModal";
+
+const symbol = (overrides) => ({
+  id: "faction-a",
+  cardUuid: "a",
+  image: new Blob(["<svg />"], { type: "image/svg+xml" }),
+  filename: "chapter.svg",
+  size: 1024,
+  type: "image/svg+xml",
+  uploadedAt: "2026-01-01T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("dedupeSymbols", () => {
+  it("collapses the same symbol stored against several cards", () => {
+    const result = dedupeSymbols([symbol(), symbol({ id: "faction-b", cardUuid: "b" })]);
+    expect(result).toHaveLength(1);
+    expect(result[0].usedOnCards).toBe(2);
+  });
+
+  it("keeps symbols that differ in name, size or type apart", () => {
+    const result = dedupeSymbols([
+      symbol(),
+      symbol({ id: "faction-b", filename: "other.svg" }),
+      symbol({ id: "faction-c", size: 2048 }),
+      symbol({ id: "faction-d", type: "image/png" }),
+    ]);
+    expect(result).toHaveLength(4);
+    expect(result.every((entry) => entry.usedOnCards === 1)).toBe(true);
+  });
+
+  it("tolerates an empty library", () => {
+    expect(dedupeSymbols()).toEqual([]);
+  });
+});
+
+describe("FactionSymbolLibraryModal", () => {
+  beforeEach(() => {
+    listFactionSymbols.mockReset();
+    global.URL.createObjectURL = vi.fn(() => "blob:preview");
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  it("lists the stored symbols and hands the picked one back", async () => {
+    listFactionSymbols.mockResolvedValue([symbol(), symbol({ id: "faction-b", filename: "badge.png" })]);
+    const onSelect = vi.fn();
+    render(<FactionSymbolLibraryModal open onCancel={vi.fn()} onSelect={onSelect} />);
+
+    await waitFor(() => expect(screen.getByText("chapter.svg")).toBeInTheDocument());
+    expect(screen.getByText("badge.png")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle("chapter.svg"));
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ filename: "chapter.svg" }));
+  });
+
+  it("explains itself when nothing has been uploaded yet", async () => {
+    listFactionSymbols.mockResolvedValue([]);
+    render(<FactionSymbolLibraryModal open onCancel={vi.fn()} onSelect={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("You have not uploaded any faction symbols yet")).toBeInTheDocument());
+  });
+
+  it("does not read the library while it is closed", () => {
+    render(<FactionSymbolLibraryModal open={false} onCancel={vi.fn()} onSelect={vi.fn()} />);
+    expect(listFactionSymbols).not.toHaveBeenCalled();
+  });
+
+  it("releases the preview urls it created when it closes", async () => {
+    listFactionSymbols.mockResolvedValue([symbol()]);
+    const { unmount } = render(<FactionSymbolLibraryModal open onCancel={vi.fn()} onSelect={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("chapter.svg")).toBeInTheDocument());
+    unmount();
+    expect(global.URL.revokeObjectURL).toHaveBeenCalledWith("blob:preview");
+  });
+});

--- a/src/Helpers/__tests__/formatFileSize.test.js
+++ b/src/Helpers/__tests__/formatFileSize.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { formatFileSize } from "../generic.helpers";
+
+describe("formatFileSize", () => {
+  it("reports small files in bytes", () => {
+    expect(formatFileSize(0)).toBe("0 bytes");
+    expect(formatFileSize(1023)).toBe("1023 bytes");
+  });
+
+  it("switches to KB at a kilobyte and MB at a megabyte", () => {
+    expect(formatFileSize(1024)).toBe("1 KB");
+    expect(formatFileSize(1048575)).toBe("1024 KB");
+    expect(formatFileSize(1048576)).toBe("1 MB");
+    expect(formatFileSize(2202010)).toBe("2.1 MB");
+  });
+
+  it("says nothing when the size is unknown", () => {
+    expect(formatFileSize(undefined)).toBe("");
+    expect(formatFileSize(null)).toBe("");
+    expect(formatFileSize(NaN)).toBe("");
+  });
+});

--- a/src/Helpers/generic.helpers.js
+++ b/src/Helpers/generic.helpers.js
@@ -5,3 +5,14 @@ export const reorder = (list, startIndex, endIndex) => {
 
   return result;
 };
+
+/**
+ * Human readable size for an uploaded file, as shown next to card images and
+ * faction symbols. Returns an empty string when the size is unknown.
+ */
+export const formatFileSize = (bytes) => {
+  if (typeof bytes !== "number" || Number.isNaN(bytes)) return "";
+  if (bytes < 1024) return `${bytes} bytes`;
+  if (bytes < 1048576) return `${Math.round(bytes / 1024)} KB`;
+  return `${Math.round((bytes / 1048576) * 10) / 10} MB`;
+};

--- a/src/Hooks/__tests__/useIndexedDBImages.test.js
+++ b/src/Hooks/__tests__/useIndexedDBImages.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { FACTION_SYMBOL_PREFIX, toFactionSymbolEntries } from "../useIndexedDBImages";
+
+const record = (id, overrides = {}) => ({
+  id,
+  image: `blob-${id}`,
+  filename: "symbol.svg",
+  size: 512,
+  type: "image/svg+xml",
+  uploadedAt: "2026-01-01T00:00:00.000Z",
+  ...overrides,
+});
+
+describe("toFactionSymbolEntries", () => {
+  it("keeps only faction symbols, not the card artwork sharing the store", () => {
+    const entries = toFactionSymbolEntries([record(`${FACTION_SYMBOL_PREFIX}card-1`), record("card-1")]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].id).toBe("faction-card-1");
+  });
+
+  it("tags each symbol with the card it was uploaded for", () => {
+    const entries = toFactionSymbolEntries([record(`${FACTION_SYMBOL_PREFIX}card-9`)]);
+    expect(entries[0].cardUuid).toBe("card-9");
+    expect(entries[0].filename).toBe("symbol.svg");
+    expect(entries[0].image).toBe("blob-faction-card-9");
+  });
+
+  it("returns the newest upload first, with undated entries last", () => {
+    const entries = toFactionSymbolEntries([
+      record(`${FACTION_SYMBOL_PREFIX}a`, { uploadedAt: "2026-01-01T00:00:00.000Z" }),
+      record(`${FACTION_SYMBOL_PREFIX}b`, { uploadedAt: undefined }),
+      record(`${FACTION_SYMBOL_PREFIX}c`, { uploadedAt: "2026-06-01T00:00:00.000Z" }),
+    ]);
+    expect(entries.map((entry) => entry.cardUuid)).toEqual(["c", "a", "b"]);
+  });
+
+  it("survives a missing or malformed store result", () => {
+    expect(toFactionSymbolEntries(undefined)).toEqual([]);
+    expect(toFactionSymbolEntries([null, { id: 42 }])).toEqual([]);
+  });
+});

--- a/src/Hooks/useIndexedDBImages.jsx
+++ b/src/Hooks/useIndexedDBImages.jsx
@@ -3,6 +3,27 @@ import React, { useEffect, useState } from "react";
 const DB_NAME = "CardImagesDB";
 const DB_VERSION = 1;
 const STORE_NAME = "images";
+// Faction symbols share the image store; the prefix keeps them apart from the
+// card artwork stored under the bare card uuid.
+export const FACTION_SYMBOL_PREFIX = "faction-";
+
+/**
+ * Picks the faction symbols out of raw image-store records, newest first, each
+ * tagged with the uuid of the card it was uploaded for.
+ */
+export const toFactionSymbolEntries = (stored) =>
+  (Array.isArray(stored) ? stored : [])
+    .filter((entry) => typeof entry?.id === "string" && entry.id.startsWith(FACTION_SYMBOL_PREFIX))
+    .map((entry) => ({
+      id: entry.id,
+      cardUuid: entry.id.slice(FACTION_SYMBOL_PREFIX.length),
+      image: entry.image,
+      filename: entry.filename,
+      size: entry.size,
+      type: entry.type,
+      uploadedAt: entry.uploadedAt,
+    }))
+    .sort((a, b) => String(b.uploadedAt || "").localeCompare(String(a.uploadedAt || "")));
 
 export function useIndexedDBImages() {
   const [db, setDb] = useState(null);
@@ -49,7 +70,9 @@ export function useIndexedDBImages() {
     };
   }, []);
 
-  const saveImage = async (cardId, file) => {
+  // `filename` is only needed when saving a Blob that carries no name of its own
+  // — a symbol copied out of the library, for instance.
+  const saveImage = async (cardId, file, filename) => {
     if (!db || !isReady) {
       throw new Error("IndexedDB is not ready");
     }
@@ -66,7 +89,7 @@ export function useIndexedDBImages() {
       const imageData = {
         id: cardId,
         image: file, // This must be a Blob/File, not a plain object
-        filename: file.name || "unknown",
+        filename: filename || file.name || "unknown",
         size: file.size,
         type: file.type,
         uploadedAt: new Date().toISOString(),
@@ -163,10 +186,35 @@ export function useIndexedDBImages() {
   };
 
   // Faction symbol methods - use prefixed keys to store separately from card images
-  const getFactionSymbolKey = (cardId) => `faction-${cardId}`;
+  const getFactionSymbolKey = (cardId) => `${FACTION_SYMBOL_PREFIX}${cardId}`;
 
-  const saveFactionSymbol = async (cardId, file) => {
-    return saveImage(getFactionSymbolKey(cardId), file);
+  const saveFactionSymbol = async (cardId, file, filename) => {
+    return saveImage(getFactionSymbolKey(cardId), file, filename);
+  };
+
+  /**
+   * Every faction symbol stored in this browser, newest first, each with the
+   * uuid of the card it was uploaded for. Backs the library that lets a symbol
+   * be reused on another card instead of being picked from disk again.
+   */
+  const listFactionSymbols = async () => {
+    if (!db || !isReady) {
+      return [];
+    }
+
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction([STORE_NAME], "readonly");
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.getAll();
+
+      request.onsuccess = () => {
+        resolve(toFactionSymbolEntries(request.result));
+      };
+
+      request.onerror = () => {
+        reject(new Error(`Failed to list faction symbols: ${request.error}`));
+      };
+    });
   };
 
   const getFactionSymbol = async (cardId) => {
@@ -192,6 +240,7 @@ export function useIndexedDBImages() {
     deleteImage,
     getImageUrl,
     saveFactionSymbol,
+    listFactionSymbols,
     getFactionSymbol,
     getFactionSymbolData,
     deleteFactionSymbol,


### PR DESCRIPTION
## Proposed Changes

Follow-up to the faction symbol fix in [#270](https://github.com/ronplanken/game-datacards/pull/270), from user feedback on Discord.

**1. Custom symbols were always flattened to black.**
`CustomFactionSymbol` applied `filter: invert(0%) sepia(2%) saturate(0%) …` to uploaded symbols — the filter the LESS uses to flatten the built-in faction SVGs to match the printed cards. `saturate(0%)` strips all colour, so an uploaded colour symbol could never keep its colours. The panel now has an **Original Colours** switch writing `keepFactionSymbolColours`; when on, the filter is skipped. It defaults to off so existing cards look exactly as they do today.

**2. Replacing a symbol left the old image on screen.**
`useCustomFactionSymbolUrl` keyed only off the card uuid and `hasCustomFactionSymbol`. Uploading onto a card whose switch was already on changes neither, so the effect never re-ran and the badge kept the previous image until the switch was toggled off and back on. Cards now carry `factionSymbolUpdatedAt`, stamped on every upload, library pick and removal, and the loader watches it. (The card-artwork loader has the same shape but is not affected: its Upload button is hidden once an image exists, so `hasLocalImage` always flips as part of the action.)

**3. No way to reuse a symbol already uploaded.**
Symbols are stored per card under `faction-<card uuid>`, so putting the same badge on ten cards meant picking the file from disk ten times. `listFactionSymbols` reads every `faction-` entry in the store, and a **Saved symbols** picker shows them as thumbnails — deduplicated by filename, size and type, since reuse stores a copy per card — and copies the chosen one onto the current card, preserving its original filename.

Two supporting UI changes this needed: **Remove** now clears the stored image without switching the whole panel off (previously it did both, collapsing the panel so you could not pick a replacement), and the upload button replaces in place instead of only appearing when no symbol is set.

The faction symbol section moved into a shared `CardEditor/FactionSymbolPanel`. The 10e and 11e styling editors were carrying byte-identical copies of it, and this change would have doubled that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

`docs/card-data-formats.md` gains the two new card fields and a "Custom symbols" subsection covering the IndexedDB layout, the cache-key timestamp and the library's dedupe rule. Release note in `changes/unreleased/`; the patch bump and `releaseNotes.json` entry are applied by `.github/workflows/release.yml` after merge, per `changes/README.md`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes

`yarn lint` and `yarn test:ci` pass (219 files, 3398 tests). New tests cover the symbol loader's refresh behaviour and the colour filter, the library's dedupe/list/cleanup, the panel's upload, pick and remove flows, and `toFactionSymbolEntries`. The refresh test was verified to fail against the old dependency list.

Not verified in a browser: this sandbox's egress proxy blocks the datasource host, so the app cannot load a datasource and no card can be opened in the styling editor. `yarn build` also fails here on the pre-existing Google Fonts `@import` in `starcraft-tmg.less` (the proxy answers it 405) — unrelated to this diff, which touches no LESS.