### PR TITLE
Card Designer improvements (community side)

### DIFF
--- a/changes/unreleased/card-designer.json
+++ b/changes/unreleased/card-designer.json
@@ -1,0 +1,5 @@
+{
+  "title": "Card Designer gets undo, a data panel and more",
+  "body": "The Card Designer now supports undo and redo, plus a new Data panel that lets you drag fields straight onto the card instead of typing them by hand. Zoom, pan and alignment guides make positioning easier, text and images gained more styling and fit options, and 11th edition datasheets are now supported.",
+  "severity": "success"
+}

--- a/changes/unreleased/card-designer.json
+++ b/changes/unreleased/card-designer.json
@@ -1,5 +1,5 @@
 {
   "title": "Card Designer gets undo, a data panel and more",
-  "body": "The Card Designer now supports undo and redo, plus a new Data panel that lets you drag fields straight onto the card instead of typing them by hand. Zoom, pan and alignment guides make positioning easier, text and images gained more styling and fit options, and 11th edition datasheets are now supported.",
+  "body": "The Card Designer now supports undo and redo, plus a new Data panel that lets you drag fields straight onto the card instead of typing them by hand. Zoom, pan and alignment guides make positioning easier, text and images gained more styling and fit options, and 11th edition datasheets are now supported. Frames can hug their width and height separately, repeater rows can grow to fit their content, double-clicking a frame selects the element inside it, and cards can grow with their content.",
   "severity": "success"
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "author": "<ron.planken@gmail.com>",
   "license": "GPL-3.0-or-later",
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@formkit/auto-animate": "^0.8.0",
     "@mdx-js/react": "^3.1.1",
     "@mdx-js/rollup": "^3.1.1",

--- a/src/Components/Icons/FactionIcon.jsx
+++ b/src/Components/Icons/FactionIcon.jsx
@@ -1,6 +1,7 @@
 // Faction icon component for Warhammer 40k 10th edition cards
 // Fetches SVG and renders inline to fix MacOS print-to-PDF rendering issues
 import React, { useState, useEffect } from "react";
+import { FACTION_SYMBOL_BASE_URL } from "../../Helpers/factionSymbol.helpers";
 
 // Sanitize fetched SVG to prevent XSS and strip rendering artifacts
 const DANGEROUS_ELEMENTS = ["script", "foreignobject"];
@@ -56,10 +57,8 @@ const sanitizeSvg = (raw) => {
 // so a faction without a symbol is not re-requested on every render.
 const svgCache = new Map();
 
-const BASE_URL = "https://raw.githubusercontent.com/ronplanken/40k-Data-Card/master/src/dc";
-
 const fetchSvg = async (factionId) => {
-  const url = `${BASE_URL}/${factionId}.svg`;
+  const url = `${FACTION_SYMBOL_BASE_URL}/${factionId}.svg`;
   if (svgCache.has(url)) return svgCache.get(url);
 
   try {

--- a/src/Components/MiddlePanel/CardView.jsx
+++ b/src/Components/MiddlePanel/CardView.jsx
@@ -8,6 +8,7 @@ import { Warhammer40K11eCardDisplay } from "../Warhammer40k-11e/CardDisplay";
 import { Warhammer40KCardDisplay } from "../Warhammer40k/CardDisplay";
 import { CustomCardDisplay } from "../Custom/CustomCardDisplay";
 import { useAutoFitScale } from "../../Hooks/useAutoFitScale";
+import { useTemplateCardWidth } from "../../Hooks/useTemplateCardWidth";
 
 /**
  * The card-display view for the middle panel. Owns the auto-fit scaling and
@@ -41,7 +42,13 @@ export const CardView = ({
     return "unit";
   };
 
-  const { autoScale } = useAutoFitScale(cardContainerRef, getCardType(), settings.autoFitEnabled !== false);
+  const templateWidth = useTemplateCardWidth(activeCard);
+  const { autoScale } = useAutoFitScale(
+    cardContainerRef,
+    getCardType(),
+    settings.autoFitEnabled !== false,
+    templateWidth,
+  );
 
   const effectiveScale = settings.autoFitEnabled !== false ? autoScale : (settings.zoom || 100) / 100;
   const currentZoom = settings.zoom || 100;

--- a/src/Components/Viewer/ViewerCardDisplay.jsx
+++ b/src/Components/Viewer/ViewerCardDisplay.jsx
@@ -4,6 +4,7 @@ import { useCardStorage } from "../../Hooks/useCardStorage";
 import { useDataSourceStorage } from "../../Hooks/useDataSourceStorage";
 import { useSettingsStorage } from "../../Hooks/useSettingsStorage";
 import { useAutoFitScale } from "../../Hooks/useAutoFitScale";
+import { useTemplateCardWidth } from "../../Hooks/useTemplateCardWidth";
 import { Warhammer40K10eCardDisplay } from "../Warhammer40k-10e/CardDisplay";
 import { Warhammer40K11eCardDisplay } from "../Warhammer40k-11e/CardDisplay";
 import { Warhammer40KCardDisplay } from "../Warhammer40k/CardDisplay";
@@ -31,7 +32,8 @@ export const ViewerCardDisplay = ({ side = "front", type, containerRef }) => {
   };
 
   // Use auto-fit hook
-  const { autoScale } = useAutoFitScale(displayRef, getCardType(), settings.autoFitEnabled !== false);
+  const templateWidth = useTemplateCardWidth(activeCard);
+  const { autoScale } = useAutoFitScale(displayRef, getCardType(), settings.autoFitEnabled !== false, templateWidth);
 
   // Determine effective scale based on mode
   const effectiveScale = settings.autoFitEnabled !== false ? autoScale : (settings.zoom || 100) / 100;

--- a/src/Helpers/__tests__/bindingResolver.test.js
+++ b/src/Helpers/__tests__/bindingResolver.test.js
@@ -234,8 +234,12 @@ describe("bindingResolver", () => {
   describe("stripMarkup", () => {
     it("keeps the content of inline tags", () => {
       expect(stripMarkup("Add 1 to its <k>Leadership</k>.")).toBe("Add 1 to its Leadership.");
-      expect(stripMarkup("Re-roll a failed <b>Battle-shock</b> test.")).toBe("Re-roll a failed Battle-shock test.");
-      expect(stripMarkup("An <i>italic</i> word.")).toBe("An italic word.");
+    });
+
+    it("turns bold and italic tags into markdown markers", () => {
+      expect(stripMarkup("Re-roll a failed <b>Battle-shock</b> test.")).toBe("Re-roll a failed **Battle-shock** test.");
+      expect(stripMarkup("An <i>italic</i> word.")).toBe("An *italic* word.");
+      expect(stripMarkup("<b>Bold</b> and <k>keyword</k>")).toBe("**Bold** and keyword");
     });
 
     it("turns list items into dashed lines", () => {
@@ -352,12 +356,12 @@ describe("bindingResolver", () => {
       expect(resolve("{{abilities.invul.value}}", card)).toBe("4+");
     });
 
-    it("strips rich-text markup from ability descriptions", () => {
+    it("strips rich-text markup from ability descriptions, keeping bold as markdown", () => {
       const description = resolve("{{abilities.other[0].description}}", card);
       expect(description).toBe('While a friendly unit is within 6", add 1 to its Leadership.');
       expect(description).not.toContain("<k>");
       expect(resolve("{{abilities.other[1].description}}", card)).toBe(
-        "Once per battle, this unit can re-roll a failed Battle-shock test.",
+        "Once per battle, this unit can re-roll a failed **Battle-shock** test.",
       );
     });
 

--- a/src/Helpers/__tests__/bindingResolver.test.js
+++ b/src/Helpers/__tests__/bindingResolver.test.js
@@ -1,12 +1,17 @@
 import { describe, it, expect } from "vitest";
 import {
+  areBindingsEmpty,
   extractBindings,
+  formatBindingExpression,
   formatBindingValue,
   getNestedValue,
   hasBindings,
   isLanguageKeyedObject,
   normalizeBindingItem,
   normalizeCardForBinding,
+  parseBindingExpression,
+  parseBindings,
+  resolveExpression,
   resolveTemplate,
   stripMarkup,
 } from "../bindingResolver";
@@ -480,6 +485,133 @@ describe("bindingResolver", () => {
       normalizeCardForBinding(card);
       expect(card.keywords[0]).toEqual({ en: "Infantry", de: "Infanterie" });
       expect(card.rangedWeapons[0].name).toBeUndefined();
+    });
+  });
+
+  describe("binding expressions", () => {
+    it("parses a bare path", () => {
+      expect(parseBindingExpression("name")).toEqual({ path: "name", filters: [] });
+      expect(parseBindingExpression(" stats[0].m ")).toEqual({ path: "stats[0].m", filters: [] });
+    });
+
+    it("parses filters with and without arguments", () => {
+      expect(parseBindingExpression("name | upper")).toEqual({ path: "name", filters: [{ name: "upper" }] });
+      expect(parseBindingExpression('keywords | join:", "')).toEqual({
+        path: "keywords",
+        filters: [{ name: "join", arg: ", " }],
+      });
+      expect(parseBindingExpression('name | upper | prefix:"A: " | truncate:10')).toEqual({
+        path: "name",
+        filters: [{ name: "upper" }, { name: "prefix", arg: "A: " }, { name: "truncate", arg: "10" }],
+      });
+    });
+
+    it("keeps a pipe inside a quoted argument", () => {
+      expect(parseBindingExpression('keywords | join:" | "')).toEqual({
+        path: "keywords",
+        filters: [{ name: "join", arg: " | " }],
+      });
+    });
+
+    it("round-trips through formatBindingExpression", () => {
+      const expressions = [
+        "name",
+        "name | upper",
+        'keywords | join:", "',
+        'missing | default:"n/a"',
+        'name | prefix:"Weapon: " | truncate:"12"',
+      ];
+      for (const expression of expressions) {
+        const parsed = parseBindingExpression(expression);
+        expect(parseBindingExpression(formatBindingExpression(parsed))).toEqual(parsed);
+      }
+      expect(formatBindingExpression({ path: "name", filters: [{ name: "upper" }] })).toBe("name | upper");
+      expect(formatBindingExpression({ path: "keywords", filters: [{ name: "join", arg: ", " }] })).toBe(
+        'keywords | join:", "',
+      );
+    });
+
+    it("escapes quotes in arguments", () => {
+      const expression = formatBindingExpression({ path: "name", filters: [{ name: "prefix", arg: 'a"b' }] });
+      expect(expression).toBe('name | prefix:"a\\"b"');
+      expect(parseBindingExpression(expression).filters[0].arg).toBe('a"b');
+    });
+
+    it("parses the bindings of a text", () => {
+      expect(parseBindings('{{name | upper}} {{keywords | join:" / "}}')).toEqual([
+        { expression: "name | upper", path: "name", filters: [{ name: "upper" }] },
+        { expression: 'keywords | join:" / "', path: "keywords", filters: [{ name: "join", arg: " / " }] },
+      ]);
+      expect(parseBindings("plain text")).toEqual([]);
+    });
+  });
+
+  describe("binding filters", () => {
+    const context = normalizeCardForBinding(make10eCard());
+
+    it("keeps plain bindings working", () => {
+      expect(resolveTemplate("{{name}}", context)).toBe("Captain");
+      expect(resolveTemplate("{{ name }}", context)).toBe("Captain");
+    });
+
+    it("applies case filters", () => {
+      expect(resolveTemplate("{{name | upper}}", context)).toBe("CAPTAIN");
+      expect(resolveTemplate("{{name | lower}}", context)).toBe("captain");
+      expect(resolveTemplate("{{subname | title}}", context)).toBe("Chapter Master");
+    });
+
+    it("applies trim", () => {
+      expect(resolveExpression({ value: "  spaced  " }, "value | trim")).toBe("spaced");
+    });
+
+    it("joins arrays with the given separator and defaults to a comma", () => {
+      expect(resolveTemplate("{{keywords | join}}", context)).toBe("Infantry, Character, Imperium, Captain");
+      expect(resolveTemplate('{{keywords | join:" / "}}', context)).toBe("Infantry / Character / Imperium / Captain");
+      expect(resolveTemplate("{{keywords}}", context)).toBe("Infantry, Character, Imperium, Captain");
+    });
+
+    it("adds a prefix and a suffix only when the value is filled", () => {
+      expect(resolveTemplate('{{rangedWeapons[0].name | prefix:"Weapon: "}}', context)).toBe("Weapon: Bolt pistol");
+      expect(resolveTemplate('{{rangedWeapons[9].name | prefix:"Weapon: "}}', context)).toBe("");
+      expect(resolveTemplate('{{name | suffix:" (unit)"}}', context)).toBe("Captain (unit)");
+      expect(resolveTemplate('{{missing | suffix:" (unit)"}}', context)).toBe("");
+    });
+
+    it("falls back to a default for missing and empty values", () => {
+      expect(resolveTemplate('{{missingField | default:"n/a"}}', context)).toBe("n/a");
+      expect(resolveExpression({ value: "" }, 'value | default:"n/a"')).toBe("n/a");
+      expect(resolveTemplate('{{name | default:"n/a"}}', context)).toBe("Captain");
+    });
+
+    it("truncates with an ellipsis", () => {
+      expect(resolveTemplate("{{abilities.other[0].description | truncate:10}}", context)).toBe("Add 1 to L...");
+      expect(resolveTemplate("{{name | truncate:20}}", context)).toBe("Captain");
+    });
+
+    it("takes the first item and counts arrays", () => {
+      expect(resolveTemplate("{{keywords | first}}", context)).toBe("Infantry");
+      expect(resolveTemplate("{{keywords | count}}", context)).toBe("4");
+      expect(resolveTemplate("{{rangedWeapons | first | upper}}", context)).toBe("BOLT PISTOL");
+      expect(resolveTemplate("{{missing | count}}", context)).toBe("0");
+    });
+
+    it("chains filters in order", () => {
+      expect(resolveTemplate('{{name | upper | prefix:"Unit: "}}', context)).toBe("Unit: CAPTAIN");
+      expect(resolveTemplate('{{missing | default:"none" | upper}}', context)).toBe("NONE");
+    });
+
+    it("ignores unknown filters", () => {
+      expect(resolveTemplate("{{name | bogus}}", context)).toBe("Captain");
+      expect(resolveTemplate('{{name | bogus:"x" | upper}}', context)).toBe("CAPTAIN");
+    });
+
+    it("reports when every binding of a text is empty", () => {
+      expect(areBindingsEmpty("{{transport}}", context)).toBe(true);
+      expect(areBindingsEmpty("{{name}}", context)).toBe(false);
+      expect(areBindingsEmpty("{{transport}} {{missing}}", context)).toBe(true);
+      expect(areBindingsEmpty("{{transport}} {{name}}", context)).toBe(false);
+      expect(areBindingsEmpty('{{transport | default:"-"}}', context)).toBe(false);
+      expect(areBindingsEmpty("static text", context)).toBe(false);
     });
   });
 

--- a/src/Helpers/__tests__/bindingResolver.test.js
+++ b/src/Helpers/__tests__/bindingResolver.test.js
@@ -1,0 +1,507 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractBindings,
+  formatBindingValue,
+  getNestedValue,
+  hasBindings,
+  isLanguageKeyedObject,
+  normalizeBindingItem,
+  normalizeCardForBinding,
+  resolveTemplate,
+  stripMarkup,
+} from "../bindingResolver";
+
+const make10eCard = () => ({
+  id: "10e-1",
+  source: "40k-10e",
+  cardType: "DataCard",
+  name: "Captain",
+  subname: "Chapter Master",
+  stats: [{ name: "Captain", m: '6"', t: "4", sv: "3+", w: "5", ld: "6+", oc: "1", invul: "4+" }],
+  rangedWeapons: [
+    {
+      active: true,
+      profiles: [{ name: "Bolt pistol", range: '12"', attacks: "1", skill: "3+", strength: "4", ap: "0", damage: "1" }],
+    },
+    {
+      active: true,
+      profiles: [
+        { name: "Plasma gun", range: '24"', attacks: "1", skill: "3+", strength: "7", ap: "-2", damage: "1" },
+        {
+          name: "Plasma gun - supercharge",
+          range: '24"',
+          attacks: "1",
+          skill: "3+",
+          strength: "8",
+          ap: "-3",
+          damage: "2",
+        },
+      ],
+    },
+  ],
+  meleeWeapons: [
+    {
+      active: true,
+      profiles: [
+        { name: "Chainsword", range: "Melee", attacks: "4", skill: "3+", strength: "4", ap: "-1", damage: "1" },
+      ],
+    },
+  ],
+  abilities: {
+    core: ["Deep Strike", "Leader"],
+    faction: ["Oath of Moment"],
+    invul: { value: "4+", info: "", showInvulnerableSave: true },
+    other: [
+      { name: "Aura of Command", description: "Add 1 to Leadership.", showAbility: true },
+      { name: "Iron Will", description: "Re-roll a failed Battle-shock test.", showAbility: true },
+    ],
+  },
+  keywords: ["Infantry", "Character", "Imperium", "Captain"],
+  factions: ["Adeptus Astartes"],
+  composition: ["1 Captain"],
+  loadout: "This model is equipped with: bolt pistol; chainsword.",
+  points: [
+    { models: "1", cost: "80", active: true },
+    { models: "3", cost: "220", active: true },
+  ],
+});
+
+const make11eCard = () => ({
+  id: "11e-1",
+  source: "40k-11e",
+  cardType: "DataCard",
+  name: "Captain",
+  subname: { en: "Chapter Master", de: "Ordensmeister" },
+  stats: [{ name: { en: "Captain", de: "Hauptmann" }, m: '6"', t: "4", sv: "3+", w: "5", ld: "6+", oc: "1" }],
+  rangedWeapons: [
+    {
+      profiles: [
+        {
+          name: { en: "Bolt pistol", de: "Bolterpistole" },
+          keywords: ["Pistol"],
+          range: '12"',
+          attacks: "1",
+          skill: "3+",
+          strength: "4",
+          ap: "0",
+          damage: "1",
+        },
+      ],
+    },
+  ],
+  meleeWeapons: [
+    {
+      profiles: [
+        {
+          name: { en: "Chainsword" },
+          keywords: [],
+          range: "Melee",
+          attacks: "4",
+          skill: "3+",
+          strength: "4",
+          ap: "-1",
+          damage: "1",
+        },
+      ],
+    },
+  ],
+  abilities: {
+    core: [{ name: { en: "Deep Strike", de: "Tiefschlag" } }, { name: { en: "Leader", de: "Anführer" } }],
+    faction: [{ name: { en: "Oath of Moment", de: "Schwur des Augenblicks" } }],
+    invul: { value: "4+" },
+    other: [
+      {
+        name: { en: "Aura of Command", de: "Aura des Befehls" },
+        description: {
+          en: 'While a friendly unit is within 6", add 1 to its <k>Leadership</k>.',
+          de: "Aura Beschreibung",
+        },
+      },
+      {
+        name: { en: "Iron Will" },
+        description: { en: "Once per battle, this unit can re-roll a failed <b>Battle-shock</b> test." },
+      },
+    ],
+    primarch: [],
+    special: [],
+    wargear: [],
+    damaged: null,
+  },
+  keywords: [
+    { en: "Infantry", de: "Infanterie" },
+    { en: "Character", de: "Charaktermodell" },
+  ],
+  factions: ["Adeptus Astartes"],
+  composition: [{ en: "1 Captain", de: "1 Hauptmann" }],
+  loadout: { en: "This model is equipped with: bolt pistol.", de: "Ausrüstung." },
+  leader: { en: "This model can be attached to a Squad.", de: "Anführer." },
+  wargear: [{ en: "None", de: "Keine" }],
+  points: [{ models: "1", cost: "80", keyword: { en: "Captain", de: "Hauptmann" }, faction: null }],
+});
+
+const makeAoSCard = () => ({
+  id: "aos-1",
+  source: "aos",
+  cardType: "warscroll",
+  name: "Liberators",
+  subname: "",
+  points: 110,
+  stats: { move: '5"', save: "3+", control: "2", health: "2", ward: "-", wizard: "-", priest: "-" },
+  weapons: {
+    ranged: [],
+    melee: [{ name: "Warhammer", range: "1", attacks: "3", hit: "3+", wound: "3+", rend: "1", damage: "1" }],
+  },
+  abilities: [
+    { name: "Shield of Civilisation", effect: "Add 1 to save rolls.", timing: "Passive" },
+    { name: "Grand Strikes", effect: "Improve Rend by 1." },
+  ],
+  keywords: ["Infantry", "Stormcast Eternals"],
+});
+
+const makeCustomCard = () => ({
+  id: "custom-1",
+  source: "custom-abc",
+  cardType: "unit",
+  name: "Marine",
+  stats: [{ m: '6"', t: "4", sv: "3+" }],
+  weapons: {
+    ranged: [
+      { profiles: [{ name: "Boltgun", range: '24"', a: "2", bs: "3+", s: "4", ap: "0", d: "1" }] },
+      { profiles: [{ name: "Bolt pistol", range: '12"', a: "1", bs: "3+", s: "4", ap: "0", d: "1" }] },
+    ],
+    melee: [{ profiles: [{ name: "Combat knife", range: "Melee", a: "3", ws: "3+", s: "4", ap: "0", d: "1" }] }],
+  },
+  abilities: {
+    core: [{ name: "Deep Strike" }],
+    unit: [
+      { name: "Squad Tactics", description: "Re-roll hit rolls of 1." },
+      { name: "Bolter Drill", description: "Sustained Hits 1." },
+    ],
+  },
+  keywords: ["Infantry", "Imperium"],
+  factionKeywords: ["Adeptus Astartes"],
+  points: 100,
+});
+
+const makeLegacyCustomCard = () => ({
+  id: "custom-2",
+  source: "custom-abc",
+  cardType: "unit",
+  name: "Legacy Marine",
+  abilities: [
+    { category: "unit", name: "Squad Tactics", description: "Re-roll hit rolls of 1." },
+    { category: "unit", name: "Bolter Drill", description: "Sustained Hits 1." },
+    { category: "core", name: "Deep Strike" },
+  ],
+});
+
+const resolve = (template, card, options = {}) =>
+  resolveTemplate(template, normalizeCardForBinding(card, options), options);
+
+describe("bindingResolver", () => {
+  describe("getNestedValue", () => {
+    it("reads dot paths", () => {
+      expect(getNestedValue({ a: { b: "c" } }, "a.b")).toBe("c");
+    });
+
+    it("reads array indexes", () => {
+      expect(getNestedValue({ a: [{ b: "c" }] }, "a[0].b")).toBe("c");
+    });
+
+    it("reads keys containing hyphens", () => {
+      expect(
+        getNestedValue({ abilities: { "special-rules": [{ name: "Fly" }] } }, "abilities.special-rules[0].name"),
+      ).toBe("Fly");
+    });
+
+    it("returns undefined for missing values and non-arrays", () => {
+      expect(getNestedValue({ a: {} }, "a.b.c")).toBeUndefined();
+      expect(getNestedValue({ a: { b: "c" } }, "a[0]")).toBeUndefined();
+      expect(getNestedValue(null, "a")).toBeUndefined();
+      expect(getNestedValue({ a: 1 }, "")).toBeUndefined();
+    });
+
+    it("reads repeater variables", () => {
+      expect(getNestedValue({ $index: 2 }, "$index")).toBe(2);
+    });
+  });
+
+  describe("stripMarkup", () => {
+    it("keeps the content of inline tags", () => {
+      expect(stripMarkup("Add 1 to its <k>Leadership</k>.")).toBe("Add 1 to its Leadership.");
+      expect(stripMarkup("Re-roll a failed <b>Battle-shock</b> test.")).toBe("Re-roll a failed Battle-shock test.");
+      expect(stripMarkup("An <i>italic</i> word.")).toBe("An italic word.");
+    });
+
+    it("turns list items into dashed lines", () => {
+      expect(stripMarkup("Choose one:<ul><li>Move</li><li>Shoot</li></ul>")).toBe("Choose one:\n- Move\n- Shoot");
+    });
+
+    it("normalises carriage returns", () => {
+      expect(stripMarkup("First\r\nSecond\rThird")).toBe("First\nSecond\nThird");
+    });
+
+    it("puts box bullets on their own line", () => {
+      expect(stripMarkup("Effects: ■ One ■ Two")).toBe("Effects:\n■ One\n■ Two");
+    });
+
+    it("leaves markdown alone", () => {
+      expect(stripMarkup("**Bold** and _italic_ and 3 < 4")).toBe("**Bold** and _italic_ and 3 < 4");
+    });
+
+    it("handles non-strings", () => {
+      expect(stripMarkup(undefined)).toBe("");
+      expect(stripMarkup("")).toBe("");
+    });
+  });
+
+  describe("isLanguageKeyedObject", () => {
+    it("detects language maps", () => {
+      expect(isLanguageKeyedObject({ en: "a", de: "b" })).toBe(true);
+      expect(isLanguageKeyedObject({ en: "a", extra: "b" })).toBe(false);
+      expect(isLanguageKeyedObject({})).toBe(false);
+      expect(isLanguageKeyedObject(["en"])).toBe(false);
+      expect(isLanguageKeyedObject("en")).toBe(false);
+    });
+  });
+
+  describe("40k 10th edition", () => {
+    const card = make10eCard();
+
+    it("exposes weapon profile fields at item level", () => {
+      expect(resolve("{{rangedWeapons[0].name}}", card)).toBe("Bolt pistol");
+      expect(resolve("{{rangedWeapons[0].range}} {{rangedWeapons[0].damage}}", card)).toBe('12" 1');
+      expect(resolve("{{meleeWeapons[0].name}}", card)).toBe("Chainsword");
+      expect(resolve("{{rangedWeapons[1].name}}", card)).toBe("Plasma gun");
+    });
+
+    it("keeps the profiles array for repeaters", () => {
+      const normalized = normalizeCardForBinding(card);
+      expect(normalized.rangedWeapons[1].profiles).toHaveLength(2);
+      expect(normalized.rangedWeapons[1].profiles[1].name).toBe("Plasma gun - supercharge");
+    });
+
+    it("resolves keywords as plain strings", () => {
+      expect(resolve("{{keywords[0]}}", card)).toBe("Infantry");
+      expect(resolve("{{keywords[3]}}", card)).toBe("Captain");
+      expect(resolve("{{keywords}}", card)).toBe("Infantry, Character, Imperium, Captain");
+      expect(resolve("{{factions}}", card)).toBe("Adeptus Astartes");
+    });
+
+    it("resolves abilities", () => {
+      expect(resolve("{{abilities.other[0].name}}", card)).toBe("Aura of Command");
+      expect(resolve("{{abilities.other[1].description}}", card)).toBe("Re-roll a failed Battle-shock test.");
+      expect(resolve("{{abilities.core}}", card)).toBe("Deep Strike, Leader");
+      expect(resolve("{{abilities.faction}}", card)).toBe("Oath of Moment");
+      expect(resolve("{{abilities.invul.value}}", card)).toBe("4+");
+    });
+
+    it("resolves stats and points", () => {
+      expect(resolve("{{stats[0].m}}/{{stats[0].t}}/{{stats[0].sv}}", card)).toBe('6"/4/3+');
+      expect(resolve("{{points[0].cost}}", card)).toBe("80");
+      expect(resolve("{{points[1].models}}", card)).toBe("3");
+    });
+
+    it("returns an empty string for missing values", () => {
+      expect(resolve("{{rangedWeapons[9].name}}", card)).toBe("");
+      expect(resolve("{{nope.at.all}}", card)).toBe("");
+    });
+  });
+
+  describe("40k 11th edition", () => {
+    const card = make11eCard();
+
+    it("localises fields at every level", () => {
+      expect(resolve("{{name}}", card)).toBe("Captain");
+      expect(resolve("{{subname}}", card)).toBe("Chapter Master");
+      expect(resolve("{{stats[0].name}}", card)).toBe("Captain");
+      expect(resolve("{{rangedWeapons[0].name}}", card)).toBe("Bolt pistol");
+      expect(resolve("{{meleeWeapons[0].name}}", card)).toBe("Chainsword");
+      expect(resolve("{{abilities.other[0].name}}", card)).toBe("Aura of Command");
+      expect(resolve("{{keywords}}", card)).toBe("Infantry, Character");
+      expect(resolve("{{keywords[1]}}", card)).toBe("Character");
+      expect(resolve("{{composition}}", card)).toBe("1 Captain");
+      expect(resolve("{{loadout}}", card)).toBe("This model is equipped with: bolt pistol.");
+      expect(resolve("{{leader}}", card)).toBe("This model can be attached to a Squad.");
+      expect(resolve("{{wargear}}", card)).toBe("None");
+      expect(resolve("{{points[0].keyword}}", card)).toBe("Captain");
+      expect(resolve("{{points[0].cost}}", card)).toBe("80");
+    });
+
+    it("uses the requested language", () => {
+      const options = { language: "de" };
+      expect(resolve("{{subname}}", card, options)).toBe("Ordensmeister");
+      expect(resolve("{{rangedWeapons[0].name}}", card, options)).toBe("Bolterpistole");
+      expect(resolve("{{keywords}}", card, options)).toBe("Infanterie, Charaktermodell");
+      expect(resolve("{{abilities.core}}", card, options)).toBe("Tiefschlag, Anführer");
+    });
+
+    it("falls back to English when a language is missing", () => {
+      expect(resolve("{{meleeWeapons[0].name}}", card, { language: "fr" })).toBe("Chainsword");
+      expect(resolve("{{abilities.other[1].name}}", card, { language: "de" })).toBe("Iron Will");
+    });
+
+    it("resolves core and faction abilities to their names", () => {
+      expect(resolve("{{abilities.core}}", card)).toBe("Deep Strike, Leader");
+      expect(resolve("{{abilities.faction}}", card)).toBe("Oath of Moment");
+      expect(resolve("{{abilities.invul.value}}", card)).toBe("4+");
+    });
+
+    it("strips rich-text markup from ability descriptions", () => {
+      const description = resolve("{{abilities.other[0].description}}", card);
+      expect(description).toBe('While a friendly unit is within 6", add 1 to its Leadership.');
+      expect(description).not.toContain("<k>");
+      expect(resolve("{{abilities.other[1].description}}", card)).toBe(
+        "Once per battle, this unit can re-roll a failed Battle-shock test.",
+      );
+    });
+
+    it("never prints [object Object]", () => {
+      const paths = [
+        "name",
+        "subname",
+        "stats[0].name",
+        "rangedWeapons[0].name",
+        "abilities.core",
+        "abilities.faction",
+        "abilities.other[0].name",
+        "abilities.other[0].description",
+        "keywords",
+        "composition",
+        "loadout",
+        "leader",
+        "wargear",
+        "points[0].keyword",
+      ];
+      const rendered = paths.map((path) => resolve(`{{${path}}}`, card)).join(" | ");
+      expect(rendered).not.toContain("[object Object]");
+    });
+  });
+
+  describe("Age of Sigmar", () => {
+    const card = makeAoSCard();
+
+    it("resolves stats, weapons, abilities and keywords", () => {
+      expect(resolve("{{stats.move}}", card)).toBe('5"');
+      expect(resolve("{{stats.save}}", card)).toBe("3+");
+      expect(resolve("{{weapons.melee[0].name}}", card)).toBe("Warhammer");
+      expect(resolve("{{weapons.melee[0].hit}}", card)).toBe("3+");
+      expect(resolve("{{abilities[0].name}}", card)).toBe("Shield of Civilisation");
+      expect(resolve("{{abilities[0].effect}}", card)).toBe("Add 1 to save rolls.");
+      expect(resolve("{{keywords[0]}}", card)).toBe("Infantry");
+      expect(resolve("{{keywords}}", card)).toBe("Infantry, Stormcast Eternals");
+      expect(resolve("{{points}}", card)).toBe("110");
+    });
+
+    it("keeps the ability array shape", () => {
+      const normalized = normalizeCardForBinding(card);
+      expect(Array.isArray(normalized.abilities)).toBe(true);
+      expect(normalized.abilities).toHaveLength(2);
+    });
+  });
+
+  describe("custom datasources", () => {
+    const card = makeCustomCard();
+
+    it("resolves weapon fields through profiles", () => {
+      expect(resolve("{{weapons.ranged[0].name}}", card)).toBe("Boltgun");
+      expect(resolve("{{weapons.ranged[1].name}}", card)).toBe("Bolt pistol");
+      expect(resolve("{{weapons.ranged[0].bs}}", card)).toBe("3+");
+      expect(resolve("{{weapons.melee[0].name}}", card)).toBe("Combat knife");
+    });
+
+    it("resolves abilities per category", () => {
+      expect(resolve("{{abilities.unit[0].name}}", card)).toBe("Squad Tactics");
+      expect(resolve("{{abilities.unit[1].description}}", card)).toBe("Sustained Hits 1.");
+    });
+
+    it("keeps a name-only custom category addressable by name", () => {
+      expect(resolve("{{abilities.core[0].name}}", card)).toBe("Deep Strike");
+    });
+
+    it("resolves keywords and faction keywords", () => {
+      expect(resolve("{{keywords[0]}}", card)).toBe("Infantry");
+      expect(resolve("{{factionKeywords}}", card)).toBe("Adeptus Astartes");
+      expect(resolve("{{points}}", card)).toBe("100");
+    });
+
+    it("converts a legacy flat ability array into the category object", () => {
+      const legacy = makeLegacyCustomCard();
+      const normalized = normalizeCardForBinding(legacy);
+      expect(Array.isArray(normalized.abilities)).toBe(false);
+      expect(normalized.abilities.unit).toHaveLength(2);
+      expect(resolve("{{abilities.unit[0].name}}", legacy)).toBe("Squad Tactics");
+      expect(resolve("{{abilities.core[0].name}}", legacy)).toBe("Deep Strike");
+    });
+  });
+
+  describe("repeater context", () => {
+    const card = make10eCard();
+
+    it("resolves item fields through the flattened weapon", () => {
+      const normalizedCard = normalizeCardForBinding(card);
+      const item = normalizeBindingItem(card.rangedWeapons[0]);
+      const context = { ...normalizedCard, ...item, $index: 0, $count: 2, $first: true, $last: false };
+
+      expect(resolveTemplate("{{name}} {{range}} {{damage}}", context)).toBe('Bolt pistol 12" 1');
+      expect(resolveTemplate("{{$index}}/{{$count}}", context)).toBe("0/2");
+      expect(resolveTemplate("{{$first}} {{$last}}", context)).toBe("true false");
+    });
+
+    it("leaves card level paths reachable from inside the repeater", () => {
+      const normalizedCard = normalizeCardForBinding(card);
+      const item = normalizeBindingItem(card.rangedWeapons[1]);
+      const context = { ...normalizedCard, ...item };
+
+      expect(resolveTemplate("{{name}}", context)).toBe("Plasma gun");
+      expect(resolveTemplate("{{abilities.other[0].name}}", context)).toBe("Aura of Command");
+      expect(resolveTemplate("{{keywords[0]}}", context)).toBe("Infantry");
+      expect(resolveTemplate("{{stats[0].t}}", context)).toBe("4");
+    });
+
+    it("localises 11th edition repeater items", () => {
+      const card11e = make11eCard();
+      const item = normalizeBindingItem(card11e.rangedWeapons[0], { language: "de" });
+      expect(resolveTemplate("{{name}}", item, { language: "de" })).toBe("Bolterpistole");
+    });
+  });
+
+  describe("caching", () => {
+    it("returns the same normalised object for the same card and language", () => {
+      const card = make11eCard();
+      expect(normalizeCardForBinding(card, { language: "en" })).toBe(normalizeCardForBinding(card, { language: "en" }));
+      expect(normalizeCardForBinding(card, { language: "en" })).not.toBe(
+        normalizeCardForBinding(card, { language: "de" }),
+      );
+    });
+
+    it("does not mutate the source card", () => {
+      const card = make11eCard();
+      normalizeCardForBinding(card);
+      expect(card.keywords[0]).toEqual({ en: "Infantry", de: "Infanterie" });
+      expect(card.rangedWeapons[0].name).toBeUndefined();
+    });
+  });
+
+  describe("template helpers", () => {
+    it("detects and extracts bindings", () => {
+      expect(hasBindings("Name: {{name}}")).toBe(true);
+      expect(hasBindings("Name")).toBe(false);
+      expect(extractBindings("{{name}} - {{ stats[0].m }}")).toEqual(["name", "stats[0].m"]);
+    });
+
+    it("formats values", () => {
+      expect(formatBindingValue(undefined)).toBe("");
+      expect(formatBindingValue(null)).toBe("");
+      expect(formatBindingValue(0)).toBe("0");
+      expect(formatBindingValue(false)).toBe("false");
+      expect(formatBindingValue(["a", "b"])).toBe("a, b");
+      expect(formatBindingValue({ en: "Leader", de: "Anführer" }, "de")).toBe("Anführer");
+    });
+
+    it("returns the template unchanged without a context", () => {
+      expect(resolveTemplate("{{name}}", null)).toBe("{{name}}");
+      expect(resolveTemplate("", {})).toBe("");
+    });
+  });
+});

--- a/src/Helpers/__tests__/customSchemaBindings.test.js
+++ b/src/Helpers/__tests__/customSchemaBindings.test.js
@@ -60,14 +60,19 @@ describe("customSchemaBindings", () => {
         expect(melee.bindings[0].path).toBe("weapons.melee[0].name");
       });
 
-      it("includes Abilities group", () => {
-        const abilities = result.groups.find((g) => g.name === "Abilities");
-        expect(abilities).toBeDefined();
-        // 3 abilities x 3 fields (name, description, category) = 9
-        expect(abilities.bindings.length).toBe(9);
-        expect(abilities.bindings[0].path).toBe("abilities[0].name");
-        expect(abilities.bindings[1].path).toBe("abilities[0].description");
-        expect(abilities.bindings[2].path).toBe("abilities[0].category");
+      it("includes one abilities group per category", () => {
+        const core = result.groups.find((g) => g.name === "Core");
+        expect(core).toBeDefined();
+        expect(core.bindings.length).toBe(6);
+        expect(core.bindings[0].path).toBe("abilities.core[0].name");
+        expect(core.bindings[1].path).toBe("abilities.core[0].description");
+
+        const unit = result.groups.find((g) => g.name === "Unit Abilities");
+        expect(unit).toBeDefined();
+        expect(unit.bindings[0].path).toBe("abilities.unit[0].name");
+        expect(unit.bindings[5].path).toBe("abilities.unit[2].description");
+
+        expect(result.groups.find((g) => g.name === "Damaged")).toBeDefined();
       });
 
       it("includes Keywords group with keywords and factionKeywords", () => {
@@ -181,10 +186,17 @@ describe("customSchemaBindings", () => {
         expect(melee.itemFields).toEqual(["name", "range", "a", "ws", "s", "ap", "d"]);
       });
 
-      it("includes abilities array source", () => {
-        const abilities = result.find((s) => s.path === "abilities");
-        expect(abilities).toBeDefined();
-        expect(abilities.itemFields).toEqual(["name", "description", "category"]);
+      it("includes one abilities array source per category", () => {
+        const core = result.find((s) => s.path === "abilities.core");
+        expect(core).toBeDefined();
+        expect(core.label).toBe("Core");
+        expect(core.itemFields).toEqual(["name", "description"]);
+
+        const unit = result.find((s) => s.path === "abilities.unit");
+        expect(unit).toBeDefined();
+        expect(unit.label).toBe("Unit Abilities");
+
+        expect(result.find((s) => s.path === "abilities")).toBeUndefined();
       });
 
       it("includes keywords and factionKeywords array sources", () => {

--- a/src/Helpers/__tests__/factionSymbol.helpers.test.js
+++ b/src/Helpers/__tests__/factionSymbol.helpers.test.js
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
+  FACTION_SYMBOL_BASE_URL,
   buildFactionIconCandidates,
   factionNamesFromCard,
+  factionSymbolUrl,
+  resolveFactionSymbolUrl,
+  resolveFactionSymbolUrlForValue,
   isLegacyFactionCode,
   normalizeFactionName,
   resolveFactionCode,
@@ -95,5 +99,58 @@ describe("buildFactionIconCandidates", () => {
   it("returns an empty list when nothing resolves", () => {
     expect(buildFactionIconCandidates({ factionId: "my-own-faction", names: ["My Own Faction"] })).toEqual([]);
     expect(buildFactionIconCandidates()).toEqual([]);
+  });
+});
+
+describe("resolveFactionSymbolUrl", () => {
+  it("builds the symbol url for a 10th edition faction id", () => {
+    expect(resolveFactionSymbolUrl({ faction_id: "CSM" })).toBe(`${FACTION_SYMBOL_BASE_URL}/CSM.svg`);
+  });
+
+  it("uses the faction keywords when the id is not a symbol code", () => {
+    expect(resolveFactionSymbolUrl({ faction_id: "3f0a-uuid", factions: ["Adeptus Astartes", "Ultramarines"] })).toBe(
+      `${FACTION_SYMBOL_BASE_URL}/CHUL.svg`,
+    );
+  });
+
+  it("uses the datasource faction name as a last candidate", () => {
+    expect(resolveFactionSymbolUrl({ faction_id: "necrons-slug" }, { name: "Necrons" })).toBe(
+      `${FACTION_SYMBOL_BASE_URL}/NEC.svg`,
+    );
+  });
+
+  it("prefers an uploaded external symbol", () => {
+    expect(
+      resolveFactionSymbolUrl({
+        faction_id: "CSM",
+        hasCustomFactionSymbol: true,
+        externalFactionSymbol: "https://example.com/logo.png",
+      }),
+    ).toBe("https://example.com/logo.png");
+  });
+
+  it("returns null when nothing resolves", () => {
+    expect(resolveFactionSymbolUrl({ faction_id: "my-own-faction" })).toBeNull();
+    expect(resolveFactionSymbolUrl()).toBeNull();
+    expect(factionSymbolUrl(null)).toBeNull();
+  });
+});
+
+describe("resolveFactionSymbolUrlForValue", () => {
+  it("returns a url value unchanged", () => {
+    expect(resolveFactionSymbolUrlForValue("https://example.com/a.svg", {})).toBe("https://example.com/a.svg");
+    expect(resolveFactionSymbolUrlForValue("data:image/png;base64,AAA", {})).toBe("data:image/png;base64,AAA");
+  });
+
+  it("resolves a symbol code or a faction name", () => {
+    expect(resolveFactionSymbolUrlForValue("TYR", {})).toBe(`${FACTION_SYMBOL_BASE_URL}/TYR.svg`);
+    expect(resolveFactionSymbolUrlForValue("Death Guard", {})).toBe(`${FACTION_SYMBOL_BASE_URL}/DG.svg`);
+  });
+
+  it("falls back to the card when the value resolves to nothing", () => {
+    expect(resolveFactionSymbolUrlForValue("9f1c-uuid", { factions: ["Orks"] })).toBe(
+      `${FACTION_SYMBOL_BASE_URL}/ORK.svg`,
+    );
+    expect(resolveFactionSymbolUrlForValue("", { faction_id: "my-own-faction" })).toBeNull();
   });
 });

--- a/src/Helpers/__tests__/templateFormats.test.js
+++ b/src/Helpers/__tests__/templateFormats.test.js
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import {
+  describeFormat,
+  formatForCard,
+  getCompatibleFormats,
+  isBuiltInFormat,
+  isFormatCompatible,
+  listFormats,
+} from "../templateFormats";
+
+const customDatasources = [
+  {
+    id: "custom-10e",
+    name: "Fake 10e",
+    schema: {
+      baseSystem: "40k-10e",
+      cardTypes: [
+        { key: "unit", label: "Unit", baseType: "unit" },
+        { key: "strat", label: "Stratagem", baseType: "stratagem" },
+      ],
+    },
+  },
+  {
+    id: "custom-11e",
+    name: "Fake 11e",
+    schema: {
+      baseSystem: "40k-11e",
+      cardTypes: [{ key: "datasheet", label: "Datasheet", baseType: "unit" }],
+    },
+  },
+  {
+    id: "custom-aos",
+    name: "Fake AoS",
+    schema: {
+      baseSystem: "aos",
+      cardTypes: [{ key: "warscroll", label: "Warscroll", baseType: "unit" }],
+    },
+  },
+  {
+    id: "custom-blank",
+    name: "Fake Blank",
+    schema: {
+      baseSystem: "blank",
+      cardTypes: [{ key: "card", label: "Card", baseType: "unit" }],
+    },
+  },
+];
+
+describe("templateFormats", () => {
+  describe("describeFormat", () => {
+    it("describes the built-in formats", () => {
+      expect(describeFormat("40k-10e")).toEqual({
+        key: "40k-10e",
+        label: "40K 10th Edition",
+        gameSystem: "40k",
+        datasourceId: null,
+        cardTypeKey: null,
+        family: "40k-unit",
+        builtIn: true,
+      });
+      expect(describeFormat("40k-11e").family).toBe("40k-unit");
+      expect(describeFormat("aos")).toMatchObject({ gameSystem: "aos", family: "aos-warscroll", builtIn: true });
+    });
+
+    it("returns null without a format", () => {
+      expect(describeFormat(null)).toBeNull();
+      expect(describeFormat("")).toBeNull();
+    });
+
+    it("describes a custom datasource card type", () => {
+      expect(describeFormat("custom-10e:unit", customDatasources)).toEqual({
+        key: "custom-10e:unit",
+        label: "Fake 10e - Unit",
+        gameSystem: "40k",
+        datasourceId: "custom-10e",
+        cardTypeKey: "unit",
+        family: "40k-unit",
+        builtIn: false,
+      });
+      expect(describeFormat("custom-10e:strat", customDatasources)).toMatchObject({
+        family: "40k-10e:stratagem",
+        label: "Fake 10e - Stratagem",
+      });
+      expect(describeFormat("custom-blank:card", customDatasources)).toMatchObject({
+        gameSystem: "custom",
+        family: "blank:unit",
+      });
+    });
+
+    it("falls back to the key when the datasource is unknown", () => {
+      expect(describeFormat("custom-missing:unit")).toEqual({
+        key: "custom-missing:unit",
+        label: "custom-missing:unit",
+        gameSystem: "custom",
+        datasourceId: "custom-missing",
+        cardTypeKey: "unit",
+        family: "custom-missing:unit",
+        builtIn: false,
+      });
+    });
+
+    it("falls back to the key for an unparsable format", () => {
+      expect(describeFormat("necromunda")).toMatchObject({
+        key: "necromunda",
+        family: "necromunda",
+        gameSystem: "custom",
+        builtIn: false,
+      });
+    });
+  });
+
+  describe("isFormatCompatible", () => {
+    it("treats the two 40K editions as compatible", () => {
+      expect(isFormatCompatible("40k-10e", "40k-11e")).toBe(true);
+      expect(isFormatCompatible("40k-11e", "40k-10e")).toBe(true);
+      expect(isFormatCompatible("40k-10e", "40k-10e")).toBe(true);
+    });
+
+    it("keeps Age of Sigmar separate from 40K", () => {
+      expect(isFormatCompatible("aos", "40k-10e")).toBe(false);
+      expect(isFormatCompatible("40k-11e", "aos")).toBe(false);
+      expect(isFormatCompatible("aos", "aos")).toBe(true);
+    });
+
+    it("accepts a custom 40K unit datasource on both editions", () => {
+      expect(isFormatCompatible("custom-10e:unit", "40k-10e", customDatasources)).toBe(true);
+      expect(isFormatCompatible("custom-10e:unit", "40k-11e", customDatasources)).toBe(true);
+      expect(isFormatCompatible("40k-11e", "custom-11e:datasheet", customDatasources)).toBe(true);
+      expect(isFormatCompatible("custom-10e:unit", "custom-11e:datasheet", customDatasources)).toBe(true);
+    });
+
+    it("keeps other custom card types to themselves", () => {
+      expect(isFormatCompatible("custom-10e:strat", "40k-10e", customDatasources)).toBe(false);
+      expect(isFormatCompatible("custom-aos:warscroll", "aos", customDatasources)).toBe(false);
+      expect(isFormatCompatible("custom-aos:warscroll", "custom-aos:warscroll", customDatasources)).toBe(true);
+    });
+
+    it("needs both formats", () => {
+      expect(isFormatCompatible(null, "40k-10e")).toBe(false);
+      expect(isFormatCompatible("40k-10e", null)).toBe(false);
+    });
+  });
+
+  describe("getCompatibleFormats", () => {
+    it("lists the compatible built-in and custom formats", () => {
+      expect(getCompatibleFormats("40k-10e", customDatasources)).toEqual([
+        "40k-10e",
+        "40k-11e",
+        "custom-10e:unit",
+        "custom-11e:datasheet",
+      ]);
+      expect(getCompatibleFormats("aos", customDatasources)).toEqual(["aos"]);
+      expect(getCompatibleFormats("custom-10e:strat", customDatasources)).toEqual(["custom-10e:strat"]);
+      expect(getCompatibleFormats(null)).toEqual([]);
+    });
+  });
+
+  describe("listFormats", () => {
+    it("lists built-in formats and every custom card type", () => {
+      expect(listFormats()).toEqual(["40k-10e", "40k-11e", "aos"]);
+      expect(listFormats(customDatasources)).toContain("custom-aos:warscroll");
+    });
+  });
+
+  describe("formatForCard", () => {
+    it("derives the format of a built-in card", () => {
+      expect(formatForCard({ source: "40k-10e", cardType: "DataCard" })).toBe("40k-10e");
+      expect(formatForCard({ source: "40k-11e" })).toBe("40k-11e");
+      expect(formatForCard({ source: "aos", cardType: "spell" })).toBe("aos");
+    });
+
+    it("derives the format of a custom card", () => {
+      expect(formatForCard({ source: "custom-10e", cardType: "unit" })).toBe("custom-10e:unit");
+      expect(formatForCard({ source: "custom-10e" })).toBe("custom-10e");
+    });
+
+    it("returns null without a source", () => {
+      expect(formatForCard(null)).toBeNull();
+      expect(formatForCard({})).toBeNull();
+    });
+  });
+
+  describe("isBuiltInFormat", () => {
+    it("knows the built-in keys", () => {
+      expect(isBuiltInFormat("40k-10e")).toBe(true);
+      expect(isBuiltInFormat("custom-10e:unit")).toBe(false);
+      expect(isBuiltInFormat(null)).toBe(false);
+    });
+  });
+});

--- a/src/Helpers/bindingResolver.js
+++ b/src/Helpers/bindingResolver.js
@@ -1,0 +1,255 @@
+import { SUPPORTED_LANGUAGES, localize } from "./localization.helpers";
+
+const LANGUAGE_KEYS = new Set(SUPPORTED_LANGUAGES);
+
+const WEAPON_ARRAY_KEYS = ["rangedWeapons", "meleeWeapons"];
+
+const NAME_ABILITY_KEYS = ["core", "faction"];
+
+const BUILT_IN_40K_FORMATS = new Set(["40k-10e", "40k-11e"]);
+
+const cardCache = new WeakMap();
+const itemCache = new WeakMap();
+
+export const isLanguageKeyedObject = (value) => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const entries = Object.entries(value);
+  if (entries.length === 0) return false;
+  return entries.every(([key, entry]) => LANGUAGE_KEYS.has(key) && (entry == null || typeof entry === "string"));
+};
+
+const localizeDeep = (value, language) => {
+  if (Array.isArray(value)) return value.map((entry) => localizeDeep(entry, language));
+  if (value && typeof value === "object") {
+    if (isLanguageKeyedObject(value)) return localize(value, language);
+    const result = {};
+    for (const [key, entry] of Object.entries(value)) {
+      result[key] = localizeDeep(entry, language);
+    }
+    return result;
+  }
+  return value;
+};
+
+export const toDisplayString = (value, language = "en") => {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (Array.isArray(value)) return value.map((entry) => toDisplayString(entry, language)).join(", ");
+  if (typeof value === "object") {
+    if (isLanguageKeyedObject(value)) return localize(value, language);
+    if (typeof value.keyword === "string") return value.keyword;
+    if (isLanguageKeyedObject(value.keyword)) return localize(value.keyword, language);
+    if (typeof value.name === "string") return value.name;
+    if (isLanguageKeyedObject(value.name)) return localize(value.name, language);
+    return "";
+  }
+  return String(value);
+};
+
+const flattenWeaponItem = (item) => {
+  if (!item || typeof item !== "object" || Array.isArray(item)) return item;
+  const profiles = Array.isArray(item.profiles) ? item.profiles : null;
+  if (!profiles || profiles.length === 0) return item;
+  const first = profiles[0];
+  if (!first || typeof first !== "object" || Array.isArray(first)) return item;
+  return { ...item, ...first, profiles };
+};
+
+const flattenWeaponList = (list) => (Array.isArray(list) ? list.map(flattenWeaponItem) : list);
+
+const toStringList = (list, language) => {
+  if (!Array.isArray(list)) return list;
+  return list.map((entry) => toDisplayString(entry, language));
+};
+
+const isNameOnlyAbility = (entry) => {
+  if (typeof entry === "string") return true;
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) return false;
+  if (typeof entry.name !== "string") return false;
+  return entry.description == null && entry.effect == null;
+};
+
+const groupAbilitiesByCategory = (abilities) => {
+  const groups = {};
+  for (const ability of abilities) {
+    if (!ability || typeof ability !== "object") continue;
+    const category = typeof ability.category === "string" ? ability.category : null;
+    if (!category) continue;
+    if (!groups[category]) groups[category] = [];
+    groups[category].push(ability);
+  }
+  return groups;
+};
+
+const normalizeAbilities = (abilities, language, collapseNameLists) => {
+  if (Array.isArray(abilities)) {
+    const hasCategories = abilities.some((entry) => entry && typeof entry.category === "string" && entry.category);
+    return hasCategories ? groupAbilitiesByCategory(abilities) : abilities;
+  }
+  if (!abilities || typeof abilities !== "object") return abilities;
+  if (!collapseNameLists) return abilities;
+
+  const result = { ...abilities };
+  for (const key of NAME_ABILITY_KEYS) {
+    const list = result[key];
+    if (!Array.isArray(list) || list.length === 0) continue;
+    if (!list.every(isNameOnlyAbility)) continue;
+    result[key] = list.map((entry) => toDisplayString(entry, language));
+  }
+  return result;
+};
+
+const buildNormalizedCard = (card, language, format) => {
+  const localized = localizeDeep(card, language);
+  const result = { ...localized };
+
+  for (const key of WEAPON_ARRAY_KEYS) {
+    if (Array.isArray(result[key])) result[key] = flattenWeaponList(result[key]);
+  }
+
+  if (Array.isArray(result.weapons)) {
+    result.weapons = flattenWeaponList(result.weapons);
+  } else if (result.weapons && typeof result.weapons === "object") {
+    const weapons = {};
+    for (const [key, list] of Object.entries(result.weapons)) {
+      weapons[key] = flattenWeaponList(list);
+    }
+    result.weapons = weapons;
+  }
+
+  for (const key of ["keywords", "factions", "factionKeywords"]) {
+    if (Array.isArray(result[key])) result[key] = toStringList(result[key], language);
+  }
+
+  if (result.abilities != null) {
+    result.abilities = normalizeAbilities(result.abilities, language, BUILT_IN_40K_FORMATS.has(format));
+  }
+
+  return result;
+};
+
+export const normalizeCardForBinding = (card, options = {}) => {
+  if (!card || typeof card !== "object" || Array.isArray(card)) return card;
+
+  const language = options.language || "en";
+  const format = options.format || card.source || "";
+  const cacheKey = `${language}|${format}`;
+
+  let byKey = cardCache.get(card);
+  if (byKey) {
+    const cached = byKey.get(cacheKey);
+    if (cached) return cached;
+  } else {
+    byKey = new Map();
+    cardCache.set(card, byKey);
+  }
+
+  const normalized = buildNormalizedCard(card, language, format);
+  byKey.set(cacheKey, normalized);
+  return normalized;
+};
+
+export const normalizeBindingItem = (item, options = {}) => {
+  if (!item || typeof item !== "object" || Array.isArray(item)) return item;
+
+  const language = options.language || "en";
+  let byLanguage = itemCache.get(item);
+  if (byLanguage) {
+    const cached = byLanguage.get(language);
+    if (cached) return cached;
+  } else {
+    byLanguage = new Map();
+    itemCache.set(item, byLanguage);
+  }
+
+  const normalized = flattenWeaponItem(localizeDeep(item, language));
+  byLanguage.set(language, normalized);
+  return normalized;
+};
+
+export const getNestedValue = (obj, path) => {
+  if (!obj || !path) return undefined;
+
+  let current = obj;
+  for (const segment of String(path).split(".")) {
+    if (current === undefined || current === null) return undefined;
+
+    const match = segment.match(/^([^[\]]*)((?:\[\d+\])*)$/);
+    if (!match) return undefined;
+
+    const [, key, indices] = match;
+    if (key) {
+      if (typeof current !== "object") return undefined;
+      current = current[key];
+    }
+
+    if (indices) {
+      for (const index of indices.match(/\d+/g) || []) {
+        if (!Array.isArray(current)) return undefined;
+        current = current[Number(index)];
+      }
+    }
+  }
+
+  return current;
+};
+
+const HTML_TAG = /<\/?[a-zA-Z][a-zA-Z0-9-]*(\s[^<>]*)?>/g;
+
+export const stripMarkup = (text) => {
+  if (typeof text !== "string" || text === "") return typeof text === "string" ? text : "";
+
+  return text
+    .replace(/\r\n?/g, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<li(\s[^<>]*)?>/gi, "\n- ")
+    .replace(/<\/li\s*>/gi, "")
+    .replace(/<(ul|ol)(\s[^<>]*)?>/gi, "")
+    .replace(/<\/(ul|ol)\s*>/gi, "\n")
+    .replace(HTML_TAG, "")
+    .replace(/[ \t]*■[ \t]*/g, "\n■ ")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+};
+
+export const formatBindingValue = (value, language = "en") => {
+  if (value === undefined || value === null) return "";
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => stripMarkup(toDisplayString(entry, language)))
+      .filter((entry) => entry !== "")
+      .join(", ");
+  }
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") return String(value);
+  return stripMarkup(toDisplayString(value, language));
+};
+
+export const resolveTemplate = (template, context, options = {}) => {
+  if (typeof template !== "string" || template === "") return template;
+  if (!context) return template;
+
+  const language = options.language || "en";
+
+  return template.replace(/\{\{([^}]+)\}\}/g, (match, path) => {
+    try {
+      return formatBindingValue(getNestedValue(context, path.trim()), language);
+    } catch {
+      return "";
+    }
+  });
+};
+
+export const hasBindings = (text) => {
+  if (!text) return false;
+  return /\{\{[^}]+\}\}/.test(text);
+};
+
+export const extractBindings = (template) => {
+  if (!template) return [];
+  const matches = template.match(/\{\{([^}]+)\}\}/g) || [];
+  return matches.map((match) => match.slice(2, -2).trim());
+};

--- a/src/Helpers/bindingResolver.js
+++ b/src/Helpers/bindingResolver.js
@@ -228,15 +228,203 @@ export const formatBindingValue = (value, language = "en") => {
   return stripMarkup(toDisplayString(value, language));
 };
 
+export const BINDING_FILTERS = [
+  { name: "upper", takesArg: false },
+  { name: "lower", takesArg: false },
+  { name: "title", takesArg: false },
+  { name: "trim", takesArg: false },
+  { name: "join", takesArg: true, defaultArg: ", " },
+  { name: "prefix", takesArg: true, defaultArg: "" },
+  { name: "suffix", takesArg: true, defaultArg: "" },
+  { name: "default", takesArg: true, defaultArg: "" },
+  { name: "truncate", takesArg: true, defaultArg: "20" },
+  { name: "first", takesArg: false },
+  { name: "count", takesArg: false },
+];
+
+const FILTER_NAMES = new Set(BINDING_FILTERS.map((filter) => filter.name));
+
+const splitExpressionSegments = (text) => {
+  const segments = [];
+  let current = "";
+  let quote = null;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+
+    if (quote) {
+      if (char === "\\" && index + 1 < text.length) {
+        current += char + text[index + 1];
+        index += 1;
+        continue;
+      }
+      if (char === quote) quote = null;
+      current += char;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      current += char;
+      continue;
+    }
+
+    if (char === "|") {
+      segments.push(current);
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  segments.push(current);
+  return segments;
+};
+
+const unquoteArg = (raw) => {
+  const trimmed = raw.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === '"' || first === "'") && last === first) {
+      return trimmed
+        .slice(1, -1)
+        .replace(/\\(["'\\])/g, "$1")
+        .replace(/\\n/g, "\n");
+    }
+  }
+  return trimmed;
+};
+
+export const parseBindingExpression = (expressionText) => {
+  const text = typeof expressionText === "string" ? expressionText : "";
+  const segments = splitExpressionSegments(text);
+  const path = segments.shift()?.trim() || "";
+  const filters = [];
+
+  for (const segment of segments) {
+    const trimmed = segment.trim();
+    if (trimmed === "") continue;
+
+    const colon = trimmed.indexOf(":");
+    const name = (colon === -1 ? trimmed : trimmed.slice(0, colon)).trim();
+    if (name === "") continue;
+
+    const filter = { name };
+    if (colon !== -1) filter.arg = unquoteArg(trimmed.slice(colon + 1));
+    filters.push(filter);
+  }
+
+  return { path, filters };
+};
+
+const quoteArg = (arg) => {
+  const text = String(arg).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${text}"`;
+};
+
+export const formatBindingExpression = (expression) => {
+  const path = expression?.path ? String(expression.path).trim() : "";
+  const filters = Array.isArray(expression?.filters) ? expression.filters : [];
+  const parts = [path];
+
+  for (const filter of filters) {
+    if (!filter?.name) continue;
+    parts.push(
+      filter.arg === undefined || filter.arg === null ? filter.name : `${filter.name}:${quoteArg(filter.arg)}`,
+    );
+  }
+
+  return parts.join(" | ");
+};
+
+const stateText = (state, language) => (state.text != null ? state.text : formatBindingValue(state.value, language));
+
+const toTitleCase = (text) =>
+  text.replace(/\S+/g, (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
+
+const applyFilter = (state, filter, language) => {
+  switch (filter.name) {
+    case "upper":
+      return { text: stateText(state, language).toUpperCase() };
+    case "lower":
+      return { text: stateText(state, language).toLowerCase() };
+    case "title":
+      return { text: toTitleCase(stateText(state, language)) };
+    case "trim":
+      return { text: stateText(state, language).trim() };
+    case "join": {
+      const separator = filter.arg === undefined ? ", " : filter.arg;
+      if (!Array.isArray(state.value) || state.text != null) {
+        return { text: stateText(state, language) };
+      }
+      return {
+        text: state.value
+          .map((entry) => formatBindingValue(entry, language))
+          .filter((entry) => entry !== "")
+          .join(separator),
+      };
+    }
+    case "prefix": {
+      const text = stateText(state, language);
+      return { text: text === "" ? "" : `${filter.arg ?? ""}${text}` };
+    }
+    case "suffix": {
+      const text = stateText(state, language);
+      return { text: text === "" ? "" : `${text}${filter.arg ?? ""}` };
+    }
+    case "default": {
+      const text = stateText(state, language);
+      return text === "" ? { text: filter.arg ?? "" } : state;
+    }
+    case "truncate": {
+      const limit = parseInt(filter.arg, 10);
+      const text = stateText(state, language);
+      if (!Number.isFinite(limit) || limit < 0) return { text };
+      return { text: text.length <= limit ? text : `${text.slice(0, limit)}...` };
+    }
+    case "first":
+      if (Array.isArray(state.value) && state.text == null) {
+        return { value: state.value[0] };
+      }
+      return state;
+    case "count": {
+      if (Array.isArray(state.value) && state.text == null) {
+        return { text: String(state.value.length) };
+      }
+      return { text: stateText(state, language) === "" ? "0" : "1" };
+    }
+    default:
+      return state;
+  }
+};
+
+export const resolveExpression = (context, expressionText, options = {}) => {
+  const language = options.language || "en";
+  const parsed =
+    expressionText && typeof expressionText === "object" ? expressionText : parseBindingExpression(expressionText);
+
+  let state = { value: getNestedValue(context, parsed.path), text: null };
+
+  for (const filter of parsed.filters || []) {
+    if (!FILTER_NAMES.has(filter.name)) continue;
+    const next = applyFilter(state, filter, language);
+    state = { value: next.value, text: next.text ?? null };
+  }
+
+  return stateText(state, language);
+};
+
 export const resolveTemplate = (template, context, options = {}) => {
   if (typeof template !== "string" || template === "") return template;
   if (!context) return template;
 
   const language = options.language || "en";
 
-  return template.replace(/\{\{([^}]+)\}\}/g, (match, path) => {
+  return template.replace(/\{\{([^}]+)\}\}/g, (match, expression) => {
     try {
-      return formatBindingValue(getNestedValue(context, path.trim()), language);
+      return resolveExpression(context, expression, { language });
     } catch {
       return "";
     }
@@ -252,4 +440,24 @@ export const extractBindings = (template) => {
   if (!template) return [];
   const matches = template.match(/\{\{([^}]+)\}\}/g) || [];
   return matches.map((match) => match.slice(2, -2).trim());
+};
+
+export const parseBindings = (template) =>
+  extractBindings(template).map((expression) => {
+    const { path, filters } = parseBindingExpression(expression);
+    return { expression, path, filters };
+  });
+
+export const areBindingsEmpty = (template, context, options = {}) => {
+  const expressions = extractBindings(template);
+  if (expressions.length === 0) return false;
+  if (!context) return false;
+
+  return expressions.every((expression) => {
+    try {
+      return resolveExpression(context, expression, options) === "";
+    } catch {
+      return true;
+    }
+  });
 };

--- a/src/Helpers/bindingResolver.js
+++ b/src/Helpers/bindingResolver.js
@@ -204,6 +204,8 @@ export const stripMarkup = (text) => {
   return text
     .replace(/\r\n?/g, "\n")
     .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/?b(\s[^<>]*)?>/gi, "**")
+    .replace(/<\/?i(\s[^<>]*)?>/gi, "*")
     .replace(/<li(\s[^<>]*)?>/gi, "\n- ")
     .replace(/<\/li\s*>/gi, "")
     .replace(/<(ul|ol)(\s[^<>]*)?>/gi, "")

--- a/src/Helpers/customSchemaBindings.js
+++ b/src/Helpers/customSchemaBindings.js
@@ -69,29 +69,25 @@ const generateUnitBindings = (cardTypeDef, datasourceName) => {
     }
   }
 
-  // Abilities group
   if (schema.abilities?.categories?.length > 0) {
-    const bindings = [];
+    for (const category of schema.abilities.categories) {
+      const bindings = [];
 
-    for (let i = 0; i < 3; i++) {
-      bindings.push({
-        path: `abilities[${i}].name`,
-        label: `Ability ${i + 1} Name`,
-        type: "string",
-      });
-      bindings.push({
-        path: `abilities[${i}].description`,
-        label: `Ability ${i + 1} Description`,
-        type: "string",
-      });
-      bindings.push({
-        path: `abilities[${i}].category`,
-        label: `Ability ${i + 1} Category`,
-        type: "string",
-      });
+      for (let i = 0; i < 3; i++) {
+        bindings.push({
+          path: `abilities.${category.key}[${i}].name`,
+          label: `Ability ${i + 1} Name`,
+          type: "string",
+        });
+        bindings.push({
+          path: `abilities.${category.key}[${i}].description`,
+          label: `Ability ${i + 1} Description`,
+          type: "string",
+        });
+      }
+
+      groups.push({ name: category.label || category.key, bindings });
     }
-
-    groups.push({ name: schema.abilities.label || "Abilities", bindings });
   }
 
   // Keywords group
@@ -228,13 +224,14 @@ const generateUnitArraySources = (cardTypeDef) => {
     }
   }
 
-  // Abilities
   if (schema.abilities?.categories?.length > 0) {
-    sources.push({
-      path: "abilities",
-      label: schema.abilities.label || "Abilities",
-      itemFields: ["name", "description", "category"],
-    });
+    for (const category of schema.abilities.categories) {
+      sources.push({
+        path: `abilities.${category.key}`,
+        label: category.label || category.key,
+        itemFields: ["name", "description"],
+      });
+    }
   }
 
   // Keywords

--- a/src/Helpers/factionSymbol.helpers.js
+++ b/src/Helpers/factionSymbol.helpers.js
@@ -119,3 +119,45 @@ export const buildFactionIconCandidates = ({ factionId, names = [] } = {}) => {
   });
   return candidates;
 };
+
+export const FACTION_SYMBOL_BASE_URL = "https://raw.githubusercontent.com/ronplanken/40k-Data-Card/master/src/dc";
+
+/** URL of the SVG for a symbol code, or null when there is no code. */
+export const factionSymbolUrl = (code) => (code ? `${FACTION_SYMBOL_BASE_URL}/${code}.svg` : null);
+
+/**
+ * The faction symbol URL for a card, following the same order as
+ * `UnitFactionSymbol`: an uploaded external symbol wins, otherwise the first
+ * symbol code the card's faction id and faction names resolve to. The optional
+ * faction is the datasource faction the card belongs to; its name is used as a
+ * last lookup candidate.
+ */
+export const resolveFactionSymbolUrl = (card, faction) => {
+  if (card?.hasCustomFactionSymbol && card?.externalFactionSymbol) {
+    return card.externalFactionSymbol;
+  }
+
+  const names = factionNamesFromCard(card);
+  if (faction?.name) names.push(faction.name);
+
+  const candidates = buildFactionIconCandidates({ factionId: card?.faction_id, names });
+  return factionSymbolUrl(candidates[0]);
+};
+
+/**
+ * The faction symbol URL for a resolved binding value. The value is a URL, a
+ * symbol code or a faction name; when it resolves to none of those the card is
+ * used instead, so `{{faction_id}}` still finds a symbol on editions whose ids
+ * are not symbol codes.
+ */
+export const resolveFactionSymbolUrlForValue = (value, card, faction) => {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (/^(https?:|data:)/i.test(text)) return text;
+
+  if (text) {
+    const candidates = buildFactionIconCandidates({ factionId: text, names: [text] });
+    if (candidates.length > 0) return factionSymbolUrl(candidates[0]);
+  }
+
+  return resolveFactionSymbolUrl(card, faction);
+};

--- a/src/Helpers/templateFormats.js
+++ b/src/Helpers/templateFormats.js
@@ -1,0 +1,126 @@
+import { VALID_BASE_SYSTEMS } from "./customSchema.helpers";
+import { buildCustomFormat, parseCustomFormat } from "./customSchemaBindings";
+
+export const BUILT_IN_FORMATS = {
+  "40k-10e": { label: "40K 10th Edition", gameSystem: "40k", family: "40k-unit" },
+  "40k-11e": { label: "40K 11th Edition", gameSystem: "40k", family: "40k-unit" },
+  aos: { label: "Age of Sigmar", gameSystem: "aos", family: "aos-warscroll" },
+};
+
+const CUSTOM_FAMILIES = {
+  "40k-10e:unit": "40k-unit",
+  "40k-11e:unit": "40k-unit",
+};
+
+const FAMILY_COMPATIBILITY = {
+  "40k-unit": ["40k-unit"],
+  "aos-warscroll": ["aos-warscroll"],
+};
+
+const BASE_SYSTEM_GAME_SYSTEMS = {
+  "40k-10e": "40k",
+  "40k-11e": "40k",
+  aos: "aos",
+};
+
+const CUSTOM_PREFIX = "custom-";
+
+export const isBuiltInFormat = (formatKey) => Boolean(formatKey && BUILT_IN_FORMATS[formatKey]);
+
+export const describeFormat = (formatKey, customDatasources = []) => {
+  if (!formatKey) return null;
+
+  const builtIn = BUILT_IN_FORMATS[formatKey];
+  if (builtIn) {
+    return {
+      key: formatKey,
+      label: builtIn.label,
+      gameSystem: builtIn.gameSystem,
+      datasourceId: null,
+      cardTypeKey: null,
+      family: builtIn.family,
+      builtIn: true,
+    };
+  }
+
+  const parsed = parseCustomFormat(formatKey);
+  if (!parsed) {
+    return {
+      key: formatKey,
+      label: formatKey,
+      gameSystem: "custom",
+      datasourceId: null,
+      cardTypeKey: null,
+      family: formatKey,
+      builtIn: false,
+    };
+  }
+
+  const datasource = (customDatasources || []).find((entry) => entry?.id === parsed.datasourceId) || null;
+  const cardType = datasource?.schema?.cardTypes?.find((entry) => entry.key === parsed.cardTypeKey) || null;
+  const baseSystem = VALID_BASE_SYSTEMS.includes(datasource?.schema?.baseSystem) ? datasource.schema.baseSystem : null;
+  const baseType = cardType?.baseType || null;
+
+  let family = formatKey;
+  if (baseSystem && baseType) {
+    family = CUSTOM_FAMILIES[`${baseSystem}:${baseType}`] || `${baseSystem}:${baseType}`;
+  }
+
+  let label = formatKey;
+  if (datasource && cardType) label = `${datasource.name} - ${cardType.label}`;
+  else if (datasource) label = datasource.name;
+
+  return {
+    key: formatKey,
+    label,
+    gameSystem: BASE_SYSTEM_GAME_SYSTEMS[baseSystem] || "custom",
+    datasourceId: parsed.datasourceId,
+    cardTypeKey: parsed.cardTypeKey,
+    family,
+    builtIn: false,
+  };
+};
+
+export const isFormatCompatible = (templateFormat, cardFormat, customDatasources = []) => {
+  if (!templateFormat || !cardFormat) return false;
+  if (templateFormat === cardFormat) return true;
+
+  const template = describeFormat(templateFormat, customDatasources);
+  const card = describeFormat(cardFormat, customDatasources);
+  if (!template || !card) return false;
+
+  const families = FAMILY_COMPATIBILITY[template.family] || [template.family];
+  return families.includes(card.family);
+};
+
+export const listFormats = (customDatasources = []) => {
+  const keys = Object.keys(BUILT_IN_FORMATS);
+
+  for (const datasource of customDatasources || []) {
+    for (const cardType of datasource?.schema?.cardTypes || []) {
+      keys.push(buildCustomFormat(datasource.id, cardType.key));
+    }
+  }
+
+  return keys;
+};
+
+export const getCompatibleFormats = (formatKey, customDatasources = []) => {
+  if (!formatKey) return [];
+
+  const compatible = listFormats(customDatasources).filter((key) =>
+    isFormatCompatible(formatKey, key, customDatasources),
+  );
+
+  return compatible.includes(formatKey) ? compatible : [formatKey, ...compatible];
+};
+
+export const formatForCard = (card) => {
+  const source = card?.source;
+  if (!source) return null;
+  if (BUILT_IN_FORMATS[source]) return source;
+  if (String(source).startsWith(CUSTOM_PREFIX) && card.cardType) {
+    return buildCustomFormat(source, card.cardType);
+  }
+  return source;
+};

--- a/src/Hooks/__tests__/useAutoFitScale.test.jsx
+++ b/src/Hooks/__tests__/useAutoFitScale.test.jsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useAutoFitScale } from "../useAutoFitScale";
+
+class FakeResizeObserver {
+  observe() {}
+  disconnect() {}
+}
+
+describe("useAutoFitScale", () => {
+  beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const containerOf = (clientWidth) => ({ current: { clientWidth } });
+
+  it("fits the card type width into the container", () => {
+    const { result } = renderHook(() => useAutoFitScale(containerOf(1077 + 32), "unit", true));
+    expect(result.current.autoScale).toBe(1);
+    const half = renderHook(() => useAutoFitScale(containerOf(1077 / 2 + 32), "unit", true));
+    expect(half.result.current.autoScale).toBeCloseTo(0.5, 5);
+  });
+
+  it("uses the template width when one is given", () => {
+    const { result } = renderHook(() => useAutoFitScale(containerOf(540 + 32), "unit", true, 1080));
+    expect(result.current.autoScale).toBeCloseTo(0.5, 5);
+    const ignored = renderHook(() => useAutoFitScale(containerOf(540 + 32), "unit", true, null));
+    expect(ignored.result.current.autoScale).toBeCloseTo(540 / 1077, 5);
+  });
+
+  it("returns 1 when disabled", () => {
+    const { result } = renderHook(() => useAutoFitScale(containerOf(200), "unit", false, 1080));
+    expect(result.current.autoScale).toBe(1);
+  });
+});

--- a/src/Hooks/__tests__/useTemplateCardWidth.test.js
+++ b/src/Hooks/__tests__/useTemplateCardWidth.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { templateCardWidth } from "../useTemplateCardWidth";
+
+const templates = [
+  { uuid: "t1", canvas: { width: 1080, height: 720 } },
+  { uuid: "t2", canvas: { width: "640", height: 900 } },
+  { uuid: "t3", canvas: {} },
+];
+
+describe("templateCardWidth", () => {
+  it("returns the width of the card's template", () => {
+    expect(templateCardWidth(templates, { templateId: "t1" })).toBe(1080);
+    expect(templateCardWidth(templates, { templateId: "t2" })).toBe(640);
+  });
+
+  it("returns null for cards without a template or an unknown one", () => {
+    expect(templateCardWidth(templates, { cardType: "DataCard" })).toBeNull();
+    expect(templateCardWidth(templates, { templateId: "missing" })).toBeNull();
+    expect(templateCardWidth(templates, { templateId: "t3" })).toBeNull();
+    expect(templateCardWidth(undefined, { templateId: "t1" })).toBeNull();
+    expect(templateCardWidth(templates, null)).toBeNull();
+  });
+});

--- a/src/Hooks/useAutoFitScale.jsx
+++ b/src/Hooks/useAutoFitScale.jsx
@@ -10,19 +10,22 @@ const CARD_DIMENSIONS = {
   spell: { width: 650, height: null },
 };
 
-export function useAutoFitScale(containerRef, cardType = "unit", isEnabled = true) {
+export function useAutoFitScale(containerRef, cardType = "unit", isEnabled = true, cardWidth = null) {
   const [autoScale, setAutoScale] = useState(1);
   const resizeObserverRef = useRef(null);
 
   const calculateScale = useCallback(
     (width) => {
       if (!width || !isEnabled) return 1;
-      const cardWidth = CARD_DIMENSIONS[cardType]?.width || CARD_DIMENSIONS.unit.width;
+      const baseWidth =
+        Number.isFinite(cardWidth) && cardWidth > 0
+          ? cardWidth
+          : CARD_DIMENSIONS[cardType]?.width || CARD_DIMENSIONS.unit.width;
       const availableWidth = width - 32; // padding buffer
-      const calculatedScale = Math.min(1, availableWidth / cardWidth);
+      const calculatedScale = Math.min(1, availableWidth / baseWidth);
       return Math.max(0.25, calculatedScale);
     },
-    [cardType, isEnabled],
+    [cardType, isEnabled, cardWidth],
   );
 
   useEffect(() => {

--- a/src/Hooks/useSettingsStorage.jsx
+++ b/src/Hooks/useSettingsStorage.jsx
@@ -59,6 +59,16 @@ export function useSettingsStorage() {
   return context;
 }
 
+export function useOptionalSettingsStorage() {
+  return React.useContext(SettingsStorageContext);
+}
+
+export function useCardLanguage() {
+  const context = useOptionalSettingsStorage();
+  const language = context?.settings?.language;
+  return typeof language === "string" && language ? language : "en";
+}
+
 export const SettingsStorageProviderComponent = (props) => {
   const [localSettings, setLocalSettings] = React.useState(() => {
     try {

--- a/src/Hooks/useTemplateCardWidth.jsx
+++ b/src/Hooks/useTemplateCardWidth.jsx
@@ -1,0 +1,13 @@
+import { useTemplateStorage } from "../Premium";
+
+export const templateCardWidth = (templates, card) => {
+  if (!card?.templateId || !Array.isArray(templates)) return null;
+  const template = templates.find((t) => t.uuid === card.templateId);
+  const width = Number(template?.canvas?.width);
+  return Number.isFinite(width) && width > 0 ? width : null;
+};
+
+export function useTemplateCardWidth(card) {
+  const { templateStorage } = useTemplateStorage();
+  return templateCardWidth(templateStorage?.templates, card);
+}

--- a/src/Pages/Help/components/helpIcons.js
+++ b/src/Pages/Help/components/helpIcons.js
@@ -21,6 +21,7 @@ export {
   ArrowRight,
   ArrowDown,
   Grid3X3,
+  Magnet,
   AlignStartVertical,
   AlignCenterVertical,
   Copy,

--- a/src/Pages/Help/components/helpIcons.js
+++ b/src/Pages/Help/components/helpIcons.js
@@ -30,6 +30,7 @@ export {
   Globe,
   Share2,
   Pencil,
+  Pentagon,
   CheckCircle,
   Clock,
   Loader2,

--- a/src/Pages/Help/content/designer/creating-a-template.mdx
+++ b/src/Pages/Help/content/designer/creating-a-template.mdx
@@ -1,7 +1,39 @@
 ## Creating a Template
 
-To create a new template, click "New Template" in the layer panel. You'll choose three things:
+To create a new template, click "New Template" in the layer panel. The dialog
+walks you through two steps.
 
-- **A starting size** — Pick a preset that matches your card type, or set custom dimensions.
-- **A target format** — Choose whether this template is for Warhammer 40K or Age of Sigmar. This determines which data fields are available for binding.
-- **A name** — Give your template a name so you can find it later.
+### Step 1: Game and edition
+
+Pick the game the template is for: Warhammer 40K 10th edition, Warhammer 40K
+11th edition, or Age of Sigmar. Every card type from your custom datasources is
+listed here as well, grouped per datasource. The tile that matches the
+datasource you are using in the app is selected for you.
+
+If you want a sheet that is not tied to one of those sizes, pick "Custom
+format". That lets you set your own width and height and choose the card format
+separately.
+
+Use the arrow keys to move between tiles and Enter to continue.
+
+### Step 2: Layout
+
+Pick the layout you want to start from. Each tile shows a small drawing of the
+layout, its size in pixels and a one-line description. For 40K the desktop
+datacard comes first because it is the most complete starting point, followed by
+the styled datacard, a blank datacard and the stratagem size. Age of Sigmar has
+the warscroll size, and custom formats start from a blank sheet.
+
+Below the tiles are the options that apply to the layout you picked:
+
+- **Template name** — Prefilled with the game and layout, for example "40K
+  Datacard (Desktop)". Change it to anything you like.
+- **Faction colour scheme** — Shown for the styled and desktop layouts. The
+  pre-built elements are coloured from that faction's palette.
+- **Size in pixels** — Shown for custom sizes, between 100 and 2000 pixels.
+- **Card format** — Shown for the custom format tile. It decides which card data
+  you can bind to.
+
+The line above the Create button summarises what you are about to create, such
+as "1080 x 720 px, 40K 10th edition, Space Marines colours". Use Back to return
+to step 1, Enter to create the template, and Escape to close the dialog.

--- a/src/Pages/Help/content/designer/data-binding.mdx
+++ b/src/Pages/Help/content/designer/data-binding.mdx
@@ -9,33 +9,61 @@ Wrap any field path in double curly braces inside a text element:
 - `{{name}}` — Shows the unit name
 - `{{stats[0].m}}` — Shows the first stat profile's Movement value
 
-### Available bindings — Warhammer 40K
+### Available bindings — Warhammer 40K (10th and 11th edition)
 
 | Category | Bindings |
 |----------|----------|
-| **Basic** | `name`, `subname`, `description`, `faction_id` |
-| **Stats** | `stats[0].m`, `stats[0].t`, `stats[0].sv`, `stats[0].w`, `stats[0].ld`, `stats[0].oc`, `stats[0].invul` |
+| **Basic** | `name`, `subname`, `faction_id` (10th edition also has `description`) |
+| **Stats** | `stats[0].m`, `stats[0].t`, `stats[0].sv`, `stats[0].w`, `stats[0].ld`, `stats[0].oc` |
 | **Ranged weapons** | `rangedWeapons[N].name`, `.range`, `.attacks`, `.skill`, `.strength`, `.ap`, `.damage` |
 | **Melee weapons** | `meleeWeapons[N].name`, `.range`, `.attacks`, `.skill`, `.strength`, `.ap`, `.damage` |
-| **Abilities** | `abilities[N].name`, `abilities[N].description` |
-| **Keywords** | `keywords[N].keyword` |
-| **Other** | `composition`, `loadout`, `transport` |
+| **Abilities** | `abilities.other[N].name`, `abilities.other[N].description`, `abilities.core`, `abilities.faction` |
+| **Invulnerable save** | `abilities.invul.value` (10th edition also has `stats[0].invul` and `abilities.invul.info`) |
+| **Keywords** | `keywords[N]`, `factions` |
+| **Points** | `points[N].cost`, `points[N].models` (11th edition also has `points[N].keyword`) |
+| **Other** | `composition`, `loadout`, 10th edition `transport`, 11th edition `leader` and `wargear` |
 
 Replace `[N]` with an index (0, 1, 2...) to access specific items in a list.
+
+Weapons store their values in a profile. A weapon binding such as `{{rangedWeapons[0].name}}` resolves the weapon's first profile, so you do not have to write `profiles[0]` yourself. Use a repeater frame when a weapon has several profiles.
+
+`abilities.core` and `abilities.faction` are lists of names. They are joined with commas, for example "Deep Strike, Leader".
+
+### 11th edition
+
+11th edition templates use the same paths as 10th edition. Two things differ:
+
+- Values are shown in the card language you picked in Settings. A field with no translation falls back to English.
+- Ability text carries markup (`<k>`, `<b>`, bullet lists). The markup is removed before the text is drawn, so a canvas text element shows plain text with list items on their own lines.
+
+Set the template format to "40K 11th Edition" in the Card properties, or start from one of the 11th edition presets in the new template dialog. Preview needs the app datasource to be set to 11th edition as well.
 
 ### Available bindings — Age of Sigmar
 
 | Category | Bindings |
 |----------|----------|
+| **Basic** | `name`, `subname`, `points` |
 | **Stats** | `stats.move`, `stats.save`, `stats.control`, `stats.health`, `stats.ward`, `stats.wizard`, `stats.priest` |
-| **Weapons** | `weapons.ranged[N]` / `weapons.melee[N]` with `.name`, `.hit`, `.wound`, `.rend`, `.damage` |
+| **Weapons** | `weapons.ranged[N]` / `weapons.melee[N]` with `.name`, `.range`, `.attacks`, `.hit`, `.wound`, `.rend`, `.damage` |
+| **Abilities** | `abilities[N].name`, `abilities[N].effect` |
+| **Keywords** | `keywords[N]`, `keywords` |
+
+### Custom datasources
+
+A template that targets a custom datasource card type gets its bindings from that card type's schema:
+
+- Weapons: `weapons.<type>[N].name` plus one path per column, resolved through the weapon's first profile.
+- Abilities: `abilities.<category>[N].name` and `abilities.<category>[N].description`, one group per ability category.
+- Keywords and points follow the card type's metadata settings.
 
 ### Preview mode
 
-Toggle preview mode in the toolbar to see your template with real unit data. Select a datasheet from the dropdown to populate all bound fields. This lets you check layout and sizing before finalizing your design.
+Toggle preview mode in the properties panel to see your template with real unit data. Select a datasheet from the dropdown to populate all bound fields. This lets you check layout and sizing before finalizing your design.
+
+The faction and datasheet lists follow the template's format. If the app is showing a different datasource than the template targets, the panel says which datasource to switch to instead of listing unrelated units.
 
 The original template text is preserved — preview mode only affects the display. Switch back to edit mode to continue working on your template.
 
 ### Binding modal
 
-Click the binding icon on any text element to open the binding browser. Bindings are organized by category and searchable. Click a binding to insert it at the cursor position.
+Click the binding icon on any text element to open the binding browser. Bindings are organized by category and searchable. Clicking a binding appends it to the end of the element's text, so move it into place afterwards if the element already holds text.

--- a/src/Pages/Help/content/designer/data-binding.mdx
+++ b/src/Pages/Help/content/designer/data-binding.mdx
@@ -1,69 +1,147 @@
 ## Data Binding
 
-Connect your template to real game data so cards fill in automatically. Data binding replaces placeholder text with actual values from your datasheets.
+Connect your template to real game data so cards fill in automatically. A bound
+text element shows real values from a datasheet instead of static text.
 
-### Binding syntax
+### The Data tab
 
-Wrap any field path in double curly braces inside a text element:
+The left panel has two tabs: **Layers** and **Data**. The Data tab shows every
+field your template's format can bind to, grouped the same way as the card
+(basic info, stats, weapons, abilities, keywords). A sample card selector sits
+at the top of the tab. Whichever card you pick there, every field in the tree
+shows that card's actual value next to its name, so you can see what you are
+binding before you drop it on the canvas.
 
-- `{{name}}` — Shows the unit name
-- `{{stats[0].m}}` — Shows the first stat profile's Movement value
+### Drag to bind
 
-### Available bindings — Warhammer 40K (10th and 11th edition)
+Drag a field from the Data tab onto the canvas to create a new text element
+bound to it. Drag a field onto an existing text element to replace its
+content with that binding, or drop it at the cursor position if you are
+already editing the text.
 
-| Category | Bindings |
-|----------|----------|
-| **Basic** | `name`, `subname`, `faction_id` (10th edition also has `description`) |
-| **Stats** | `stats[0].m`, `stats[0].t`, `stats[0].sv`, `stats[0].w`, `stats[0].ld`, `stats[0].oc` |
-| **Ranged weapons** | `rangedWeapons[N].name`, `.range`, `.attacks`, `.skill`, `.strength`, `.ap`, `.damage` |
-| **Melee weapons** | `meleeWeapons[N].name`, `.range`, `.attacks`, `.skill`, `.strength`, `.ap`, `.damage` |
-| **Abilities** | `abilities.other[N].name`, `abilities.other[N].description`, `abilities.core`, `abilities.faction` |
-| **Invulnerable save** | `abilities.invul.value` (10th edition also has `stats[0].invul` and `abilities.invul.info`) |
-| **Keywords** | `keywords[N]`, `factions` |
-| **Points** | `points[N].cost`, `points[N].models` (11th edition also has `points[N].keyword`) |
-| **Other** | `composition`, `loadout`, 10th edition `transport`, 11th edition `leader` and `wargear` |
+Drag a list — Ranged Weapons, Abilities, Keywords, and so on — onto the canvas
+to create a repeater frame in one step. This lays out one row per item, side
+by side, with a text child for each of that list's fields. See Repeater
+Frames for how to adjust it afterwards.
 
-Replace `[N]` with an index (0, 1, 2...) to access specific items in a list.
+### Binding chips
 
-Weapons store their values in a profile. A weapon binding such as `{{rangedWeapons[0].name}}` resolves the weapon's first profile, so you do not have to write `profiles[0]` yourself. Use a repeater frame when a weapon has several profiles.
+Inside a text element, a bound field shows as a chip with its label and the
+sample value from the card you picked in the Data tab, not as raw
+`{{ }}` braces. Click a chip to open a small popover where you can add a
+filter, change the field, or remove the chip. Text and chips can be mixed
+freely, for example "Cost: " followed by a `points[0].cost` chip.
 
-`abilities.core` and `abilities.faction` are lists of names. They are joined with commas, for example "Deep Strike, Leader".
+Under the hood a chip is still stored as `{{path}}`, or `{{path | filter}}`
+once you add a filter, so older templates and the raw text editor below both
+keep working.
 
-### 11th edition
+### Filters
 
-11th edition templates use the same paths as 10th edition. Two things differ:
+A filter changes how a bound value is shown. Chain several with `|`, in the
+order you want them applied.
 
-- Values are shown in the card language you picked in Settings. A field with no translation falls back to English.
-- Ability text carries markup (`<k>`, `<b>`, bullet lists). The markup is removed before the text is drawn, so a canvas text element shows plain text with list items on their own lines.
+| Filter | What it does | Example |
+|--------|--------------|---------|
+| `upper` | Upper-cases the text | `{{name \| upper}}` → INTERCESSOR SQUAD |
+| `lower` | Lower-cases the text | `{{name \| lower}}` → intercessor squad |
+| `title` | Capitalizes each word | `{{name \| title}}` → Intercessor Squad |
+| `trim` | Removes leading and trailing spaces | `{{subname \| trim}}` |
+| `join` | Joins a list with a separator (default `, `) | `{{keywords \| join:" / "}}` → Infantry / Imperium |
+| `prefix` | Adds text before the value, only if it is not empty | `{{points[0].cost \| prefix:"Cost: "}}` → Cost: 90 |
+| `suffix` | Adds text after the value, only if it is not empty | `{{stats[0].m \| suffix:"\\""}}` → 6" |
+| `default` | Shows fallback text when the value is empty | `{{subname \| default:"—"}}` |
+| `truncate` | Cuts text to a length and adds `...` | `{{abilities.other[0].description \| truncate:"40"}}` |
+| `first` | Takes the first item of a list | `{{keywords \| first}}` → Infantry |
+| `count` | Counts the items in a list | `{{rangedWeapons \| count}}` → 2 |
 
-Set the template format to "40K 11th Edition" in the Card properties, or start from one of the 11th edition presets in the new template dialog. Preview needs the app datasource to be set to 11th edition as well.
+An unknown filter is ignored, so a plain `{{path}}` with no filter always
+keeps working.
 
-### Available bindings — Age of Sigmar
+### Hide when empty
 
-| Category | Bindings |
-|----------|----------|
-| **Basic** | `name`, `subname`, `points` |
-| **Stats** | `stats.move`, `stats.save`, `stats.control`, `stats.health`, `stats.ward`, `stats.wizard`, `stats.priest` |
-| **Weapons** | `weapons.ranged[N]` / `weapons.melee[N]` with `.name`, `.range`, `.attacks`, `.hit`, `.wound`, `.rend`, `.damage` |
-| **Abilities** | `abilities[N].name`, `abilities[N].effect` |
-| **Keywords** | `keywords[N]`, `keywords` |
+Every text element has a "Hide when empty" checkbox in its Content section.
+Turn it on and the element disappears from the card whenever all of its
+bindings resolve to nothing — useful for an optional line like a subname or
+an invulnerable save that not every unit has.
 
-### Custom datasources
+### Sample values on the canvas
 
-A template that targets a custom datasource card type gets its bindings from that card type's schema:
+While you are editing, a bound text element shows the sample value from the
+card selected in the Data tab, not the raw `{{path}}` placeholder. This lets
+you judge width and wrapping against real data as you build the layout,
+without switching to preview mode. The stored template text is still the
+binding expression — the sample value is only what's drawn while you edit.
 
-- Weapons: `weapons.<type>[N].name` plus one path per column, resolved through the weapon's first profile.
-- Abilities: `abilities.<category>[N].name` and `abilities.<category>[N].description`, one group per ability category.
-- Keywords and points follow the card type's metadata settings.
+### Validation and format changes
+
+If a binding no longer exists for the template's format, the text panel shows
+a warning below the Content section listing which paths are unknown, and the
+layer panel shows a warning triangle on that row instead of the usual "Bound"
+badge.
+
+Changing the format in the Card properties panel checks every binding against
+the new format. If nothing breaks, the format switches immediately. If some
+bindings would stop resolving, a dialog lists them and offers:
+
+- **Keep** — leave the bindings as they are, so they show as unresolved until you fix them.
+- **Clear** — remove the broken bindings from the affected text.
+- **Remap** — switch each broken binding to the matching field in the new format, where one exists (for example a field that only changed which edition it comes from).
+
+The whole change, including any remapping, is a single undo step.
+
+### Format compatibility
+
+10th and 11th edition Warhammer 40K unit templates are compatible with each
+other. A template built for 10th edition can be assigned to an 11th edition
+card and the other way round, because both share the same underlying field
+paths. When you assign a template to a card elsewhere in the app, the
+template picker shows all compatible templates and labels the ones built for
+a different format so you know what you are choosing. A custom datasource
+whose base system is 40K and whose card type is a unit joins the same
+compatibility group.
+
+Templates for Age of Sigmar, or for a custom datasource with a different base
+system, are only compatible with templates built for that same system.
+
+### Built-in paths by format
+
+For power users, or for anything the Data tab does not cover yet, you can
+still type a binding directly.
+
+| Format | Reference |
+|--------|-----------|
+| 40K 10th and 11th edition | Share the same paths: `name`, `subname`, `faction_id` (10th also has `description`); `stats[0].m/t/sv/w/ld/oc`; `rangedWeapons[N]` / `meleeWeapons[N]` with `.name`, `.range`, `.attacks`, `.skill`, `.strength`, `.ap`, `.damage`; `abilities.other[N].name/.description`, `abilities.core`, `abilities.faction`; `abilities.invul.value` (10th also has `stats[0].invul` and `abilities.invul.info`); `keywords[N]`, `factions`; `points[N].cost`, `points[N].models` (11th also has `points[N].keyword`); `composition`, `loadout`; 10th also has `transport`; 11th also has `leader` and `wargear` |
+| Age of Sigmar | `name`, `subname`, `points`; `stats.move/save/control/health/ward/wizard/priest`; `weapons.ranged[N]` / `weapons.melee[N]` with `.name`, `.range`, `.attacks`, `.hit`, `.wound`, `.rend`, `.damage`; `abilities[N].name/.effect`; `keywords[N]`, `keywords` |
+| Custom datasources | Generated from the card type's own schema: `weapons.<type>[N].name` plus one path per column; `abilities.<category>[N].name/.description`, one group per ability category; keywords and points follow the card type's metadata settings |
+
+Replace `[N]` with an index (0, 1, 2...) to reach a specific item in a list.
+Weapons resolve through the item's first profile automatically, so
+`{{rangedWeapons[0].name}}` works without writing `profiles[0]`. Use a
+repeater frame for a weapon with several profiles. `abilities.core` and
+`abilities.faction` are lists of names joined with commas, for example
+"Deep Strike, Leader".
+
+11th edition also localizes values to the card language set in Settings,
+falling back to English when a field has no translation, and strips markup
+(`<k>`, `<b>`, bullet lists) from ability text so a text element shows plain
+text with list items on their own lines.
 
 ### Preview mode
 
-Toggle preview mode in the properties panel to see your template with real unit data. Select a datasheet from the dropdown to populate all bound fields. This lets you check layout and sizing before finalizing your design.
+Toggle Preview in the properties panel to see the whole card with real unit
+data instead of just the sample values inside each element. Select a faction
+and a datasheet from the dropdowns to choose which unit to preview. The
+faction and datasheet lists follow the template's format — if the app is
+showing a different datasource than the template targets, the panel tells
+you which datasource to switch to instead of listing unrelated units.
 
-The faction and datasheet lists follow the template's format. If the app is showing a different datasource than the template targets, the panel says which datasource to switch to instead of listing unrelated units.
+The original template text is preserved; preview mode only changes what is
+displayed. Turn preview off to keep editing.
 
-The original template text is preserved — preview mode only affects the display. Switch back to edit mode to continue working on your template.
+### The raw text editor
 
-### Binding modal
-
-Click the binding icon on any text element to open the binding browser. Bindings are organized by category and searchable. Clicking a binding appends it to the end of the element's text, so move it into place afterwards if the element already holds text.
+The Content section still has a plain text box under the chips. Anyone who
+prefers typing can write `{{path}}` or `{{path | filter:"arg"}}` directly, and
+the chips update to match. This is also where you can chain several filters
+by hand, for example `{{keywords | join:" / " | upper}}`.

--- a/src/Pages/Help/content/designer/data-binding.mdx
+++ b/src/Pages/Help/content/designer/data-binding.mdx
@@ -139,6 +139,16 @@ you which datasource to switch to instead of listing unrelated units.
 The original template text is preserved; preview mode only changes what is
 displayed. Turn preview off to keep editing.
 
+### Keywords and selectable text
+
+Cards drawn from a template are rendered as HTML, so the text can be selected
+and copied like any other text on the page. Weapon keywords, the core ability
+list and rule references inside ability descriptions carry the same hover
+tooltips as the built-in cards: hover a keyword with a dotted underline to read
+its rule. 10th edition uses the built-in keyword dictionary, 11th edition looks
+each keyword up in the datasource's keyword glossary. Preview mode shows the
+same rendering as the app and the print page.
+
 ### The raw text editor
 
 The Content section still has a plain text box under the chips. Anyone who

--- a/src/Pages/Help/content/designer/data-binding.mdx
+++ b/src/Pages/Help/content/designer/data-binding.mdx
@@ -41,19 +41,19 @@ keep working.
 A filter changes how a bound value is shown. Chain several with `|`, in the
 order you want them applied.
 
-| Filter | What it does | Example |
-|--------|--------------|---------|
-| `upper` | Upper-cases the text | `{{name \| upper}}` → INTERCESSOR SQUAD |
-| `lower` | Lower-cases the text | `{{name \| lower}}` → intercessor squad |
-| `title` | Capitalizes each word | `{{name \| title}}` → Intercessor Squad |
-| `trim` | Removes leading and trailing spaces | `{{subname \| trim}}` |
-| `join` | Joins a list with a separator (default `, `) | `{{keywords \| join:" / "}}` → Infantry / Imperium |
-| `prefix` | Adds text before the value, only if it is not empty | `{{points[0].cost \| prefix:"Cost: "}}` → Cost: 90 |
-| `suffix` | Adds text after the value, only if it is not empty | `{{stats[0].m \| suffix:"\\""}}` → 6" |
-| `default` | Shows fallback text when the value is empty | `{{subname \| default:"—"}}` |
-| `truncate` | Cuts text to a length and adds `...` | `{{abilities.other[0].description \| truncate:"40"}}` |
-| `first` | Takes the first item of a list | `{{keywords \| first}}` → Infantry |
-| `count` | Counts the items in a list | `{{rangedWeapons \| count}}` → 2 |
+| Filter     | What it does                                        | Example                                               |
+| ---------- | --------------------------------------------------- | ----------------------------------------------------- |
+| `upper`    | Upper-cases the text                                | `{{name \| upper}}` → INTERCESSOR SQUAD               |
+| `lower`    | Lower-cases the text                                | `{{name \| lower}}` → intercessor squad               |
+| `title`    | Capitalizes each word                               | `{{name \| title}}` → Intercessor Squad               |
+| `trim`     | Removes leading and trailing spaces                 | `{{subname \| trim}}`                                 |
+| `join`     | Joins a list with a separator (default `, `)        | `{{keywords \| join:" / "}}` → Infantry / Imperium    |
+| `prefix`   | Adds text before the value, only if it is not empty | `{{points[0].cost \| prefix:"Cost: "}}` → Cost: 90    |
+| `suffix`   | Adds text after the value, only if it is not empty  | `{{stats[0].m \| suffix:"\\""}}` → 6"                 |
+| `default`  | Shows fallback text when the value is empty         | `{{subname \| default:"—"}}`                          |
+| `truncate` | Cuts text to a length and adds `...`                | `{{abilities.other[0].description \| truncate:"40"}}` |
+| `first`    | Takes the first item of a list                      | `{{keywords \| first}}` → Infantry                    |
+| `count`    | Counts the items in a list                          | `{{rangedWeapons \| count}}` → 2                      |
 
 An unknown filter is ignored, so a plain `{{path}}` with no filter always
 keeps working.
@@ -109,11 +109,11 @@ system, are only compatible with templates built for that same system.
 For power users, or for anything the Data tab does not cover yet, you can
 still type a binding directly.
 
-| Format | Reference |
-|--------|-----------|
+| Format                    | Reference                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | 40K 10th and 11th edition | Share the same paths: `name`, `subname`, `faction_id` (10th also has `description`); `stats[0].m/t/sv/w/ld/oc`; `rangedWeapons[N]` / `meleeWeapons[N]` with `.name`, `.range`, `.attacks`, `.skill`, `.strength`, `.ap`, `.damage`; `abilities.other[N].name/.description`, `abilities.core`, `abilities.faction`; `abilities.invul.value` (10th also has `stats[0].invul` and `abilities.invul.info`); `keywords[N]`, `factions`; `points[N].cost`, `points[N].models` (11th also has `points[N].keyword`); `composition`, `loadout`; 10th also has `transport`; 11th also has `leader` and `wargear` |
-| Age of Sigmar | `name`, `subname`, `points`; `stats.move/save/control/health/ward/wizard/priest`; `weapons.ranged[N]` / `weapons.melee[N]` with `.name`, `.range`, `.attacks`, `.hit`, `.wound`, `.rend`, `.damage`; `abilities[N].name/.effect`; `keywords[N]`, `keywords` |
-| Custom datasources | Generated from the card type's own schema: `weapons.<type>[N].name` plus one path per column; `abilities.<category>[N].name/.description`, one group per ability category; keywords and points follow the card type's metadata settings |
+| Age of Sigmar             | `name`, `subname`, `points`; `stats.move/save/control/health/ward/wizard/priest`; `weapons.ranged[N]` / `weapons.melee[N]` with `.name`, `.range`, `.attacks`, `.hit`, `.wound`, `.rend`, `.damage`; `abilities[N].name/.effect`; `keywords[N]`, `keywords`                                                                                                                                                                                                                                                                                                                                            |
+| Custom datasources        | Generated from the card type's own schema: `weapons.<type>[N].name` plus one path per column; `abilities.<category>[N].name/.description`, one group per ability category; keywords and points follow the card type's metadata settings                                                                                                                                                                                                                                                                                                                                                                |
 
 Replace `[N]` with an index (0, 1, 2...) to reach a specific item in a list.
 Weapons resolve through the item's first profile automatically, so
@@ -137,7 +137,10 @@ showing a different datasource than the template targets, the panel tells
 you which datasource to switch to instead of listing unrelated units.
 
 The original template text is preserved; preview mode only changes what is
-displayed. Turn preview off to keep editing.
+displayed. Turn preview off to keep editing. While preview is on, the canvas
+grid is hidden and the card is shown exactly as the app renders it; you can
+still zoom with <Kbd mod>wheel</Kbd> and pan with the mouse wheel, and select
+text on the card.
 
 ### Keywords and selectable text
 

--- a/src/Pages/Help/content/designer/elements.mdx
+++ b/src/Pages/Help/content/designer/elements.mdx
@@ -6,13 +6,55 @@ Elements are the building blocks of your template.
 
 <IconLabel icon="Type" label="Text" />
 
-Add headings, labels, stat values, or any other text. You can customize the font (choose from 10 font families including Helvetica, Arial, and Georgia), weight, size, alignment, and fill color. Bind a text element to game data — see Data Binding.
+Add headings, labels, stat values, or any other text. Bind a text element to game data — see Data Binding.
+
+#### Typography
+
+Choose the font family from the app's own bundled fonts, a curated set of
+Google Fonts, or the ten classic system fonts, along with weight, size,
+alignment and fill colour. You can also set line height, letter spacing,
+italic, underline and a text transform (uppercase, lowercase or capitalize)
+— uppercase is what most 40K headings use. Vertical alignment controls
+where the text sits inside its box (top, middle or bottom) when the box is
+taller than the text itself.
+
+#### Sizing
+
+A text element's Sizing mode controls how its box responds to its content:
+
+- **Auto width** — The box grows or shrinks to fit the text on one line.
+- **Auto height** — The box keeps a fixed width and grows or shrinks in height as text wraps.
+- **Fixed** — The box keeps the size you set. Set an overflow behaviour for text that doesn't fit: Clip (cut off at the box edge) or Shrink to fit (the font size steps down until the text fits, without changing what you typed).
 
 ### Images
 
 <IconLabel icon="Image" label="Image" />
 
-Add artwork, icons, faction logos, or decorative elements. Upload an image file or place a placeholder to fill in later. Adjust scaling and opacity to get the look you want.
+Add artwork, icons, faction logos, or decorative elements. Upload an image
+file or place a placeholder to fill in later.
+
+#### Fit
+
+Choose how the image fills its box:
+
+- **Fill** — Stretches the image to exactly match the box, ignoring its aspect ratio.
+- **Contain** — Scales the image to fit entirely inside the box, keeping its aspect ratio; you may see empty space on two sides.
+- **Cover** — Scales the image to fill the box completely, keeping its aspect ratio; the parts that don't fit are cropped.
+
+#### Crop
+
+Use the crop tool to choose exactly which part of the image shows. The full
+image appears as a faded guide behind your crop box; drag and resize the
+crop box, then confirm to commit it. A cropped image always fills its box
+exactly (as if set to Fill).
+
+#### Binding
+
+An image can take its source from the card's data instead of a fixed file:
+drag a field from the Data tab onto an image to bind it. A plain URL field
+is used as-is; a faction-related field resolves to the app's own faction
+symbol artwork. "Hide when empty" removes the element entirely when its
+bound source has nothing to show, the same as for text.
 
 ### Shapes
 

--- a/src/Pages/Help/content/designer/elements.mdx
+++ b/src/Pages/Help/content/designer/elements.mdx
@@ -6,7 +6,7 @@ Elements are the building blocks of your template.
 
 <IconLabel icon="Type" label="Text" />
 
-Add headings, labels, stat values, or any other text. You can customize the font (choose from 10 font families including Helvetica, Arial, and Georgia), size, weight, style, color, and alignment. Adjust line height and the space between characters for fine-tuned control.
+Add headings, labels, stat values, or any other text. You can customize the font (choose from 10 font families including Helvetica, Arial, and Georgia), weight, size, alignment, and fill color. Bind a text element to game data — see Data Binding.
 
 ### Images
 

--- a/src/Pages/Help/content/designer/elements.mdx
+++ b/src/Pages/Help/content/designer/elements.mdx
@@ -63,6 +63,7 @@ Add visual structure with basic shapes:
 - <IconLabel icon="Square" label="Rectangle" /> — Set fill color, border, and rounded corners
 - <IconLabel icon="Circle" label="Circle" /> — Set fill color and border
 - <IconLabel icon="Minus" label="Line" /> — Set color and thickness
+- <IconLabel icon="Pentagon" label="Polygon" /> — A shape with its own corner points. The styled presets use polygons for the header banner and the notched stat boxes. Resizing keeps the shape in proportion.
 
 ### Frames
 

--- a/src/Pages/Help/content/designer/frames-and-auto-layout.mdx
+++ b/src/Pages/Help/content/designer/frames-and-auto-layout.mdx
@@ -72,11 +72,13 @@ run off the bottom. Turn on **Card grows with content** in the card's Canvas
 properties to let the card get taller instead.
 
 With it on, the card is measured against the unit being rendered: the lowest
-edge of everything on it, every repeater row included, plus the same bottom
-margin the design keeps below its lowest element. The card never gets shorter
-than its design height, and **Max** caps how tall it may get (leave it
-blank for no limit). Repeaters ignore their Max Items cap while the card can
-grow, so every item is drawn.
+edge of everything that flows, every repeater row included. The card keeps
+its design height for as long as that content stays **Gap** px (16 by
+default) above the elements anchored to the bottom, and past that it grows by
+exactly what is missing, so a card with room to spare stays its designed
+size. **Max** caps how tall it may get (leave it blank for no limit).
+Repeaters ignore their Max Items cap while the card can grow, so every item
+is drawn.
 
 Two element checkboxes in the Transform section tell the rest of the card
 what to do with the extra height. They apply to shapes, frames and images:
@@ -84,6 +86,12 @@ what to do with the extra height. They apply to shapes, frames and images:
 - **Stretch to card bottom** — The element gets taller by the same amount the card did. Use it for a background panel or a column divider that should cover the whole card. On a polygon, only the points in its lower half move, so notched corners keep their shape.
 - **Keep distance to card bottom** — The element moves down by the same amount, staying the same distance from the bottom edge. Use it for a footer bar or a badge that sits at the bottom of the card but is not part of the section flow.
 
+A section that is set to hug its contents grows too: its auto-height text is
+measured against the real card, the frame grows to fit it, and the sections
+below it in the same column move down by the same amount. That is what keeps
+a long wargear list readable instead of shrinking it into its box.
+
 Both 40K styled presets ship with this set up: the data panel background and
 the column divider stretch, the keywords footer and the faction diamond stay
-anchored to the bottom.
+anchored to the bottom, and the wargear, unit composition and abilities
+blocks hug their text.

--- a/src/Pages/Help/content/designer/frames-and-auto-layout.mdx
+++ b/src/Pages/Help/content/designer/frames-and-auto-layout.mdx
@@ -2,7 +2,9 @@
 
 Frames act as containers that hold and organize other elements.
 
-Drag elements into a frame to group them. The frame can then control how its children are arranged.
+Drag elements into a frame to group them, either by dropping onto the frame
+on the canvas or by dragging a row onto the frame in the Layers tree. The
+frame can then control how its children are arranged.
 
 ### Auto-layout modes
 
@@ -16,8 +18,48 @@ When auto-layout is active, you can adjust:
 
 - **Gap** — The space between each child element
 - **Padding** — The space between the frame edge and its contents
-- **Alignment** — Where children sit along the cross-axis (start, center, or end)
+- **Align** — Where children sit on the cross-axis (start, center, or end)
+- **Justify** — Where children sit on the main-axis when there is spare room (start, center, or end)
+- **Wrap to next line** — Only for horizontal layouts. When a row of children would run past the frame's width, the rest continue on a new line below.
+
+### Sizing
+
+A frame's Sizing setting controls how it responds to its contents:
+
+- **Fixed** — The frame keeps the size you set. Content that does not fit is clipped or overflows, depending on Clip Content.
+- **Hug contents** — The frame resizes itself to fit its children plus padding, growing and shrinking automatically as children are added, removed or edited. With Wrap on, a hug frame only adjusts its height; its width stays fixed and is what sets the wrap point.
 
 ### Clipping
 
 Enable "Clip content" to hide anything that extends beyond the frame boundaries. This keeps your layout tidy when elements are larger than the available space.
+
+### Repeater row styling
+
+A repeater frame (see Repeater Frames) has three extra options for how its
+rows are drawn:
+
+- **Alternate row fill** — A background colour painted behind every other row, for a striped table look.
+- **Separator** — Draws a line or dotted rule between rows, in the colour you choose.
+- **Empty state text** — Text shown as a single row when the data source array is empty. With no empty text set, a repeater with nothing to show hides itself entirely.
+
+### Sections and the card's vertical flow
+
+A frame with a Section Order takes part in the card's vertical flow, and a
+repeater whose "Push elements below" is on can push everything after it
+down as it grows. A frame's own properties panel only shows a read-only
+summary of its place in the flow, with a "Manage in card settings" link —
+the actual list lives on the card itself.
+
+Select the card (click its background, or the root row in the Layers tree)
+to open its properties, then look for the **Sections** section. It lists
+every frame that takes part in the flow, grouped by column:
+
+- Drag a row to reorder it within its column — frames higher in a column are drawn first.
+- Change a row's column to move it between independent flows (for example, a two-column layout where each side pushes separately).
+- Toggle Push on a row to make it push elements below it when it expands.
+- Use "Add to flow..." to bring an unplaced frame into the flow.
+
+<Callout type="info">
+  Reordering renumbers every section across all columns into one sequence, so section numbers are not restarted per
+  column.
+</Callout>

--- a/src/Pages/Help/content/designer/frames-and-auto-layout.mdx
+++ b/src/Pages/Help/content/designer/frames-and-auto-layout.mdx
@@ -63,3 +63,27 @@ every frame that takes part in the flow, grouped by column:
   Reordering renumbers every section across all columns into one sequence, so section numbers are not restarted per
   column.
 </Callout>
+
+### Cards that grow with their content
+
+Section push moves the sections below a repeater down, but the card itself
+keeps the height you designed, so a unit with a long weapon list can still
+run off the bottom. Turn on **Card grows with content** in the card's Canvas
+properties to let the card get taller instead.
+
+With it on, the card is measured against the unit being rendered: the lowest
+edge of everything on it, every repeater row included, plus the same bottom
+margin the design keeps below its lowest element. The card never gets shorter
+than its design height, and **Max** caps how tall it may get (leave it
+blank for no limit). Repeaters ignore their Max Items cap while the card can
+grow, so every item is drawn.
+
+Two element checkboxes in the Transform section tell the rest of the card
+what to do with the extra height. They apply to shapes, frames and images:
+
+- **Stretch to card bottom** — The element gets taller by the same amount the card did. Use it for a background panel or a column divider that should cover the whole card. On a polygon, only the points in its lower half move, so notched corners keep their shape.
+- **Keep distance to card bottom** — The element moves down by the same amount, staying the same distance from the bottom edge. Use it for a footer bar or a badge that sits at the bottom of the card but is not part of the section flow.
+
+Both 40K styled presets ship with this set up: the data panel background and
+the column divider stretch, the keywords footer and the faction diamond stay
+anchored to the bottom.

--- a/src/Pages/Help/content/designer/frames-and-auto-layout.mdx
+++ b/src/Pages/Help/content/designer/frames-and-auto-layout.mdx
@@ -6,6 +6,19 @@ Drag elements into a frame to group them, either by dropping onto the frame
 on the canvas or by dragging a row onto the frame in the Layers tree. The
 frame can then control how its children are arranged.
 
+### Selecting inside a frame
+
+A click on the canvas selects the frame as a whole, even when you click on
+one of its children. Double-click the child to select it instead. The frame
+stays open while a child is selected, so a single click then picks another
+child of the same frame, and you can drag or resize the child in place.
+Press <Kbd>Escape</Kbd> to step back out to the frame, and again to clear the
+selection. A nested frame works the same way: double-click it to select it,
+double-click again to go one level deeper. Double-click a selected text to
+start editing it.
+
+The Layers tree always selects exactly the row you click, at any depth.
+
 ### Auto-layout modes
 
 - <IconLabel icon="LayoutList" label="None" /> — Children are positioned freely, just like on the main canvas
@@ -24,10 +37,20 @@ When auto-layout is active, you can adjust:
 
 ### Sizing
 
-A frame's Sizing setting controls how it responds to its contents:
+A frame has a separate sizing setting for its width and its height:
 
-- **Fixed** — The frame keeps the size you set. Content that does not fit is clipped or overflows, depending on Clip Content.
-- **Hug contents** — The frame resizes itself to fit its children plus padding, growing and shrinking automatically as children are added, removed or edited. With Wrap on, a hug frame only adjusts its height; its width stays fixed and is what sets the wrap point.
+- **Fixed** — The frame keeps the size you set on that axis. Content that does not fit is clipped or overflows, depending on Clip Content.
+- **Hug** — The frame resizes itself on that axis to fit its children plus padding, growing and shrinking automatically as children are added, removed or edited.
+
+Most section frames want a fixed width and a hugging height, so a block of
+text can grow downwards without changing the column width. A row of stats
+is the opposite: hug the width, keep the height. With Wrap on, the width is
+locked to fixed because it is what sets the wrap point, so only the height
+can hug.
+
+On a repeater frame, a hugging height applies to every row on its own: each
+row takes the height of its content, so an ability with a long description
+gets a taller row and a short one stays compact. See Repeater Frames.
 
 ### Clipping
 
@@ -93,5 +116,6 @@ a long wargear list readable instead of shrinking it into its box.
 
 Both 40K styled presets ship with this set up: the data panel background and
 the column divider stretch, the keywords footer and the faction diamond stay
-anchored to the bottom, and the wargear, unit composition and abilities
-blocks hug their text.
+anchored to the bottom, the wargear, unit composition and abilities blocks
+hug their text, and the other abilities repeater hugs each row to its
+description.

--- a/src/Pages/Help/content/designer/grid-and-alignment.mdx
+++ b/src/Pages/Help/content/designer/grid-and-alignment.mdx
@@ -1,8 +1,9 @@
 ## Grid and Alignment
 
-The grid helps you place elements precisely.
+The grid and the smart guides help you place elements precisely.
 
-A 10-pixel grid is shown by default. Elements snap to the nearest grid line as you move or resize them, making it easy to keep things aligned.
+A 10-pixel grid is shown by default. It follows the card, so it stays in place at
+any zoom level.
 
 You can:
 
@@ -11,9 +12,24 @@ You can:
 - <Icon name="Magnet" /> **Toggle snap to grid** in the floating toolbar. Turn it off when you need freeform placement;
   elements then move to any pixel position instead of snapping to the nearest grid line.
 
+### Smart guides
+
+While you drag or resize an element, red dashed lines appear when its edges or its
+centre line up with another element or with the edge or centre of the card. The
+element snaps to that line. Snapping to the grid, when it is on, is applied after
+the guides.
+
+Guides compare the element against every other element on the card, including
+elements inside frames.
+
 ### Alignment tools
 
 Select an element and use the alignment buttons in the properties panel:
 
 - <Icon name="AlignStartVertical" /> **Align left, right, top, or bottom** — Snap to the canvas edge
 - <Icon name="AlignCenterVertical" /> **Center horizontally or vertically** — Place at the exact center of the canvas
+
+### Nudging
+
+Arrow keys move the selection by one pixel. Shift and an arrow key move it by one
+grid step when snap to grid is on, or by 10 pixels when it is off.

--- a/src/Pages/Help/content/designer/grid-and-alignment.mdx
+++ b/src/Pages/Help/content/designer/grid-and-alignment.mdx
@@ -8,7 +8,8 @@ You can:
 
 - **Change the grid size** in the canvas properties
 - <Icon name="Grid3X3" /> **Toggle grid visibility** on or off
-- **Disable snapping** when you need freeform placement
+- <Icon name="Magnet" /> **Toggle snap to grid** in the floating toolbar. Turn it off when you need freeform placement;
+  elements then move to any pixel position instead of snapping to the nearest grid line.
 
 ### Alignment tools
 

--- a/src/Pages/Help/content/designer/keyboard-shortcuts.mdx
+++ b/src/Pages/Help/content/designer/keyboard-shortcuts.mdx
@@ -1,5 +1,7 @@
 ## Keyboard Shortcuts
 
+### Editing
+
 | Action                   | Shortcut                                                |
 | ------------------------ | ------------------------------------------------------- |
 | Undo                     | <Kbd mod>Z</Kbd>                                        |
@@ -8,17 +10,53 @@
 | Delete selected elements | <Kbd>Delete</Kbd> or <Kbd>Backspace</Kbd>               |
 | Copy                     | <Kbd mod>C</Kbd>                                        |
 | Paste                    | <Kbd mod>V</Kbd>                                        |
+| Duplicate in place       | <Kbd mod>D</Kbd>                                        |
 | Select all               | <Kbd mod>A</Kbd>                                        |
+| Group into a frame       | <Kbd mod>G</Kbd>                                        |
+| Ungroup a frame          | <Kbd mod>Shift</Kbd> + <Kbd>G</Kbd>                     |
 | Move by 1 pixel          | <Kbd>Arrow keys</Kbd>                                   |
-| Move by 10 pixels        | <Kbd>Shift</Kbd> + <Kbd>Arrow keys</Kbd>                |
-| Bring to front           | <Kbd mod>]</Kbd>                                        |
-| Send to back             | <Kbd mod>[</Kbd>                                        |
-| Add text                 | <Kbd>T</Kbd>                                            |
-| Add frame                | <Kbd>F</Kbd>                                            |
-| Add rectangle            | <Kbd>R</Kbd>                                            |
-| Add circle               | <Kbd>O</Kbd>                                            |
-| Add line                 | <Kbd>L</Kbd>                                            |
-| Add image                | <Kbd>I</Kbd>                                            |
+| Move by one grid step    | <Kbd>Shift</Kbd> + <Kbd>Arrow keys</Kbd>                |
+
+### Depth
+
+| Action         | Shortcut                            |
+| -------------- | ----------------------------------- |
+| Forward one    | <Kbd mod>]</Kbd>                    |
+| Backward one   | <Kbd mod>[</Kbd>                    |
+| Bring to front | <Kbd mod>Shift</Kbd> + <Kbd>]</Kbd> |
+| Send to back   | <Kbd mod>Shift</Kbd> + <Kbd>[</Kbd> |
+
+### View
+
+| Action            | Shortcut                                      |
+| ----------------- | --------------------------------------------- |
+| Zoom to fit       | <Kbd>Shift</Kbd> + <Kbd>1</Kbd>               |
+| Zoom to selection | <Kbd>Shift</Kbd> + <Kbd>2</Kbd>               |
+| Zoom to 100%      | <Kbd>Shift</Kbd> + <Kbd>0</Kbd>               |
+| Zoom in or out    | <Kbd mod>Mouse wheel</Kbd>                    |
+| Scroll up or down | <Kbd>Mouse wheel</Kbd>                        |
+| Scroll sideways   | <Kbd>Shift</Kbd> + <Kbd>Mouse wheel</Kbd>     |
+| Pan the canvas    | <Kbd>Space</Kbd> + drag, or middle mouse drag |
+
+### Tools
+
+| Tool      | Shortcut     |
+| --------- | ------------ |
+| Text      | <Kbd>T</Kbd> |
+| Frame     | <Kbd>F</Kbd> |
+| Rectangle | <Kbd>R</Kbd> |
+| Circle    | <Kbd>O</Kbd> |
+| Line      | <Kbd>L</Kbd> |
+| Image     | <Kbd>I</Kbd> |
+
+A tool key selects the tool. Drag on the card to draw the element at the size you
+want, or click once to drop it at its default size. The tool goes back to select
+after one element, unless you hold <Kbd>Shift</Kbd> while you finish the drag.
+
+<Kbd>Escape</Kbd> cancels the tool.
+
+Hold <Kbd>Shift</Kbd> while resizing to keep the aspect ratio, and while rotating
+to turn in 15 degree steps.
 
 Pasted elements are offset by a few pixels from the original, so you can see both copies.
 

--- a/src/Pages/Help/content/designer/keyboard-shortcuts.mdx
+++ b/src/Pages/Help/content/designer/keyboard-shortcuts.mdx
@@ -1,14 +1,23 @@
 ## Keyboard Shortcuts
 
-| Action | Shortcut |
-|--------|----------|
+| Action                   | Shortcut                                  |
+| ------------------------ | ----------------------------------------- |
 | Delete selected elements | <Kbd>Delete</Kbd> or <Kbd>Backspace</Kbd> |
-| Copy | <Kbd mod>C</Kbd> |
-| Paste | <Kbd mod>V</Kbd> |
-| Select all | <Kbd mod>A</Kbd> |
-| Move by 1 pixel | <Kbd>Arrow keys</Kbd> |
-| Move by 10 pixels | <Kbd>Shift</Kbd> + <Kbd>Arrow keys</Kbd> |
-| Bring to front | <Kbd mod>]</Kbd> |
-| Send to back | <Kbd mod>[</Kbd> |
+| Copy                     | <Kbd mod>C</Kbd>                          |
+| Paste                    | <Kbd mod>V</Kbd>                          |
+| Select all               | <Kbd mod>A</Kbd>                          |
+| Move by 1 pixel          | <Kbd>Arrow keys</Kbd>                     |
+| Move by 10 pixels        | <Kbd>Shift</Kbd> + <Kbd>Arrow keys</Kbd>  |
+| Bring to front           | <Kbd mod>]</Kbd>                          |
+| Send to back             | <Kbd mod>[</Kbd>                          |
+| Add text                 | <Kbd>T</Kbd>                              |
+| Add frame                | <Kbd>F</Kbd>                              |
+| Add rectangle            | <Kbd>R</Kbd>                              |
+| Add circle               | <Kbd>O</Kbd>                              |
+| Add line                 | <Kbd>L</Kbd>                              |
+| Add image                | <Kbd>I</Kbd>                              |
 
 Pasted elements are offset by a few pixels from the original, so you can see both copies.
+
+The single-letter shortcuts only work while the canvas has focus, with no
+modifier key held, and not while you're typing inside a text element.

--- a/src/Pages/Help/content/designer/keyboard-shortcuts.mdx
+++ b/src/Pages/Help/content/designer/keyboard-shortcuts.mdx
@@ -1,23 +1,31 @@
 ## Keyboard Shortcuts
 
-| Action                   | Shortcut                                  |
-| ------------------------ | ----------------------------------------- |
-| Delete selected elements | <Kbd>Delete</Kbd> or <Kbd>Backspace</Kbd> |
-| Copy                     | <Kbd mod>C</Kbd>                          |
-| Paste                    | <Kbd mod>V</Kbd>                          |
-| Select all               | <Kbd mod>A</Kbd>                          |
-| Move by 1 pixel          | <Kbd>Arrow keys</Kbd>                     |
-| Move by 10 pixels        | <Kbd>Shift</Kbd> + <Kbd>Arrow keys</Kbd>  |
-| Bring to front           | <Kbd mod>]</Kbd>                          |
-| Send to back             | <Kbd mod>[</Kbd>                          |
-| Add text                 | <Kbd>T</Kbd>                              |
-| Add frame                | <Kbd>F</Kbd>                              |
-| Add rectangle            | <Kbd>R</Kbd>                              |
-| Add circle               | <Kbd>O</Kbd>                              |
-| Add line                 | <Kbd>L</Kbd>                              |
-| Add image                | <Kbd>I</Kbd>                              |
+| Action                   | Shortcut                                                |
+| ------------------------ | ------------------------------------------------------- |
+| Undo                     | <Kbd mod>Z</Kbd>                                        |
+| Redo                     | <Kbd mod>Shift</Kbd> + <Kbd>Z</Kbd> or <Kbd mod>Y</Kbd> |
+| Clear selection          | <Kbd>Escape</Kbd>                                       |
+| Delete selected elements | <Kbd>Delete</Kbd> or <Kbd>Backspace</Kbd>               |
+| Copy                     | <Kbd mod>C</Kbd>                                        |
+| Paste                    | <Kbd mod>V</Kbd>                                        |
+| Select all               | <Kbd mod>A</Kbd>                                        |
+| Move by 1 pixel          | <Kbd>Arrow keys</Kbd>                                   |
+| Move by 10 pixels        | <Kbd>Shift</Kbd> + <Kbd>Arrow keys</Kbd>                |
+| Bring to front           | <Kbd mod>]</Kbd>                                        |
+| Send to back             | <Kbd mod>[</Kbd>                                        |
+| Add text                 | <Kbd>T</Kbd>                                            |
+| Add frame                | <Kbd>F</Kbd>                                            |
+| Add rectangle            | <Kbd>R</Kbd>                                            |
+| Add circle               | <Kbd>O</Kbd>                                            |
+| Add line                 | <Kbd>L</Kbd>                                            |
+| Add image                | <Kbd>I</Kbd>                                            |
 
 Pasted elements are offset by a few pixels from the original, so you can see both copies.
+
+Undo and redo cover canvas edits, property changes and layer operations. Typing in a
+property field counts as one step once you leave the field or press Enter. History is
+kept per template and is cleared when you switch templates. Undo and redo are
+disabled while preview mode is on.
 
 The single-letter shortcuts only work while the canvas has focus, with no
 modifier key held, and not while you're typing inside a text element.

--- a/src/Pages/Help/content/designer/keyboard-shortcuts.mdx
+++ b/src/Pages/Help/content/designer/keyboard-shortcuts.mdx
@@ -2,20 +2,20 @@
 
 ### Editing
 
-| Action                   | Shortcut                                                |
-| ------------------------ | ------------------------------------------------------- |
-| Undo                     | <Kbd mod>Z</Kbd>                                        |
-| Redo                     | <Kbd mod>Shift</Kbd> + <Kbd>Z</Kbd> or <Kbd mod>Y</Kbd> |
-| Clear selection          | <Kbd>Escape</Kbd>                                       |
-| Delete selected elements | <Kbd>Delete</Kbd> or <Kbd>Backspace</Kbd>               |
-| Copy                     | <Kbd mod>C</Kbd>                                        |
-| Paste                    | <Kbd mod>V</Kbd>                                        |
-| Duplicate in place       | <Kbd mod>D</Kbd>                                        |
-| Select all               | <Kbd mod>A</Kbd>                                        |
-| Group into a frame       | <Kbd mod>G</Kbd>                                        |
-| Ungroup a frame          | <Kbd mod>Shift</Kbd> + <Kbd>G</Kbd>                     |
-| Move by 1 pixel          | <Kbd>Arrow keys</Kbd>                                   |
-| Move by one grid step    | <Kbd>Shift</Kbd> + <Kbd>Arrow keys</Kbd>                |
+| Action                                    | Shortcut                                                |
+| ----------------------------------------- | ------------------------------------------------------- |
+| Undo                                      | <Kbd mod>Z</Kbd>                                        |
+| Redo                                      | <Kbd mod>Shift</Kbd> + <Kbd>Z</Kbd> or <Kbd mod>Y</Kbd> |
+| Step out of a frame, then clear selection | <Kbd>Escape</Kbd>                                       |
+| Delete selected elements                  | <Kbd>Delete</Kbd> or <Kbd>Backspace</Kbd>               |
+| Copy                                      | <Kbd mod>C</Kbd>                                        |
+| Paste                                     | <Kbd mod>V</Kbd>                                        |
+| Duplicate in place                        | <Kbd mod>D</Kbd>                                        |
+| Select all                                | <Kbd mod>A</Kbd>                                        |
+| Group into a frame                        | <Kbd mod>G</Kbd>                                        |
+| Ungroup a frame                           | <Kbd mod>Shift</Kbd> + <Kbd>G</Kbd>                     |
+| Move by 1 pixel                           | <Kbd>Arrow keys</Kbd>                                   |
+| Move by one grid step                     | <Kbd>Shift</Kbd> + <Kbd>Arrow keys</Kbd>                |
 
 ### Depth
 

--- a/src/Pages/Help/content/designer/layers-and-depth.mdx
+++ b/src/Pages/Help/content/designer/layers-and-depth.mdx
@@ -12,10 +12,42 @@ To change the order:
 
 Elements inside a frame are layered relative to each other within that frame. Moving a frame moves all its children together.
 
+### The layer tree
+
+The Layers tab shows the full structure of your template as a nested tree — a
+frame's children are indented underneath it, and a frame inside another frame
+nests to any depth. Click the arrow next to a frame to expand or collapse its
+children.
+
+### Moving elements into and out of frames
+
+You can reparent an element from the tree or from the canvas:
+
+- **In the tree** — drag a row onto a frame's row, nudging it slightly to the right as you drop, to nest it inside that frame. Drag it back out among the root-level rows, or drag it to the left while over a shallower row, to release it.
+- **On the canvas** — drag an element so its centre sits over a frame to drop it inside; drag an element that is already inside a frame outside that frame's bounds to release it. The frame highlights while a compatible drop is in reach.
+
+### Renaming
+
+Double-click a layer's name, press <Kbd>Enter</Kbd> with a single layer
+selected, or right-click a layer and choose Rename, to edit its name in
+place. Press <Kbd>Enter</Kbd> to save or <Kbd>Escape</Kbd> to cancel. A
+layer's default name comes from what it is bound to (for example "Unit
+Name" for a text bound to `{{name}}`) or its type, but any custom name you
+give it takes over from then on.
+
+### Selecting multiple layers
+
+Click a layer to select it on its own. <Kbd mod>Click</Kbd> a layer to add
+or remove it from the current selection. <Kbd>Shift</Kbd> + click selects
+every layer between your last click and the one you just clicked. This
+mirrors multi-select on the canvas — you can also shift-click or drag a
+selection box on the canvas itself.
+
 ### Duplicating and grouping
 
 Duplicate and grouping are keyboard shortcuts rather than menu items:
 
 - <Kbd mod>D</Kbd> duplicates the selection, offset a few pixels from the original.
 - <Kbd mod>G</Kbd> wraps the selection in a new frame, sized to fit around it.
-- <Kbd mod>Shift</Kbd> + <Kbd>G</Kbd> ungroups a selected frame, releasing its children back onto the canvas at their current position and removing the frame.
+- <Kbd mod>Shift</Kbd> + <Kbd>G</Kbd> ungroups a selected frame, releasing its children back onto the canvas at their
+  current position and removing the frame.

--- a/src/Pages/Help/content/designer/layers-and-depth.mdx
+++ b/src/Pages/Help/content/designer/layers-and-depth.mdx
@@ -6,8 +6,16 @@ Elements at the top of the layer panel sit in front on the canvas. Elements at t
 
 To change the order:
 
-- **Drag layers** up or down in the layer panel
-- **Keyboard** — Press <Kbd mod>]</Kbd> to bring an element to the front, or <Kbd mod>[</Kbd> to send it to the back
-- **Right-click** any element on the canvas and choose "Bring to Front" or "Send to Back"
+- **Drag layers** up or down in the Layers tab
+- **Keyboard** — <Kbd mod>]</Kbd> moves an element forward one step, <Kbd mod>[</Kbd> moves it back one step, <Kbd mod>Shift</Kbd> + <Kbd>]</Kbd> brings it to the front, <Kbd mod>Shift</Kbd> + <Kbd>[</Kbd> sends it to the back
+- **Right-click** any element on the canvas for the same four options: Forward One, Backward One, Bring to Front, Send to Back
 
 Elements inside a frame are layered relative to each other within that frame. Moving a frame moves all its children together.
+
+### Duplicating and grouping
+
+Duplicate and grouping are keyboard shortcuts rather than menu items:
+
+- <Kbd mod>D</Kbd> duplicates the selection, offset a few pixels from the original.
+- <Kbd mod>G</Kbd> wraps the selection in a new frame, sized to fit around it.
+- <Kbd mod>Shift</Kbd> + <Kbd>G</Kbd> ungroups a selected frame, releasing its children back onto the canvas at their current position and removing the frame.

--- a/src/Pages/Help/content/designer/repeater-frames.mdx
+++ b/src/Pages/Help/content/designer/repeater-frames.mdx
@@ -57,19 +57,14 @@ inside it, so the first and last copies do not touch the frame border.
 
 ### Section order and push
 
-Every frame has a **Section Order** number and a "Push elements below when
-expanded" checkbox, found under Section Layout in its properties. These
-control what happens to the rest of the card when a repeater grows or
-shrinks:
-
-- Section Order sets where a frame sits in the card's vertical stack of
-  sections, independent of its exact pixel position.
-- On a repeater frame, turning on "Push elements below" makes every frame
-  with a higher section order move down to make room when this repeater
-  draws more rows than it has space for by default, and move back up when it
-  draws fewer. This is what keeps a weapons table from overlapping the
-  abilities text below it as the unit's weapon count changes from card to
-  card.
-
-Push only takes effect on frames with the repeater enabled; the checkbox is
-disabled otherwise.
+A repeater frame can take part in the card's vertical flow, so the rest of
+the card moves out of the way as it grows or shrinks. This is managed from
+the **Sections** list in the card's own properties, not from the frame — see
+Frames and Auto-Layout for how the list works. Turning Push on for a
+repeater's row in that list makes every section after it in the same column
+move down when the repeater draws more rows than it has space for by
+default, and move back up when it draws fewer. This is what keeps a weapons
+table from overlapping the abilities text below it as the unit's weapon
+count changes from card to card. A frame's own properties panel shows a
+read-only summary of its place in the flow, with a link to jump to the
+card's Sections list.

--- a/src/Pages/Help/content/designer/repeater-frames.mdx
+++ b/src/Pages/Help/content/designer/repeater-frames.mdx
@@ -1,15 +1,75 @@
 ## Repeater Frames
 
-Use repeater frames to display lists of items, like weapons or abilities.
+Use a repeater frame to display a list of items, like ranged weapons or
+abilities, without adding one text element per item by hand.
 
-A repeater frame takes an array of data (for example, a list of ranged weapons) and creates a copy of its contents for each item.
+A repeater frame takes an array of data and repeats one row of content once
+for every item in that array.
 
-To set up a repeater:
+### Creating a repeater
 
-1. Create a frame and add the elements you want repeated (one row of content)
-2. Enable "Repeat" mode in the frame properties
-3. Set the **data source** — the array path to repeat over (e.g., `rangedWeapons`)
-4. Choose a **direction** — stack copies vertically or horizontally
-5. Optionally set a **maximum count** to limit how many items are shown
+The quickest way is to drag a list from the Data tab — Ranged Weapons,
+Abilities, Keywords, and so on — onto the canvas. This creates a frame with
+"Repeat" already enabled, its data source already set, and one text child per
+field in that list, laid out in a row.
 
-Switch to preview mode to see the repeater in action with real unit data.
+You can also build one by hand:
+
+1. Draw a frame and add the elements you want repeated (one row of content).
+2. Open the frame's properties and turn on "Enable repeater".
+3. Choose a **data source** — which list to repeat over, for example Ranged
+   Weapons or Other Abilities. The list depends on the template's format;
+   a custom datasource offers the lists its own schema defines.
+4. Choose a **direction** — Vertical stacks copies top to bottom, Horizontal
+   lays them out left to right.
+5. Optionally set **Max Items** to cap how many copies are shown, even if the
+   unit has more entries than that.
+
+Switch on Preview to see the repeater filled with a real unit's data.
+
+### Editing the row
+
+Whatever you put inside the frame becomes the template for every row. Bind
+each child element to a field of the item, either by dragging a field from
+the Data tab (which shows that repeater's own fields first, since it knows
+you are working inside it) or by typing the field name directly, for example
+`{{name}}` or `{{range}}` for a weapon row. You do not include the list name
+or an index — each copy already resolves its fields against its own item.
+
+### $index, $count, $first and $last
+
+Inside a repeater, four extra values are available alongside the item's own
+fields:
+
+- `{{$index}}` — the row's position, starting at 0
+- `{{$count}}` — the total number of rows being drawn
+- `{{$first}}` — true on the first row
+- `{{$last}}` — true on the last row
+
+These are useful for numbering rows or for a binding that should only show
+something on the first or last item.
+
+### Gap and padding
+
+**Gap** sets the space between one copy and the next. Padding (top, right,
+bottom, left) sets the space between the frame's edge and the row template
+inside it, so the first and last copies do not touch the frame border.
+
+### Section order and push
+
+Every frame has a **Section Order** number and a "Push elements below when
+expanded" checkbox, found under Section Layout in its properties. These
+control what happens to the rest of the card when a repeater grows or
+shrinks:
+
+- Section Order sets where a frame sits in the card's vertical stack of
+  sections, independent of its exact pixel position.
+- On a repeater frame, turning on "Push elements below" makes every frame
+  with a higher section order move down to make room when this repeater
+  draws more rows than it has space for by default, and move back up when it
+  draws fewer. This is what keeps a weapons table from overlapping the
+  abilities text below it as the unit's weapon count changes from card to
+  card.
+
+Push only takes effect on frames with the repeater enabled; the checkbox is
+disabled otherwise.

--- a/src/Pages/Help/content/designer/repeater-frames.mdx
+++ b/src/Pages/Help/content/designer/repeater-frames.mdx
@@ -55,6 +55,15 @@ something on the first or last item.
 bottom, left) sets the space between the frame's edge and the row template
 inside it, so the first and last copies do not touch the frame border.
 
+### Row height
+
+By default every row is as tall as the frame you drew. Set the frame's
+Height sizing to Hug and each row takes the height of its own content
+instead: give the row's text Auto height and a long ability description gets
+a taller row while a short one stays compact. The sections below the
+repeater move down by the measured total, and an auto-height card grows to
+fit. Horizontal repeaters give every column the height of the tallest one.
+
 ### Section order and push
 
 A repeater frame can take part in the card's vertical flow, so the rest of

--- a/src/Pages/Help/content/designer/saving-and-managing.mdx
+++ b/src/Pages/Help/content/designer/saving-and-managing.mdx
@@ -11,10 +11,40 @@ Every change you make is saved to your browser within about a second. You'll see
 
 ### Duplicate
 
-<Icon name="Copy" /> Create a copy of any template to experiment without affecting the original. Duplicates are named with "(Copy)" appended.
+<Icon name="Copy" /> Create a copy of any template to experiment without affecting the original. Duplicates are named
+with "(Copy)" appended.
 
 ### Important
 
 <Callout type="warning">
-Templates are stored in your browser's local storage. Clearing your browser data will remove them. Use export to keep backups of templates you want to keep.
+  Templates are stored in your browser's local storage. Clearing your browser data will remove them. Use export to keep
+  backups of templates you want to keep.
 </Callout>
+
+### Cloud images
+
+An image you upload into a template is stored in the cloud rather than
+inside the template file itself, so exporting, importing and syncing a
+template with images stays small and fast. Templates created before this
+change may still carry their images inline. If a template like that needs
+attention, open its Layers tab and use "Migrate images to cloud" in the
+toolbar to move its images to cloud storage and shrink the saved template.
+
+### Template formats
+
+Every template targets a format — 40K 10th Edition, 40K 11th Edition, Age
+of Sigmar, or a specific custom datasource card type — set when you create
+it and shown in Card properties. The format decides which fields are
+available to bind and which cards the template can be attached to.
+
+A template built for one format can still be attached to a card from a
+closely related format: a 40K 10th Edition template can be used on an 11th
+edition card and back again, since the two share the same card shape. The
+template selector on a card only offers templates whose format is
+compatible with that card, and shows the template's own format next to its
+name when it differs from the card's.
+
+If you change a template's format in Card properties and it has bindings
+that don't exist in the new format, you'll be asked whether to keep them
+as-is, clear them from the text, or remap them to a same-named field when
+one exists.

--- a/src/Pages/Help/content/designer/template-presets.mdx
+++ b/src/Pages/Help/content/designer/template-presets.mdx
@@ -6,8 +6,8 @@ and desktop presets, a pre-built layout with bindings already in place.
 | Preset                              | Dimensions    | Description                                                                                          |
 | ----------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------- |
 | 40K Datacard                        | 500 x 700 px  | A blank canvas at the standard Warhammer 40K datacard size, targeting 10th edition.                  |
-| 40K Datacard (Styled)               | 500 x 700 px  | Comes with a pre-built layout including text fields and faction color areas, targeting 10th edition. |
-| 40K Datacard (Desktop)              | 1080 x 720 px | A landscape, pre-styled layout for 10th edition, sized for wider desktop card designs.               |
+| 40K Datacard (Styled)               | 500 x 700 px  | A portrait version of the app's datacard look: header banner, stat boxes, weapon tables, abilities and keyword footer, targeting 10th edition. |
+| 40K Datacard (Desktop)              | 1080 x 720 px | A landscape layout that mirrors the app's full datacard, including wargear and unit composition, targeting 10th edition. |
 | 40K 11th Edition Datacard           | 500 x 700 px  | A blank canvas at the standard datacard size, targeting 11th edition.                                |
 | 40K 11th Edition Datacard (Styled)  | 500 x 700 px  | The same pre-built layout as the 10th edition styled preset, targeting 11th edition.                 |
 | 40K 11th Edition Datacard (Desktop) | 1080 x 720 px | The same landscape, pre-styled layout as the 10th edition desktop preset, targeting 11th edition.    |
@@ -17,6 +17,10 @@ and desktop presets, a pre-built layout with bindings already in place.
 
 The styled and desktop presets ask you to pick a faction when you create the
 template, and colour their pre-built elements from that faction's palette.
+Their layout follows the standard datacards the app renders: the angled
+header banner, the notched stat boxes, the invulnerable save shield, the
+weapon tables with alternating rows, and the faction diamond in the footer
+are all regular elements, so you can move, restyle or delete any of them.
 
 10th and 11th edition presets share the same card structure, so a template
 built from either one can be attached to a card from either edition — see

--- a/src/Pages/Help/content/designer/template-presets.mdx
+++ b/src/Pages/Help/content/designer/template-presets.mdx
@@ -1,11 +1,23 @@
 ## Template Presets
 
-Presets give you a head start with common card sizes.
+Presets give you a head start with common card sizes and, for the styled
+and desktop presets, a pre-built layout with bindings already in place.
 
-| Preset | Dimensions | Description |
-|--------|-----------|-------------|
-| 40K Datacard | 500 x 700 px | A blank canvas at the standard Warhammer 40K datacard size. |
-| 40K Datacard (Styled) | 500 x 700 px | Comes with a pre-built layout including text fields and faction color areas. |
-| 40K Stratagem | 500 x 350 px | Sized for stratagem cards. Shorter and wider than a standard datacard. |
-| AoS Warscroll | 500 x 700 px | Sized for Age of Sigmar warscroll cards. |
-| Custom | Your choice | Set any width and height between 100 and 2000 pixels. |
+| Preset                              | Dimensions    | Description                                                                                          |
+| ----------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------- |
+| 40K Datacard                        | 500 x 700 px  | A blank canvas at the standard Warhammer 40K datacard size, targeting 10th edition.                  |
+| 40K Datacard (Styled)               | 500 x 700 px  | Comes with a pre-built layout including text fields and faction color areas, targeting 10th edition. |
+| 40K Datacard (Desktop)              | 1080 x 720 px | A landscape, pre-styled layout for 10th edition, sized for wider desktop card designs.               |
+| 40K 11th Edition Datacard           | 500 x 700 px  | A blank canvas at the standard datacard size, targeting 11th edition.                                |
+| 40K 11th Edition Datacard (Styled)  | 500 x 700 px  | The same pre-built layout as the 10th edition styled preset, targeting 11th edition.                 |
+| 40K 11th Edition Datacard (Desktop) | 1080 x 720 px | The same landscape, pre-styled layout as the 10th edition desktop preset, targeting 11th edition.    |
+| 40K Stratagem                       | 500 x 350 px  | Sized for stratagem cards. Shorter and wider than a standard datacard.                               |
+| AoS Warscroll                       | 500 x 700 px  | Sized for Age of Sigmar warscroll cards.                                                             |
+| Custom                              | Your choice   | Set any width and height between 100 and 2000 pixels, and pick which format the template targets.    |
+
+The styled and desktop presets ask you to pick a faction when you create the
+template, and colour their pre-built elements from that faction's palette.
+
+10th and 11th edition presets share the same card structure, so a template
+built from either one can be attached to a card from either edition — see
+Template Formats in Saving and Managing.

--- a/src/Pages/Help/content/designer/template-presets.mdx
+++ b/src/Pages/Help/content/designer/template-presets.mdx
@@ -1,22 +1,25 @@
 ## Template Presets
 
 Presets give you a head start with common card sizes and, for the styled
-and desktop presets, a pre-built layout with bindings already in place.
+and desktop presets, a pre-built layout with bindings already in place. You pick
+one in the New Template dialog: step one asks for the game and edition, step two
+shows the layouts available for it. The table below lists every preset with the
+game it belongs to.
 
-| Preset                              | Dimensions    | Description                                                                                          |
-| ----------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------- |
-| 40K Datacard                        | 500 x 700 px  | A blank canvas at the standard Warhammer 40K datacard size, targeting 10th edition.                  |
+| Preset                              | Dimensions    | Description                                                                                                                                    |
+| ----------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| 40K Datacard                        | 500 x 700 px  | A blank canvas at the standard Warhammer 40K datacard size, targeting 10th edition.                                                            |
 | 40K Datacard (Styled)               | 500 x 700 px  | A portrait version of the app's datacard look: header banner, stat boxes, weapon tables, abilities and keyword footer, targeting 10th edition. |
-| 40K Datacard (Desktop)              | 1080 x 720 px | A landscape layout that mirrors the app's full datacard, including wargear and unit composition, targeting 10th edition. |
-| 40K 11th Edition Datacard           | 500 x 700 px  | A blank canvas at the standard datacard size, targeting 11th edition.                                |
-| 40K 11th Edition Datacard (Styled)  | 500 x 700 px  | The same pre-built layout as the 10th edition styled preset, targeting 11th edition.                 |
-| 40K 11th Edition Datacard (Desktop) | 1080 x 720 px | The same landscape, pre-styled layout as the 10th edition desktop preset, targeting 11th edition.    |
-| 40K Stratagem                       | 500 x 350 px  | Sized for stratagem cards. Shorter and wider than a standard datacard.                               |
-| AoS Warscroll                       | 500 x 700 px  | Sized for Age of Sigmar warscroll cards.                                                             |
-| Custom                              | Your choice   | Set any width and height between 100 and 2000 pixels, and pick which format the template targets.    |
+| 40K Datacard (Desktop)              | 1080 x 720 px | A landscape layout that mirrors the app's full datacard, including wargear and unit composition, targeting 10th edition.                       |
+| 40K 11th Edition Datacard           | 500 x 700 px  | A blank canvas at the standard datacard size, targeting 11th edition.                                                                          |
+| 40K 11th Edition Datacard (Styled)  | 500 x 700 px  | The same pre-built layout as the 10th edition styled preset, targeting 11th edition.                                                           |
+| 40K 11th Edition Datacard (Desktop) | 1080 x 720 px | The same landscape, pre-styled layout as the 10th edition desktop preset, targeting 11th edition.                                              |
+| 40K Stratagem                       | 500 x 350 px  | Sized for stratagem cards. Shorter and wider than a standard datacard.                                                                         |
+| AoS Warscroll                       | 500 x 700 px  | Sized for Age of Sigmar warscroll cards.                                                                                                       |
+| Custom                              | Your choice   | Set any width and height between 100 and 2000 pixels, and pick which format the template targets.                                              |
 
-The styled and desktop presets ask you to pick a faction when you create the
-template, and colour their pre-built elements from that faction's palette.
+The styled and desktop presets ask you to pick a faction in step two, and
+colour their pre-built elements from that faction's palette.
 Their layout follows the standard datacards the app renders: the angled
 header banner, the notched stat boxes, the invulnerable save shield, the
 weapon tables with alternating rows, and the faction diamond in the footer

--- a/src/Pages/Help/content/designer/the-workspace.mdx
+++ b/src/Pages/Help/content/designer/the-workspace.mdx
@@ -2,14 +2,37 @@
 
 The Designer workspace is split into four areas.
 
-<WorkspaceMap zones={[
-  { area: "1 / 1 / 3 / 2", label: "Layer Panel", description: "Templates, layers, element tree" },
-  { area: "1 / 2 / 2 / 4", label: "Floating Toolbar", description: "Add elements, zoom, grid" },
-  { area: "2 / 2 / 3 / 4", label: "Canvas", description: "Main editing area", accent: true },
-  { area: "1 / 4 / 3 / 5", label: "Properties Panel", description: "Settings for selected element" }
-]} />
+<WorkspaceMap
+  zones={[
+    { area: "1 / 1 / 3 / 2", label: "Layer Panel", description: "Templates, layers, element tree" },
+    { area: "1 / 2 / 2 / 4", label: "Floating Toolbar", description: "Tools, zoom, grid" },
+    { area: "2 / 2 / 3 / 4", label: "Canvas", description: "Main editing area", accent: true },
+    { area: "1 / 4 / 3 / 5", label: "Properties Panel", description: "Settings for selected element" },
+  ]}
+/>
 
 - **Layer Panel** (left side) — Shows all your elements in a tree view. Manage templates, reorder layers, and organize elements into frames. Elements at the top of the list appear in front on the canvas.
 - **Canvas** (center) — Your main editing area. Click, drag, and resize elements directly. What you see here is what your card will look like.
-- **Floating Toolbar** (above the canvas) — Quick access buttons for adding elements and controlling zoom level.
+- **Floating Toolbar** (above the canvas) — Tools for drawing elements, undo and redo, zoom controls, and the grid toggles.
 - **Properties Panel** (right side) — Shows settings for whatever you have selected. Change colors, fonts, sizes, positions, and more. When nothing is selected, it shows canvas settings like background color and dimensions.
+
+### Moving around the canvas
+
+The card sits on an endless work area, so it is never cut off, however wide it is.
+
+- **Zoom** with <Icon name="ZoomIn" /> and <Icon name="ZoomOut" />, or hold Ctrl (Cmd on a Mac) and use the mouse wheel. Wheel zoom keeps the point under the cursor in place.
+- **Type a zoom level** by clicking the percentage and pressing Enter. Anything between 5% and 800% works.
+- **The arrow next to the zoom controls** opens a menu with Fit, Zoom to selection, 100% and 200%.
+- **Scroll** with the mouse wheel, and sideways with Shift and the wheel.
+- **Pan** by holding Space and dragging, or by dragging with the middle mouse button.
+
+The card is fitted to the panel when you open a template and when the panel is
+resized. Once you zoom or pan yourself, the view is left alone until you fit it
+again with Shift+1.
+
+### Drawing elements
+
+Pick a tool in the toolbar, then drag on the card to draw the element at the size
+you want. A single click drops the element at its default size. Double click a tool
+button to drop an element in the middle of the card, the way the toolbar used to
+work.

--- a/src/Pages/Help/content/designer/the-workspace.mdx
+++ b/src/Pages/Help/content/designer/the-workspace.mdx
@@ -4,14 +4,14 @@ The Designer workspace is split into four areas.
 
 <WorkspaceMap
   zones={[
-    { area: "1 / 1 / 3 / 2", label: "Layer Panel", description: "Templates, layers, element tree" },
+    { area: "1 / 1 / 3 / 2", label: "Left Panel", description: "Layers and Data tabs" },
     { area: "1 / 2 / 2 / 4", label: "Floating Toolbar", description: "Tools, zoom, grid" },
     { area: "2 / 2 / 3 / 4", label: "Canvas", description: "Main editing area", accent: true },
     { area: "1 / 4 / 3 / 5", label: "Properties Panel", description: "Settings for selected element" },
   ]}
 />
 
-- **Layer Panel** (left side) — Shows all your elements in a tree view. Manage templates, reorder layers, and organize elements into frames. Elements at the top of the list appear in front on the canvas.
+- **Left Panel** (left side) — Two tabs. **Layers** shows all your elements in a tree view: manage templates, reorder layers, and organize elements into frames. Elements at the top of the list appear in front on the canvas. **Data** shows the fields your template's format can bind to, with a sample card selector at the top so every field shows a real value. Drag a field from here onto the canvas to bind it. See Data Binding for details.
 - **Canvas** (center) — Your main editing area. Click, drag, and resize elements directly. What you see here is what your card will look like.
 - **Floating Toolbar** (above the canvas) — Tools for drawing elements, undo and redo, zoom controls, and the grid toggles.
 - **Properties Panel** (right side) — Shows settings for whatever you have selected. Change colors, fonts, sizes, positions, and more. When nothing is selected, it shows canvas settings like background color and dimensions.

--- a/src/Pages/Shared.jsx
+++ b/src/Pages/Shared.jsx
@@ -10,6 +10,7 @@ import { useCardStorage } from "../Hooks/useCardStorage";
 import { useCategorySharing } from "../Hooks/useCategorySharing";
 import { useUmami } from "../Hooks/useUmami";
 import { useAutoFitScale } from "../Hooks/useAutoFitScale";
+import { useTemplateCardWidth } from "../Hooks/useTemplateCardWidth";
 import logo from "../Images/logo.png";
 import { SharedCardDisplay } from "../Components/Shared/SharedCardDisplay";
 import { SharedCardList } from "../Components/Shared/SharedCardList";
@@ -69,7 +70,8 @@ export const Shared = () => {
   };
 
   // Auto-fit scaling for desktop
-  const { autoScale } = useAutoFitScale(cardContainerRef, getCardType(), !isMobile);
+  const templateWidth = useTemplateCardWidth(currentCard);
+  const { autoScale } = useAutoFitScale(cardContainerRef, getCardType(), !isMobile, templateWidth);
 
   // Update document title
   useEffect(() => {

--- a/src/Pages/Viewer.jsx
+++ b/src/Pages/Viewer.jsx
@@ -14,6 +14,7 @@ import { useCardStorage } from "../Hooks/useCardStorage";
 import { useDataSourceStorage } from "../Hooks/useDataSourceStorage";
 import { useSettingsStorage } from "../Hooks/useSettingsStorage";
 import { useAutoFitScale } from "../Hooks/useAutoFitScale";
+import { useTemplateCardWidth } from "../Hooks/useTemplateCardWidth";
 import { useViewerNavigation } from "../Hooks/useViewerNavigation";
 import { useMobileSharing } from "../Hooks/useMobileSharing";
 import { Warhammer40K10eCardDisplay } from "../Components/Warhammer40k-10e/CardDisplay";
@@ -74,7 +75,13 @@ export const Viewer = ({ showManifestationLores = false, showSpellLores = false 
   };
 
   // Use auto-fit hook
-  const { autoScale } = useAutoFitScale(cardContainerRef, getCardType(), settings.autoFitEnabled !== false);
+  const templateWidth = useTemplateCardWidth(activeCard);
+  const { autoScale } = useAutoFitScale(
+    cardContainerRef,
+    getCardType(),
+    settings.autoFitEnabled !== false,
+    templateWidth,
+  );
 
   // Determine effective scale based on mode
   const effectiveScale = settings.autoFitEnabled !== false ? autoScale : (settings.zoom || 100) / 100;

--- a/src/Premium/__tests__/exportParity.test.js
+++ b/src/Premium/__tests__/exportParity.test.js
@@ -1,0 +1,93 @@
+import fs from "fs";
+import path from "path";
+import * as stub from "../index";
+
+const communitySrcRoot = path.resolve(process.cwd(), "src");
+const premiumIndexPath = path.resolve(process.cwd(), "../gdc-premium/src/index.js");
+const premiumRepoAvailable = fs.existsSync(premiumIndexPath);
+
+const PREMIUM_ALIAS_SOURCE = /^(\.\.?\/)+Premium$/;
+
+const walkFiles = (dir, out = []) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "__tests__" || entry.name === "node_modules") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(full, out);
+    } else if (/\.(jsx?|mdx)$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+};
+
+const collectPremiumImportNames = () => {
+  const names = new Set();
+  const importPattern = /import\s+(?:type\s+)?\{([^}]+)\}\s+from\s+["']([^"']+)["']/g;
+
+  for (const file of walkFiles(communitySrcRoot)) {
+    const text = fs.readFileSync(file, "utf8");
+    let match;
+    importPattern.lastIndex = 0;
+    while ((match = importPattern.exec(text))) {
+      const [, specifiers, source] = match;
+      if (!PREMIUM_ALIAS_SOURCE.test(source)) continue;
+      for (const raw of specifiers.split(",")) {
+        const spec = raw.trim();
+        if (!spec) continue;
+        const asMatch = spec.match(/^(\w+)\s+as\s+\w+$/);
+        names.add(asMatch ? asMatch[1] : spec);
+      }
+    }
+  }
+  return names;
+};
+
+const extractNamedExports = (source) => {
+  const names = new Set();
+  for (const m of source.matchAll(/export\s+const\s+(\w+)/g)) names.add(m[1]);
+  for (const m of source.matchAll(/export\s+function\s+(\w+)/g)) names.add(m[1]);
+  for (const m of source.matchAll(/export\s*\{([^}]+)\}/g)) {
+    for (const raw of m[1].split(",")) {
+      const spec = raw.trim();
+      if (!spec) continue;
+      const asMatch = spec.match(/^(\w+)\s+as\s+(\w+)$/);
+      names.add(asMatch ? asMatch[2] : spec);
+    }
+  }
+  return names;
+};
+
+describe("Premium stub / premium package export parity", () => {
+  it("every stub export the app actually imports from Premium has a matching name in the stub itself", () => {
+    const stubNames = new Set(Object.keys(stub));
+    const importedNames = collectPremiumImportNames();
+
+    const missing = [...importedNames].filter((name) => !stubNames.has(name));
+    expect(missing).toEqual([]);
+  });
+
+  it.skipIf(!premiumRepoAvailable)(
+    "every stub export the app imports from Premium also exists in the gdc-premium package index",
+    () => {
+      const premiumSource = fs.readFileSync(premiumIndexPath, "utf8");
+      const premiumNames = extractNamedExports(premiumSource);
+      const importedNames = collectPremiumImportNames();
+
+      const missing = [...importedNames].filter((name) => !premiumNames.has(name));
+      expect(missing).toEqual([]);
+    },
+  );
+
+  it.skipIf(!premiumRepoAvailable)(
+    "every named export of the community stub also exists in the gdc-premium package index",
+    () => {
+      const premiumSource = fs.readFileSync(premiumIndexPath, "utf8");
+      const premiumNames = extractNamedExports(premiumSource);
+      const stubNames = new Set(Object.keys(stub));
+
+      const missing = [...stubNames].filter((name) => !premiumNames.has(name));
+      expect(missing).toEqual([]);
+    },
+  );
+});

--- a/src/Premium/__tests__/stubs.test.js
+++ b/src/Premium/__tests__/stubs.test.js
@@ -97,7 +97,15 @@ describe("SUBSCRIPTION_LIMITS", () => {
 // TEMPLATE_PRESETS constant
 // ============================================
 describe("TEMPLATE_PRESETS", () => {
-  const presetKeys = ["40k-datacard", "40k-stratagem", "aos-warscroll", "custom"];
+  const presetKeys = [
+    "40k-datacard",
+    "40k-stratagem",
+    "aos-warscroll",
+    "40k-11e-datacard",
+    "40k-11e-datacard-styled",
+    "40k-11e-datacard-desktop",
+    "custom",
+  ];
 
   it.each(presetKeys)("should have required properties for %s preset", (preset) => {
     expect(TEMPLATE_PRESETS[preset]).toHaveProperty("name");
@@ -109,6 +117,14 @@ describe("TEMPLATE_PRESETS", () => {
   it("should have correct dimensions for 40k-datacard", () => {
     expect(TEMPLATE_PRESETS["40k-datacard"].width).toBe(500);
     expect(TEMPLATE_PRESETS["40k-datacard"].height).toBe(700);
+  });
+
+  it("should have 40k-11e target format for the 11th edition presets", () => {
+    expect(TEMPLATE_PRESETS["40k-11e-datacard"].targetFormat).toBe("40k-11e");
+    expect(TEMPLATE_PRESETS["40k-11e-datacard-styled"].targetFormat).toBe("40k-11e");
+    expect(TEMPLATE_PRESETS["40k-11e-datacard-desktop"].targetFormat).toBe("40k-11e");
+    expect(TEMPLATE_PRESETS["40k-11e-datacard-desktop"].width).toBe(1080);
+    expect(TEMPLATE_PRESETS["40k-11e-datacard-desktop"].height).toBe(720);
   });
 
   it("should have correct dimensions for 40k-stratagem", () => {

--- a/src/Premium/__tests__/stubs.test.js
+++ b/src/Premium/__tests__/stubs.test.js
@@ -1,6 +1,7 @@
 import {
   useAuth,
   useSubscription,
+  useTemplateStorage,
   SUBSCRIPTION_LIMITS,
   TEMPLATE_PRESETS,
   useTemplateSharing,
@@ -307,5 +308,28 @@ describe("useAuth stub", () => {
   it("should return user as null", () => {
     const auth = useAuth();
     expect(auth.user).toBeNull();
+  });
+});
+
+// ============================================
+// useTemplateStorage stub
+// ============================================
+describe("useTemplateStorage stub", () => {
+  it("should expose history defaults", () => {
+    const storage = useTemplateStorage();
+    expect(storage.canUndo).toBe(false);
+    expect(storage.canRedo).toBe(false);
+    expect(storage.historyLength).toBe(0);
+    expect(storage.revision).toBe(0);
+  });
+
+  it("should expose history operations as no-ops", () => {
+    const storage = useTemplateStorage();
+    expect(typeof storage.undo).toBe("function");
+    expect(typeof storage.redo).toBe("function");
+    expect(typeof storage.commitTemplate).toBe("function");
+    expect(storage.undo()).toBeUndefined();
+    expect(storage.redo()).toBeUndefined();
+    expect(storage.commitTemplate(() => ({}), "label")).toBeUndefined();
   });
 });

--- a/src/Premium/constants.js
+++ b/src/Premium/constants.js
@@ -75,7 +75,7 @@ export const TEMPLATE_PRESETS = {
     width: 500,
     height: 700,
     targetFormat: "40k-10e",
-    useFactory: true, // Indicates this preset uses a template factory
+    factory: "40k-styled",
   },
   "40k-stratagem": {
     name: "40K Stratagem",
@@ -94,7 +94,27 @@ export const TEMPLATE_PRESETS = {
     width: 1080,
     height: 720,
     targetFormat: "40k-10e",
-    useFactory: true,
+    factory: "40k-desktop",
+  },
+  "40k-11e-datacard": {
+    name: "40K 11th Edition Datacard",
+    width: 500,
+    height: 700,
+    targetFormat: "40k-11e",
+  },
+  "40k-11e-datacard-styled": {
+    name: "40K 11th Edition Datacard (Styled)",
+    width: 500,
+    height: 700,
+    targetFormat: "40k-11e",
+    factory: "40k-styled",
+  },
+  "40k-11e-datacard-desktop": {
+    name: "40K 11th Edition Datacard (Desktop)",
+    width: 1080,
+    height: 720,
+    targetFormat: "40k-11e",
+    factory: "40k-desktop",
   },
   custom: {
     name: "Custom",

--- a/src/Premium/index.js
+++ b/src/Premium/index.js
@@ -329,6 +329,13 @@ export const useTemplateStorage = () => ({
   setTemplateSyncEnabled: () => {},
   bulkUpdateTemplates: () => {},
   getTemplate: () => null,
+  commitTemplate: () => {},
+  undo: () => {},
+  redo: () => {},
+  canUndo: false,
+  canRedo: false,
+  historyLength: 0,
+  revision: 0,
 });
 
 /**

--- a/src/Premium/index.js
+++ b/src/Premium/index.js
@@ -339,6 +339,22 @@ export const useTemplateStorage = () => ({
 });
 
 /**
+ * Stub for useTemplateImages - no cloud image storage in public version
+ */
+export const useTemplateImages = () => ({
+  cloudEnabled: false,
+  uploadTemplateImage: () => Promise.resolve({ url: null, path: null, error: "not-available" }),
+  uploadTemplateImageFromDataUrl: () => Promise.resolve({ url: null, path: null, error: "not-available" }),
+  deleteTemplateImage: () => Promise.resolve(false),
+  deleteTemplateImages: () => Promise.resolve(false),
+  listTemplateImages: () => Promise.resolve([]),
+});
+
+export const TEMPLATE_IMAGE_BUCKET = "template-images";
+export const TEMPLATE_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+export const TEMPLATE_IMAGE_MIME_TYPES = ["image/png", "image/jpeg", "image/webp", "image/svg+xml"];
+
+/**
  * Stub for useDataBinding - minimal implementation
  */
 export const useDataBinding = () => ({

--- a/src/Premium/index.js
+++ b/src/Premium/index.js
@@ -344,11 +344,15 @@ export const useTemplateStorage = () => ({
 export const useDataBinding = () => ({
   getAvailableBindings: () => null,
   resolveBinding: (template) => template,
+  resolveBindingWithContext: (template) => template,
+  areBindingsEmpty: () => false,
   hasBindings: () => false,
   extractBindings: () => [],
   validateBinding: () => false,
+  validateTemplateBindings: () => [],
   createBindingString: (path) => `{{${path}}}`,
   availableFormats: [],
+  getArraySources: () => [],
 });
 
 /**

--- a/src/Premium/index.js
+++ b/src/Premium/index.js
@@ -314,6 +314,7 @@ export const useTemplateStorage = () => ({
   updateElement: () => {},
   removeElement: () => {},
   reorderElements: () => {},
+  reorderRootElements: () => {},
   syncElementsFromCanvas: () => {},
   // Canvas settings - no-op
   updateCanvasSettings: () => {},

--- a/src/Premium/index.js
+++ b/src/Premium/index.js
@@ -397,6 +397,11 @@ export const useTemplateRenderer = () => ({
 export const TemplateRenderer = () => null;
 
 /**
+ * Stub for TemplateDomRenderer - returns null (templates not available in community version)
+ */
+export const TemplateDomRenderer = () => null;
+
+/**
  * Stub for TemplateSelector - returns null (templates not available in community version)
  */
 export const TemplateSelector = () => null;

--- a/src/styles/default.less
+++ b/src/styles/default.less
@@ -22,6 +22,14 @@
   src: url("../../fonts/PassionOne-Bold.ttf");
   font-weight: bold; /*config its weight*/
 }
+@font-face {
+  font-family: "Byington";
+  src: url("../../fonts/Byington Regular.ttf");
+}
+@font-face {
+  font-family: "AmericanText";
+  src: url("../../fonts/american-text.regular.ttf");
+}
 .flex {
   display: grid;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -332,6 +332,37 @@
   resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz#b6c75a56a1947cc916ea058772d666a2c8932f31"
   integrity sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==
 
+"@dnd-kit/accessibility@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz#3b4202bd6bb370a0730f6734867785919beac6af"
+  integrity sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.3.1.tgz#4c36406a62c7baac499726f899935f93f0e6d003"
+  integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.1"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-10.0.0.tgz#1f9382b90d835cd5c65d92824fa9dafb78c4c3e8"
+  integrity sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@emotion/is-prop-valid@1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz#e9ad47adff0b5c94c72db3669ce46de33edf28c0"
@@ -8585,7 +8616,7 @@ trough@^2.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-2.2.0.tgz#94a60bd6bd375c152c1df911a4b11d5b0256f50f"
   integrity sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==
 
-tslib@2.8.1, tslib@^2.1.0:
+tslib@2.8.1, tslib@^2.0.0, tslib@^2.1.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
Community-side changes for the Card Designer rework (gdc-premium PR #36), one commit per phase. Merge together with the premium PR.

- Shared binding resolver (`src/Helpers/bindingResolver.js`) with card normalisation, localisation, filters, and `templateFormats.js` for format descriptors and compatibility.
- Custom datasource ability bindings per category, 11th edition template presets, faction symbol helper for image binding.
- Non-throwing settings accessor and card language hook.
- dnd-kit added as a dependency for the designer layer tree.
- Help pages under `src/Pages/Help/content/designer/` rewritten to match the new designer.
- Premium stubs extended for every new export, with an export parity test.
- Release fragment `changes/unreleased/card-designer.json`.

https://claude.ai/code/session_01M6LyhqyBvYKua1pRy88k9c